### PR TITLE
Expose more properties to all devices in /proc/device-tree/vpd

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -4309,6 +4309,12 @@ devtree_t *free_devtree(hd_data_t *hd_data)
     free_mem(dt->device_type);
     free_mem(dt->compatible);
     free_mem(dt->edid);
+    free_mem(dt->ccin);
+    free_mem(dt->fru_number);
+    free_mem(dt->loc_code);
+    free_mem(dt->serial_number);
+    free_mem(dt->part_number);
+    free_mem(dt->description);
 
     free_mem(dt);
   }

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -1181,6 +1181,8 @@ typedef struct devtree_s {
   char *path, *filename;
   unsigned pci:1;
   char *name, *model, *device_type, *compatible;
+  char *ccin, *fru_number, *loc_code, *serial_number, *part_number;
+  char *description;
   int class_code;                       /**< class : sub_class : prog-if */
   int vendor_id, device_id, subvendor_id, subdevice_id;
   int revision_id, interrupt;

--- a/src/hd/prom.c
+++ b/src/hd/prom.c
@@ -506,6 +506,12 @@ void read_devtree_entry(hd_data_t *hd_data, devtree_t *parent, char *dirname)
   read_str(path, "model", &devtree->model);
   read_str(path, "device_type", &devtree->device_type);
   read_str(path, "compatible", &devtree->compatible);
+  read_str(path, "ccin", &devtree->ccin);
+  read_str(path, "fru-number", &devtree->fru_number);
+  read_str(path, "ibm,loc-code", &devtree->loc_code);
+  read_str(path, "serial-number", &devtree->serial_number);
+  read_str(path, "part-number", &devtree->part_number);
+  read_str(path, "description", &devtree->description);
 
   read_int(path, "interrupts", &devtree->interrupt);
   read_int(path, "AAPL,interrupts", &devtree->interrupt);
@@ -560,6 +566,18 @@ void dump_devtree_data(hd_data_t *hd_data)
       devtree->model ? devtree->model : "",
       devtree->device_type ? devtree->device_type : "",
       devtree->compatible ? devtree->compatible : ""
+    );
+
+    if (strstr(devtree->path, "vpd") == devtree->path)
+      ADD2LOG(
+        "    ccin \"%s\", fru-number \"%s\", location-code \"%s\", serial-number \"%s\", part-number \"%s,\"\n"
+        "    description \"%s\"\n",
+        devtree->ccin ? devtree->ccin : "",
+        devtree->fru_number ? devtree->fru_number : "",
+        devtree->loc_code ? devtree->loc_code : "",
+        devtree->serial_number ? devtree->serial_number : "",
+        devtree->part_number ? devtree->part_number : "",
+        devtree->description ? devtree->description : ""
     );
 
     if(


### PR DESCRIPTION
For PowerKVM hosts, the device-tree exposed by the OPAL firmware is present at /proc/device-tree.
We find the device specific vital product data listed in linux at /proc/device-tree/vpd.
Here we are making hwinfo display more of unexposed vpd information on PPC hosts.

This patch exposes following device properties:
ccin          - Custom Card Identification Number
fru-number    - Field Replaceable Unit Number
ibm,loc-code  - location code(s) for the Field Replacable Unit
serial-number - 12 characters serial number (8 characters in old format)
part-number   - part number
description   - device description

The output will be something like:
...
  36 @01  vpd
    name "vpd", model "", dtype "", compat "ibm,opal-v3-vpd"
    ccin "", fru-number "", location-code "U8286.42A.10D6CFT", serial-number "", part-number ","
    description ""

  37 @36  vpd/root-node-vpd@a000
    name "root-node-vpd", model "", dtype "", compat ""
    ccin "", fru-number "", location-code "U8286.42A.10D6CFT", serial-number "", part-number ","
    description ""

  38 @37  vpd/root-node-vpd@a000/system-vpd@1c00
    name "system-vpd", model "", dtype "", compat ""
    ccin "", fru-number "", location-code "U8286.42A.10D6CFT", serial-number "", part-number ","
    description ""

  39 @37  vpd/root-node-vpd@a000/root-node-vpd@a001
    name "root-node-vpd", model "", dtype "", compat ""
    ccin "", fru-number "", location-code "U8286.42A.10D6CFT", serial-number "", part-number ","
    description ""

  40 @37  vpd/root-node-vpd@a000/enclosure@1e00
    name "enclosure", model "", dtype "", compat ""
    ccin "2CD4", fru-number "00E1962", location-code "U78C9.001.WZS007X", serial-number "YL30UF39H00M", part-number "00E3352,"
    description "System planar 2S4U"

  41 @40  vpd/root-node-vpd@a000/enclosure@1e00/service-processor@200
    name "service-processor", model "", dtype "", compat ""
    ccin "2CD4", fru-number "00E1962", location-code "U78C9.001.WZS007X-P1", serial-number "YL30UF39H00M", part-number "00E3352,"
    description "System planar 2S4U"
...

Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>