### PR TITLE
- Removed an unnecessary newline from dump_line call.

### DIFF
--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -497,7 +497,7 @@ void dump_normal(hd_data_t *hd_data, hd_t *h, FILE *f)
     dump_line("PROM id: %s\n", h->rom_id);
 #endif
 #if defined(__s390__) || defined(__s390x__)
-    dump_line("IUCV user: %s\n", h->rom_id);
+    dump_line("IUCV user: %s", h->rom_id);
 #endif
   }
 


### PR DESCRIPTION
  h->rom_id for IUCV connections already has a newline at the end.
- Changed the logic for IUCV detection to only include netiucv type devices
  Since /sys/bus/iucv/devices/ contains a "generic" netiucv entry as well
  as any activated devices,such as netiucv0, or netiucv1, the extra logic
  to add an unactivated device is no longer needed, so it has been removed.
- Deleted an unused variable (dl) from s390.c.
