### PR TITLE
3 small patches to please Debian package maintainers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOPDIR		= $(CURDIR)
 SUBDIRS		= src
 TARGETS		= hwinfo hwinfo.pc changelog
-CLEANFILES	= hwinfo hwinfo.pc hwinfo.static hwscan hwscan.static hwscand hwscanqueue doc/libhd doc/*~
+CLEANFILES	= hwinfo hwinfo.pc hwinfo.static hwscan hwscan.static hwscand hwscanqueue doc/libhd doc/*~ VERSION changelog
 LIBDIR		?= /usr/lib
 ULIBDIR		= $(LIBDIR)
 LIBS		= -lhd
@@ -12,10 +12,13 @@ TSO_LIBS	=
 
 export SO_LIBS
 
+ifdef HWINFO_VERSION
+VERSION := $(shell echo ${HWINFO_VERSION} > VERSION; cat VERSION)
+else
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)
 GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
-
 VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
+endif
 
 include Makefile.common
 
@@ -32,8 +35,13 @@ OBJS_NO_TINY	= names.o parallel.o modem.o
 
 .PHONY:	fullstatic static shared tiny doc diet tinydiet uc tinyuc
 
+ifdef HWINFO_VERSION
+changelog:
+	@true
+else
 changelog: $(GITDEPS)
 	$(GIT2LOG) --changelog changelog
+endif
 
 hwscan: hwscan.o $(LIBHD)
 	$(CC) hwscan.o $(LDFLAGS) $(CFLAGS) $(LIBS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TOPDIR		= $(CURDIR)
 SUBDIRS		= src
 TARGETS		= hwinfo hwinfo.pc changelog
 CLEANFILES	= hwinfo hwinfo.pc hwinfo.static hwscan hwscan.static hwscand hwscanqueue doc/libhd doc/*~
-LIBDIR		= /usr/lib
+LIBDIR		?= /usr/lib
 ULIBDIR		= $(LIBDIR)
 LIBS		= -lhd
 SLIBS		= -lhd
@@ -36,16 +36,16 @@ changelog: $(GITDEPS)
 	$(GIT2LOG) --changelog changelog
 
 hwscan: hwscan.o $(LIBHD)
-	$(CC) hwscan.o $(LDFLAGS) $(LIBS) -o $@
+	$(CC) hwscan.o $(LDFLAGS) $(CFLAGS) $(LIBS) -o $@
 
 hwinfo: hwinfo.o $(LIBHD)
-	$(CC) hwinfo.o $(LDFLAGS) $(LIBS) -o $@
+	$(CC) hwinfo.o $(LDFLAGS) $(CFLAGS) $(LIBS) -o $@
 
 hwscand: hwscand.o
-	$(CC) $< $(LDFLAGS) -o $@
+	$(CC) $< $(LDFLAGS) $(CFLAGS) -o $@
 
 hwscanqueue: hwscanqueue.o
-	$(CC) $< $(LDFLAGS) -o $@
+	$(CC) $< $(LDFLAGS) $(CFLAGS) -o $@
 
 hwinfo.pc: hwinfo.pc.in VERSION
 	VERSION=`cat VERSION`; \

--- a/Makefile.common
+++ b/Makefile.common
@@ -20,12 +20,12 @@ LIBHD_MAJOR_VERSION	:= $(shell cut -d . -f 1 $(TOPDIR)/VERSION)
 
 RPM_OPT_FLAGS	?= -O2
 
-CC	= gcc
+CC	?= gcc
 LD	= ld
-CFLAGS	= $(RPM_OPT_FLAGS) -Wall -Wno-pointer-sign -pipe -g $(SHARED_FLAGS) $(EXTRA_FLAGS) -I$(TOPDIR)/src/hd
+CFLAGS += $(RPM_OPT_FLAGS) -Wall -Wno-pointer-sign -pipe -g $(SHARED_FLAGS) $(EXTRA_FLAGS) -I$(TOPDIR)/src/hd
 SHARED_FLAGS	= -fPIC
 
-LDFLAGS	= -Lsrc
+LDFLAGS	+= -Lsrc
 
 CFILES		= $(wildcard *.c)
 OBJS		= $(CFILES:.c=.o)
@@ -41,7 +41,7 @@ export CC TOPDIR CFLAGS LIBHD ARCH
 .PHONY: all distclean clean install subdirs
 
 %.o: %.c
-	$(CC) -c $(CFLAGS) $<
+	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $<
 
 all: subdirs $(TARGETS)
 
@@ -61,7 +61,7 @@ distclean: subdirs
 ifneq "$(CFILES)" ""
 ifeq ($(findstring $(MAKECMDGOALS), clean distclean),)
 .depend: $(CFILES)
-	@$(CC) -MG -MM $(CFLAGS) $(CFILES) >$@
+	@$(CC) -MG -MM $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(CFILES) >$@
 
 -include .depend
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ $(LIBHD): $(OBJS)
 
 ifdef SHARED_FLAGS
 $(LIBHD_SO): $(LIBHD)
-	$(CC) -shared -Wl,--whole-archive $(LIBHD) -Wl,--no-whole-archive \
+	$(CC) -shared $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -Wl,--whole-archive $(LIBHD) -Wl,--no-whole-archive \
 		-Wl,-soname=$(LIBHD_SONAME) \
 		-o $(LIBHD_SO) $(SO_LIBS) 
 	ln -snf $(LIBHD_NAME) $(LIBHD_SONAME)

--- a/src/hd/Makefile
+++ b/src/hd/Makefile
@@ -4,7 +4,7 @@ CLEANFILES	= version.h
 
 include $(TOPDIR)/Makefile.common
 
-CFLAGS		+= -I /usr/include/dbus-1.0 -I /usr/lib64/dbus-1.0/include -I /usr/lib/dbus-1.0/include
+CFLAGS		+= $(shell pkg-config --cflags dbus-1)
 
 version.h: $(TOPDIR)/VERSION
 	@echo "#define HD_VERSION_STRING \"`cat $(TOPDIR)/VERSION`\"" >$@

--- a/src/hd/bios.c
+++ b/src/hd/bios.c
@@ -1044,7 +1044,7 @@ void parse_mpconfig(hd_data_t *hd_data, memory_range_t *mem, smp_info_t *smp)
       hd_log_hex(hd_data, 1, len, mem->data + cfg_len + u);
       ADD2LOG("\n");
       if(len < 2) {
-        ADD2LOG("  oops: invalid record lenght\n");
+        ADD2LOG("  oops: invalid record length\n");
         break;
       }
     }

--- a/src/ids/src/pci
+++ b/src/ids/src/pci
@@ -40633,7 +40633,7 @@
 
  vendor.id		pci 0x1139
 &device.id		pci 0x0001
-+device.name		VGA Compatable 3D Graphics
++device.name		VGA Compatible 3D Graphics
 
  vendor.id		pci 0x113a
 +vendor.name		FWB Inc
@@ -83098,7 +83098,7 @@
 
  vendor.id		pci 0x8800
 &device.id		pci 0x2008
-+device.name		Video assistent component
++device.name		Video assistant component
 
  vendor.id		pci 0x8866
 +vendor.name		T-Square Design Inc.

--- a/src/ids/src/usb
+++ b/src/ids/src/usb
@@ -2389,7 +2389,7 @@
 
  vendor.id		usb 0x046d
 &device.id		usb 0xc211
-+device.name		iTouch Cordless Reciever
++device.name		iTouch Cordless Receiver
 
  vendor.id		usb 0x046d
 &device.id		usb 0xc216
@@ -8067,7 +8067,7 @@
 
  vendor.id		usb 0x0714
 &device.id		usb 0x0003
-+device.name		ADB to USB convertor
++device.name		ADB to USB converter
 
  vendor.id		usb 0x0717
 +vendor.name		ZNK Corp.


### PR DESCRIPTION
Hi,
the following patches do 4 things:
    1) fixes spelling errors (really minor patch)
    2) updates makefiles to respect outer environmenet variables like $LIBDIR, $CFLAGS, $CPPFLAGS, and $LDFLAGS
    3) allows to build hwinfo outside github clone; if HWINFO_VERSION is defined then it is used to provide version number instead of git2log which has to be run inside git repository; also both "VERSION" and "changelog" are added to cleaned files
    4) uses pkg-config to supply includes to dbus

Cheers,
Tomasz