### PR TITLE
Correct comma placement after part-number

### DIFF
--- a/src/hd/prom.c
+++ b/src/hd/prom.c
@@ -570,7 +570,7 @@ void dump_devtree_data(hd_data_t *hd_data)
 
     if (strstr(devtree->path, "vpd") == devtree->path)
       ADD2LOG(
-        "    ccin \"%s\", fru-number \"%s\", location-code \"%s\", serial-number \"%s\", part-number \"%s,\"\n"
+        "    ccin \"%s\", fru-number \"%s\", location-code \"%s\", serial-number \"%s\", part-number \"%s\",\n"
         "    description \"%s\"\n",
         devtree->ccin ? devtree->ccin : "",
         devtree->fru_number ? devtree->fru_number : "",


### PR DESCRIPTION
comma should come after part-number value and not as a trail to
the value

Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>