### PR TITLE
Monitor detection via sysfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ TOPDIR		= $(CURDIR)
 SUBDIRS		= src
 TARGETS		= hwinfo hwinfo.pc changelog
 CLEANFILES	= hwinfo hwinfo.pc hwinfo.static hwscan hwscan.static hwscand hwscanqueue doc/libhd doc/*~
-LIBDIR		= /usr/lib
-ULIBDIR		= $(LIBDIR)
 LIBS		= -lhd
 SLIBS		= -lhd
 TLIBS		= -lhd_tiny
@@ -19,6 +17,13 @@ BRANCH  := $(shell git branch | perl -ne 'print $$_ if s/^\*\s*//')
 PREFIX  := hwinfo-$(VERSION)
 
 include Makefile.common
+
+ifeq "$(ARCH)" "x86_64"
+LIBDIR		= /usr/lib64
+else
+LIBDIR		= /usr/lib
+endif
+ULIBDIR		= $(LIBDIR)
 
 # ia64
 ifneq ($(filter i386 x86_64, $(ARCH)),)

--- a/src/hd/drm.c
+++ b/src/hd/drm.c
@@ -1,0 +1,14 @@
+
+
+#include <fcntl.h>
+
+#include "hd.h"
+#include "hd_int.h"
+
+int is_kms_active(hd_data_t *hd_data) {
+  int kms = open("/sys/class/drm/card0", O_RDONLY) > 0;
+  ADD2LOG("  KMS detected: %d\n", kms);
+
+  return kms; 
+}
+

--- a/src/hd/drm.h
+++ b/src/hd/drm.h
@@ -1,6 +1,6 @@
 
 #ifndef DRM_H
-#define	DRM_H
+#define DRM_H
 
 int is_kms_active(hd_data_t *hd_data);
 

--- a/src/hd/drm.h
+++ b/src/hd/drm.h
@@ -1,0 +1,8 @@
+
+#ifndef DRM_H
+#define	DRM_H
+
+int is_kms_active(hd_data_t *hd_data);
+
+#endif	/* DRM_H */
+

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -92,6 +92,7 @@
 #include "wlan.h"
 #include "hal.h"
 #include "klog.h"
+#include "drm.h"
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  * various functions commmon to all probing modules
@@ -661,12 +662,15 @@ void hd_set_probe_feature_hw(hd_data_t *hd_data, hd_hw_item_t item)
       break;
 
     case hw_monitor:
-      hd_set_probe_feature(hd_data, pr_misc);
-      hd_set_probe_feature(hd_data, pr_prom);
+      /* if KMS is not active the data need to be read from BIOS */
+      if (!is_kms_active(hd_data)) {
+        hd_set_probe_feature(hd_data, pr_misc);
+        hd_set_probe_feature(hd_data, pr_prom);
+        hd_set_probe_feature(hd_data, pr_bios_ddc);
+        // hd_set_probe_feature(hd_data, pr_bios_fb);
+        hd_set_probe_feature(hd_data, pr_fb);
+      }
       hd_set_probe_feature(hd_data, pr_pci);
-      hd_set_probe_feature(hd_data, pr_bios_ddc);
-      // hd_set_probe_feature(hd_data, pr_bios_fb);
-      hd_set_probe_feature(hd_data, pr_fb);
       hd_set_probe_feature(hd_data, pr_monitor);
       break;
 

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -1408,6 +1408,7 @@ typedef struct {
  */
 typedef struct {
   unsigned manu_year;
+  unsigned manu_week;
   unsigned min_vsync, max_vsync;	/**< vsync range */
   unsigned min_hsync, max_hsync;	/**< hsync range */
   unsigned clock;			/**< pixel clock in kHz */

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -1048,8 +1048,8 @@ typedef struct s_pci_t {
   char *sysfs_bus_id;				/**< sysfs bus id */
   char *modalias;				/**< module alias */
   char *label;					/**< Consistant Device Name (CDN), pci firmware spec 3.1, chapter 4.6.7 */
-  unsigned edid_len[4];				/**< edid record length */
-  unsigned char edid_data[4][0x80];		/**< edid record */
+  unsigned edid_len[6];				/**< edid record length */
+  unsigned char edid_data[6][0x80];		/**< edid record */
 } pci_t;
 
 /**

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -834,7 +834,13 @@ void dump_normal(hd_data_t *hd_data, hd_t *h, FILE *f)
     for(i = 0, mdetail = &h->detail->monitor; mdetail; i++, mdetail = mdetail->next) {
       mi  = mdetail->data;
 
-      dump_line("Year of Manufacture: %d\n", mi->manu_year);
+      if (mi->manu_week == 255) {
+        dump_line("The Model Year: %d\n", mi->manu_year);
+      }
+      else {
+        dump_line("Year of Manufacture: %d\n", mi->manu_year);
+        dump_line("Week of Manufacture: %d\n", mi->manu_week);
+      }
 
       if(mi->htotal && mi->vtotal) {
         dump_line("Detailed Timings #%d:\n", i);

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -834,6 +834,8 @@ void dump_normal(hd_data_t *hd_data, hd_t *h, FILE *f)
     for(i = 0, mdetail = &h->detail->monitor; mdetail; i++, mdetail = mdetail->next) {
       mi  = mdetail->data;
 
+      dump_line("Year of Manufacture: %d\n", mi->manu_year);
+
       if(mi->htotal && mi->vtotal) {
         dump_line("Detailed Timings #%d:\n", i);
         dump_line("   Resolution: %ux%u\n", mi->width, mi->height);

--- a/src/hd/monitor.c
+++ b/src/hd/monitor.c
@@ -11,6 +11,8 @@
  * @defgroup MONITORint Monitor (DDC) information
  * @ingroup libhdINFOint
  * @brief Monitor information functions
+ * @see http://en.wikipedia.org/wiki/Extended_Display_Identification_Data#EDID_1.3_data_format
+ *   for the detailed EDID data structure description
  *
  * @{
  */
@@ -308,7 +310,7 @@ void add_edid_info(hd_data_t *hd_data, hd_t *hd, unsigned char *edid)
   int i;
   unsigned u, u1, u2, tag;
   char *s;
-  unsigned width_mm = 0, height_mm = 0, manu_year = 0;
+  unsigned width_mm = 0, height_mm = 0, manu_year = 0, manu_week = 0;
   unsigned min_vsync = 0, max_vsync = 0, min_hsync = 0, max_hsync = 0;
   unsigned hblank, hsync_ofs, hsync, vblank, vsync_ofs, vsync;
   char *vendor = NULL, *serial = NULL, *name = NULL;
@@ -366,6 +368,7 @@ void add_edid_info(hd_data_t *hd_data, hd_t *hd, unsigned char *edid)
   }
 
   manu_year = 1990 + edid[0x11];
+  manu_week = edid[0x10];
 
   ADD2LOG("  detailed timings:\n");
 
@@ -439,6 +442,7 @@ void add_edid_info(hd_data_t *hd_data, hd_t *hd, unsigned char *edid)
           mi->width_mm = width_mm;
           mi->height_mm = height_mm;
           mi->manu_year = manu_year;
+          mi->manu_week = manu_week;
 
           u = (edid[i + 0] + (edid[i + 1] << 8)) * 10;	/* pixel clock in kHz */
           if(!u) break;

--- a/src/hd/pci.c
+++ b/src/hd/pci.c
@@ -343,7 +343,6 @@ void add_edid_from_file(const char *file, pci_t *pci, int index, hd_data_t *hd_d
     }
     else {
       ADD2LOG("    monitor list full, ignoring monitor data %s\n", file);
-      fprintf(stderr, "* WARNING: Monitor list full, ignoring the monitor data at %s\n", file);
     }
     close(fd);
   }


### PR DESCRIPTION
Do not run the BIOS emulation when probing monitors, read the data from `/sys` if KMS is active.

- Support up to 6 monitors per card
- Print date of manufacture from the EDID data
