### PR TITLE
map also alternate video bios entry points (bsc #1033832)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ For general usage instructions, see `hwinfo` manual page.
 > `hwinfo -bios` - note the single '`-`'). Please don't do this. If you are interested, you can
 > read about it [here](README-legacy.md).
 
+## Technical documentation
+
+The hardware detection library makes use of a number of technical specifications.
+
+[Here](specifications.md) is a compilation of external links to technical standards relevant to `libhd`.
+
 ## openSUSE Development
 
 To build the library, simply run `make`. Install with `make install`.

--- a/specifications.md
+++ b/specifications.md
@@ -1,0 +1,46 @@
+# Links to external technical documentaion
+
+## System Management BIOS (SMBIOS)
+
+https://www.dmtf.org/standards/smbios
+
+
+## VESA BIOS Extensions (VBE)
+
+http://www.petesqbsite.com/sections/tutorials/tuts/vbe3.pdf
+
+
+## PCI specification
+
+https://pcisig.com/specifications
+
+### device ids
+
+- http://pci-ids.ucw.cz
+
+
+## SDIO specification
+
+https://www.sdcard.org/developers/overview/sdio/
+
+### device ids
+
+- https://github.com/systemd/systemd/blob/master/hwdb/sdio.ids
+- https://wikidevi.com/wiki/Talk:Linux_Wi-Fi_device_entries
+
+
+## USB specification
+
+http://www.usb.org/developers/docs/
+
+### device ids
+
+- http://www.linux-usb.org/usb.ids
+
+
+## SCSI specification
+
+### SCSI commands
+
+Google for 'SCSI Primary Commands 5 (SPC-5)' (or choose another version).
+The latest draft is usually freely available but not directly downloadable.

--- a/src/hd/bios.c
+++ b/src/hd/bios.c
@@ -455,7 +455,7 @@ void hd_scan_bios(hd_data_t *hd_data)
       bt->vbe_ver = vbe->version;
     }
 
-    if(vbe->ok && vbe->fb_start) {
+    if(vbe->ok && vbe->modes) {
       hd = add_hd_entry(hd_data, __LINE__, 0);
       hd->base_class.id = bc_framebuffer;
       hd->sub_class.id = sc_fb_vesa;
@@ -483,7 +483,7 @@ void hd_scan_bios(hd_data_t *hd_data)
           mi = vbe->mode + u;
           if(
             (mi->attributes & 1) &&	/* mode supported */
-            mi->fb_start &&
+            (mi->fb_start || (mi->attributes & 0x80)) &&	/* has linear framebuffer support */
             mi->pixel_size != -1u	/* text mode */
           ) {
             res = add_res_entry(&hd->res, new_mem(sizeof *res));

--- a/src/hd/mdt.c
+++ b/src/hd/mdt.c
@@ -277,8 +277,8 @@ int do_int(x86emu_t *emu, u8 num, unsigned type)
     return 0;
   }
 
-  // ignore ints != 0x10
-  if(num != 0x10) return 1;
+  // ignore ints != (0x10 or 0x42 or 0x6d)
+  if(num != 0x10 && num != 0x42 && num != 0x6d) return 1;
 
   return 0;
 }
@@ -370,7 +370,9 @@ int vm_prepare(vm_t *vm)
     return ok;
   }
 
-  copy_to_vm(vm->emu, 0x10*4, p1 + 0x10*4, 4, X86EMU_PERM_RW);
+  copy_to_vm(vm->emu, 0x10*4, p1 + 0x10*4, 4, X86EMU_PERM_RW);		// video bios entry
+  copy_to_vm(vm->emu, 0x42*4, p1 + 0x42*4, 4, X86EMU_PERM_RW);		// old video bios entry
+  copy_to_vm(vm->emu, 0x6d*4, p1 + 0x6d*4, 4, X86EMU_PERM_RW);		// saved video bios entry
   copy_to_vm(vm->emu, 0x400, p1 + 0x400, 0x100, X86EMU_PERM_RW);
 
   munmap(p1, 0x1000);


### PR DESCRIPTION
Besides interrupt 0x10 there are also 0x42 and 0x6d used sometimes.

For the video mode bits, cf. [vbe 3.0 spec](http://www.petesqbsite.com/sections/tutorials/tuts/vbe3.pdf), page 30-37.