### PR TITLE
Ensure /var/lib/hardware/udi exists and with 755 permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ install:
 	install -m 755 getsysinfo $(DESTDIR)/usr/sbin
 	install -m 755 src/isdn/cdb/mk_isdnhwdb $(DESTDIR)/usr/sbin
 	install -d -m 755 $(DESTDIR)/usr/share/hwinfo
+	install -d -m 755 $(DESTDIR)/var/lib/hardware/udi
 	install -m 644 src/isdn/cdb/ISDN.CDB.txt $(DESTDIR)/usr/share/hwinfo
 	install -m 644 src/isdn/cdb/ISDN.CDB.hwdb $(DESTDIR)/usr/share/hwinfo
 


### PR DESCRIPTION
We make this fix in Makefile at installation time so that the
directory gets removed upon purging the package and doesn't
linger on.

This fixes any save-config issues one may see on Linux
distributions where the directory doesn't exist by default.

Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>