### PR TITLE
detect ARM HISILICON SAS controller (bsc #1072450)

### DIFF
--- a/src/hd/pci.c
+++ b/src/hd/pci.c
@@ -930,7 +930,7 @@ void add_mv643xx_eth(hd_data_t *hd_data, char *entry, char *platform_type)
  */
 void hd_read_platform(hd_data_t *hd_data)
 {
-  char *s, *platform_type, *device_type = NULL;
+  char *s, *platform_type, *device_type;
   str_list_t *sf_bus, *sf_bus_e, *sf_eth_dev = NULL;
   char *sf_dev, *sf_eth_net;
   int mv643xx_eth_seen = 0;
@@ -955,13 +955,14 @@ void hd_read_platform(hd_data_t *hd_data)
 
     if((s = get_sysfs_attr_by_path(sf_dev, "modalias"))) {
       platform_type = canon_str(s, strlen(s));
-      device_type = free_mem(device_type);
+      device_type = new_str("");
       if((s = get_sysfs_attr_by_path(sf_dev, "uevent"))) {
         char *t, *t2;
         if((t = strstr(s, "OF_NAME="))) {
           t += sizeof "OF_NAME=" - 1;
           if((t2 = strchr(t, '\n'))) *t2 = 0;
-          device_type = strdup(t);
+          free_mem(device_type);
+          device_type = new_str(t);
         }
       }
       ADD2LOG("    type = \"%s\", modalias = \"%s\"\n", device_type, platform_type);
@@ -969,9 +970,12 @@ void hd_read_platform(hd_data_t *hd_data)
       sf_eth_net = new_str(hd_read_sysfs_link(sf_dev, "net"));
       sf_eth_dev = read_dir(sf_eth_net, 'd');
       is_net = sf_eth_net && sf_eth_dev;
-      is_storage = device_type && !strcmp(device_type, "sata");
-      is_usb = device_type && (!strcmp(device_type, "usb") || !strcmp(device_type, "dwusb"));
-      is_xhci = platform_type && strstr(platform_type, ":xhci-hcd");
+      is_storage =
+        !strcmp(device_type, "sata") ||
+        !strcmp(platform_type, "acpi:HISI0161:") ||
+        !strcmp(platform_type, "acpi:HISI0162:");
+      is_usb = !strcmp(device_type, "usb") || !strcmp(device_type, "dwusb");
+      is_xhci = !!strstr(platform_type, ":xhci-hcd");
       if(is_net) ADD2LOG("    is net: sf_eth_net = %s\n", sf_eth_net);
       if(is_storage) ADD2LOG("    is storage\n");
       if(is_usb) ADD2LOG("    is usb\n");
@@ -990,7 +994,7 @@ void hd_read_platform(hd_data_t *hd_data)
         hd = add_hd_entry(hd_data, __LINE__, 0);
         hd->base_class.id = bc_network;
         hd->sub_class.id = 0;
-        str_printf(&hd->device.name, 0, "ARM Ethernet %d", hd->slot);
+        str_printf(&hd->device.name, 0, "ARM Ethernet controller");
         hd->modalias = new_str(platform_type);
         hd->sysfs_id = new_str(hd_sysfs_id(sf_dev));
         hd->sysfs_bus_id = new_str(sf_bus_e->str);
@@ -1000,8 +1004,18 @@ void hd_read_platform(hd_data_t *hd_data)
       else if(is_storage) {
         hd = add_hd_entry(hd_data, __LINE__, 0);
         hd->base_class.id = bc_storage;
-        hd->sub_class.id = sc_sto_ide;
-        str_printf(&hd->device.name, 0, "ARM SATA %d", hd->slot);
+        if(!strcmp(device_type, "sata")) {
+          str_printf(&hd->device.name, 0, "ARM SATA controller");
+          hd->sub_class.id = sc_sto_ide;
+        }
+        else if(!strcmp(platform_type, "acpi:HISI0162:") || !strcmp(platform_type, "acpi:HISI0161:")) {
+          str_printf(&hd->device.name, 0, "HISILICON SAS controller");
+          hd->sub_class.id = sc_sto_scsi;
+        }
+        else {
+          str_printf(&hd->device.name, 0, "Storage controller");
+          hd->sub_class.id = sc_sto_other;
+        }
         hd->modalias = new_str(platform_type);
         hd->sysfs_id = new_str(hd_sysfs_id(sf_dev));
         hd->sysfs_bus_id = new_str(sf_bus_e->str);
@@ -1018,7 +1032,7 @@ void hd_read_platform(hd_data_t *hd_data)
           str_printf(&hd->device.name, 0, "ARM USB XHCI Controller");
         }
         else {
-          str_printf(&hd->device.name, 0, "ARM USB %d", hd->slot);
+          str_printf(&hd->device.name, 0, "ARM USB");
         }
         hd->modalias = new_str(platform_type);
         hd->sysfs_id = new_str(hd_sysfs_id(sf_dev));
@@ -1026,6 +1040,7 @@ void hd_read_platform(hd_data_t *hd_data)
         s = hd_sysfs_find_driver(hd_data, hd->sysfs_id, 1);
         if(s) add_str_list(&hd->drivers, s);
       }
+      free_mem(device_type);
       free_mem(platform_type);
     }
 


### PR DESCRIPTION
There seems no better way than to check the modalias ('platform_type' variable).

Also, since hd->slot is always 0 there's really no point using it to enumerate controllers.

Note that both device_type and platform_type are never NULL in the new code - so we can save these checks.