### PR TITLE
adjust system type detection (bsc #1117982)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ install:
 	fi
 	install -m 644 hwinfo.pc $(DESTDIR)$(ULIBDIR)/pkgconfig
 	install -m 644 src/hd/hd.h $(DESTDIR)/usr/include
-	perl -pi -e "s/define\s+HD_VERSION\s+\d+/define HD_VERSION\t\t$(LIBHD_MAJOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
-	perl -pi -e "s/define\s+HD_MINOR_VERSION\s+\d+/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
+	perl -pi -e "s/define\s+HD_VERSION\b.*/define HD_VERSION\t\t$(LIBHD_MAJOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
+	perl -pi -e "s/define\s+HD_MINOR_VERSION\b.*/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
 	install -m 755 getsysinfo $(DESTDIR)/usr/sbin
 	install -m 755 src/isdn/cdb/mk_isdnhwdb $(DESTDIR)/usr/sbin
 	install -d -m 755 $(DESTDIR)/usr/share/hwinfo

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ install:
 	fi
 	install -m 644 hwinfo.pc $(DESTDIR)$(ULIBDIR)/pkgconfig
 	install -m 644 src/hd/hd.h $(DESTDIR)/usr/include
+	perl -pi -e "s/define\s+HD_VERSION\s+\d+/define HD_VERSION\t\t$(LIBHD_MAJOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
+	perl -pi -e "s/define\s+HD_MINOR_VERSION\s+\d+/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
 	install -m 755 getsysinfo $(DESTDIR)/usr/sbin
 	install -m 755 src/isdn/cdb/mk_isdnhwdb $(DESTDIR)/usr/sbin
 	install -d -m 755 $(DESTDIR)/usr/share/hwinfo
@@ -125,7 +127,6 @@ install:
 
 archive: changelog
 	@if [ ! -d .git ] ; then echo no git repo ; false ; fi
-	make -C src/hd hd.h
 	mkdir -p package
 	git archive --prefix=$(PREFIX)/ $(BRANCH) > package/$(PREFIX).tar
 	tar -r -f package/$(PREFIX).tar --mode=0664 --owner=root --group=root --mtime="`git show -s --format=%ci`" --transform='s:^:$(PREFIX)/:' VERSION changelog src/hd/hd.h

--- a/src/hd/Makefile
+++ b/src/hd/Makefile
@@ -7,9 +7,5 @@ include $(TOPDIR)/Makefile.common
 version.h: $(TOPDIR)/VERSION
 	@echo "#define HD_VERSION_STRING \"`cat $(TOPDIR)/VERSION`\"" >$@
 
-hd.h: $(TOPDIR)/VERSION
-	@perl -pi -e "s/define\s+HD_VERSION\s+\d+/define HD_VERSION\t$(LIBHD_MAJOR_VERSION)/" $@
-	@perl -pi -e "s/define\s+HD_MINOR_VERSION\s+\d+/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $@
-
 $(LIBHD_D): $(OBJS)
 	ar r $(LIBHD) $?

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -19,8 +19,8 @@ extern "C" {
  */
 
 /** Interface version */
-#define HD_VERSION		0
-#define HD_MINOR_VERSION	0
+#define HD_VERSION		0	/* will be set during install */
+#define HD_MINOR_VERSION	0	/* will be set during install */
 #define HD_FULL_VERSION		(HD_VERSION * 1000 + HD_MINOR_VERSION)
 
 /**

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -19,8 +19,8 @@ extern "C" {
  */
 
 /** Interface version */
-#define HD_VERSION	21
-#define HD_MINOR_VERSION	38
+#define HD_VERSION		0
+#define HD_MINOR_VERSION	0
 #define HD_FULL_VERSION		(HD_VERSION * 1000 + HD_MINOR_VERSION)
 
 /**


### PR DESCRIPTION
The old code turned everyting with a touchpad into a laptop. Now we do this
only if there's no valid chassis info in the DMI records.