### PR TITLE
add permanent mac address field for network cards (bsc #1007172)

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -1740,7 +1740,7 @@ hd_res_t *free_res_list(hd_res_t *res)
       free_mem(res->pppd_option.option);
     }
 
-    if(res->any.type == res_hwaddr) {
+    if(res->any.type == res_hwaddr || res->any.type == res_phwaddr) {
       free_mem(res->hwaddr.addr);
     }
 

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -1636,7 +1636,7 @@ typedef struct hal_device_s {
 typedef enum resource_types {
   res_any, res_phys_mem, res_mem, res_io, res_irq, res_dma, res_monitor,
   res_size, res_disk_geo, res_cache, res_baud, res_init_strings, res_pppd_option,
-  res_framebuffer, res_hwaddr, res_link, res_wlan, res_fc
+  res_framebuffer, res_hwaddr, res_link, res_wlan, res_fc, res_phwaddr
 } hd_resource_types_t;
 
 

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -756,6 +756,10 @@ void dump_normal(hd_data_t *hd_data, hd_t *h, FILE *f)
 	dump_line("HW Address: %s\n", res->hwaddr.addr);
         break;
 
+      case res_phwaddr:
+	dump_line("Permanent HW Address: %s\n", res->hwaddr.addr);
+        break;
+
       case res_link:
 	dump_line("Link detected: %s\n", res->link.state ? "yes" : "no");
         break;


### PR DESCRIPTION
The code is similar to reading the mac address but needs an ethtool ioctl as
the value is not available in sysfs.