### PR TITLE
Please make CDBISDN_DATE ignore timezone

### DIFF
--- a/src/isdn/cdb/isdn_cdb.c
+++ b/src/isdn/cdb/isdn_cdb.c
@@ -224,7 +224,7 @@ char **argv;
 	fprintf(stdout,"const int  CDBISDN_DBVERSION = 0x%x;\n", CDB_DATAVERSION);
 	if ((source_date_epoch = getenv("SOURCE_DATE_EPOCH")) == NULL || (tim = (time_t)strtol(source_date_epoch, NULL, 10)) <= 0)
 		time(&tim);
-	strcpy(line,ctime(&tim));
+	strcpy(line,asctime(gmtime(&tim)));
 	l = strlen(line);
 	if (l)
 		line[l-1] = 0;


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that hwinfo could not be built reproducibly.

Whilst it uses SOURCE_DATE_EPOCH, it varies depending on the timezone
via ctime(&t) instead of asctime(gmtime(&t)).

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>