### PR TITLE
Fixes for compilation with musl libc

### DIFF
--- a/src/hd/bios.c
+++ b/src/hd/bios.c
@@ -9,7 +9,7 @@
 #if defined(__i386__) || defined (__x86_64__) || defined(__ia64__)
 #include <sys/io.h>
 #endif
-#include <sys/pci.h>
+#include <linux/pci.h>
 
 #include "hd.h"
 #include "hd_int.h"

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE		/* canonicalize_file_name(), strcasestr() */
+#define _GNU_SOURCE		/* strcasestr() */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2638,7 +2638,7 @@ char *hd_read_sysfs_link(char *base_dir, char *link_name)
   str_printf(&s, 0, "%s/%s", base_dir, link_name);
 
   free_mem(buf);
-  buf = canonicalize_file_name(s);
+  buf = realpath(s, NULL);
 
   free_mem(s);
 

--- a/src/hd/int.c
+++ b/src/hd/int.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/pci.h>
+#include <linux/pci.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/src/hd/manual.c
+++ b/src/hd/manual.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <ctype.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/src/hd/pci.c
+++ b/src/hd/pci.c
@@ -7,7 +7,7 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/pci.h>
+#include <linux/pci.h>
 
 #include "hd.h"
 #include "hd_int.h"

--- a/src/isdn/cdb/isdn_cdb.c
+++ b/src/isdn/cdb/isdn_cdb.c
@@ -172,12 +172,12 @@ char **argv;
 		fprintf(stderr, "Error no filename\n");
 		exit(1);
 	}
-	if (!(stdin=freopen(argv[1],"rb", stdin))) {
+	if (!freopen(argv[1],"rb", stdin)) {
 		fprintf(stderr, "Cannot open %s as stdin\n", argv[1]);
 		exit(2);
 	}
 	if (argc >2) {
-		if (!(stdout=freopen(argv[2],"w", stdout))) {
+		if (!freopen(argv[2],"w", stdout)) {
 			fprintf(stderr, "Cannot open %s as stdout\n", argv[2]);
 			exit(3);
 		}

--- a/src/isdn/cdb/mk_isdnhwdb.c
+++ b/src/isdn/cdb/mk_isdnhwdb.c
@@ -205,25 +205,25 @@ char **argv;
 	int	l;
 	time_t	tim;
 	if (argc<2) {
-		if (!(stdin=freopen(CDBISDN_CDB_FILE,"rb", stdin))) {
+		if (!freopen(CDBISDN_CDB_FILE,"rb", stdin)) {
 			fprintf(stderr, "Cannot open %s as stdin\n", CDBISDN_CDB_FILE);
 			exit(2);
 		}
 	} else {
-		if (!(stdin=freopen(argv[1],"rb", stdin))) {
+		if (!freopen(argv[1],"rb", stdin)) {
 			fprintf(stderr, "Cannot open %s as stdin\n", argv[1]);
 			exit(2);
 		}
 	}
 	if (argc >2) {
 		if (strcmp(argv[2], "-")) { /* - := stdout */
-			if (!(stdout=freopen(argv[2],"w", stdout))) {
+			if (!freopen(argv[2],"w", stdout)) {
 				fprintf(stderr, "Cannot open %s as stdout\n", argv[2]);
 				exit(3);
 			}
 		}
 	} else { /* default: CDBISDN_HWDB_FILE */
-		if (!(stdout=freopen(CDBISDN_HWDB_FILE,"w", stdout))) {
+		if (!freopen(CDBISDN_HWDB_FILE,"w", stdout)) {
 			fprintf(stderr, "Cannot open %s as stdout\n", CDBISDN_HWDB_FILE);
 			exit(3);
 		}


### PR DESCRIPTION
The `<sys/pci.h>` patch is also useful for uclibc:
https://bugs.gentoo.org/show_bug.cgi?id=506876