### PR TITLE
return BIOS UUID in decoded (with '-'s) form (bsc #1135819)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ ULIBDIR		= $(LIBDIR)
 
 # ia64
 ifneq ($(filter i386 x86_64, $(ARCH)),)
-SLIBS		+= -lx86emu
-TLIBS		+= -lx86emu
-SO_LIBS		+= -lx86emu
-TSO_LIBS	+= -lx86emu
+SLIBS		+= -lx86emu -luuid
+TLIBS		+= -lx86emu -luuid
+SO_LIBS		+= -lx86emu -luuid
+TSO_LIBS	+= -lx86emu -luuid
 endif
 
 SHARED_FLAGS	=


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1135819

- hwinfo: `56443150303436454337323130373438`
- dmidecode: `30373438-3231-4337-4536-343050314456`

The 'canonical' form has dashes inserted and some bytes are swapped.

### Solution

Display UUID properly (in the expected form) in hwinfo.

### Note

This fixes also a bug that prevented hwinfo to recognize the uuid in some cases.