### PR TITLE
add permanent mac address field for network cards (bsc #1007172)

### DIFF
--- a/src/hd/Makefile
+++ b/src/hd/Makefile
@@ -9,6 +9,7 @@ version.h: $(TOPDIR)/VERSION
 
 hd.h: $(TOPDIR)/VERSION
 	@perl -pi -e "s/define\s+HD_VERSION\s+\d+/define HD_VERSION\t$(LIBHD_MAJOR_VERSION)/" $@
+	@perl -pi -e "s/define\s+HD_MINOR_VERSION\s+\d+/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $@
 
 $(LIBHD_D): $(OBJS)
 	ar r $(LIBHD) $?

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -1740,7 +1740,7 @@ hd_res_t *free_res_list(hd_res_t *res)
       free_mem(res->pppd_option.option);
     }
 
-    if(res->any.type == res_hwaddr) {
+    if(res->any.type == res_hwaddr || res->any.type == res_phwaddr) {
       free_mem(res->hwaddr.addr);
     }
 

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -1636,7 +1636,7 @@ typedef struct hal_device_s {
 typedef enum resource_types {
   res_any, res_phys_mem, res_mem, res_io, res_irq, res_dma, res_monitor,
   res_size, res_disk_geo, res_cache, res_baud, res_init_strings, res_pppd_option,
-  res_framebuffer, res_hwaddr, res_link, res_wlan, res_fc
+  res_framebuffer, res_hwaddr, res_link, res_wlan, res_fc, res_phwaddr
 } hd_resource_types_t;
 
 

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -20,6 +20,8 @@ extern "C" {
 
 /** Interface version */
 #define HD_VERSION	21
+#define HD_MINOR_VERSION	36
+#define HD_FULL_VERSION		(HD_VERSION * 1000 + HD_MINOR_VERSION)
 
 /**
  * @defgroup DEBUGpub Debug flags

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -756,6 +756,10 @@ void dump_normal(hd_data_t *hd_data, hd_t *h, FILE *f)
 	dump_line("HW Address: %s\n", res->hwaddr.addr);
         break;
 
+      case res_phwaddr:
+	dump_line("Permanent HW Address: %s\n", res->hwaddr.addr);
+        break;
+
       case res_link:
 	dump_line("Link detected: %s\n", res->link.state ? "yes" : "no");
         break;


### PR DESCRIPTION
The code is similar to reading the mac address but needs an ethtool ioctl as
the value is not available in sysfs.

This adds a new resource type res_phwaddr to hd_resource_types_t (extends
the enum, but no new data structures).

Replaces https://github.com/openSUSE/hwinfo/pull/39.