### PR TITLE
Don't assume that "/var/lib/hardware/udi" exists on all distros

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -5930,6 +5930,11 @@ int hd_read_mmap(hd_data_t *hd_data, char *name, unsigned char *buf, off_t start
   return 1;
 }
 
+static void create_default_dir()
+{
+  mkdir(HARDWARE_DIR, 0755);
+  mkdir(HARDWARE_DIR "/udi", 0755);
+}
 
 /*
  * Get hardware data base dir (default: /var/lib/hardware).
@@ -5937,8 +5942,15 @@ int hd_read_mmap(hd_data_t *hd_data, char *name, unsigned char *buf, off_t start
 char *hd_get_hddb_dir()
 {
   char *s = getenv("LIBHD_HDDB_DIR");
+  struct stat sbuf;
 
-  return s && *s ? s : HARDWARE_DIR;
+  if (s && *s)
+    return s;
+
+  if (stat(HARDWARE_DIR, &sbuf) == -1)
+    create_default_dir();
+
+  return HARDWARE_DIR;
 }
 
 


### PR DESCRIPTION
Ubuntu, for instance does not have the hardware directory
/var/lib/hardware where configs are saved by default and it
fails to save the config files so we need to ensure that it
exists.

Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>