### PR TITLE
fix DASD detection (bsc#1136475)

### DIFF
--- a/src/hd/block.c
+++ b/src/hd/block.c
@@ -525,36 +525,37 @@ void add_other_sysfs_info(hd_data_t *hd_data, hd_t *hd)
 
   if(hd->sysfs_id) {
     if(
-      sscanf(hd->sysfs_id, "/block/cciss!c%ud%u", &u0, &u1) == 2
+      sscanf(hd->sysfs_id, "/class/block/cciss!c%ud%u", &u0, &u1) == 2
     ) {
       hd->slot = (u0 << 8) + u1;
       str_printf(&hd->device.name, 0, "CCISS disk %u/%u", u0, u1);
     }
     else if(
-      sscanf(hd->sysfs_id, "/block/ida!c%ud%u", &u0, &u1) == 2
+      sscanf(hd->sysfs_id, "/class/block/ida!c%ud%u", &u0, &u1) == 2
     ) {
       hd->slot = (u0 << 8) + u1;
       str_printf(&hd->device.name, 0, "SMART Array %u/%u", u0, u1);
     }
     else if(
-      sscanf(hd->sysfs_id, "/block/rd!c%ud%u", &u0, &u1) == 2
+      sscanf(hd->sysfs_id, "/class/block/rd!c%ud%u", &u0, &u1) == 2
     ) {
       hd->slot = (u0 << 8) + u1;
       str_printf(&hd->device.name, 0, "DAC960 RAID Array %u/%u", u0, u1);
     }
     else if(
-      sscanf(hd->sysfs_id, "/block/i2o!hd%c", &c) == 1 &&
+      sscanf(hd->sysfs_id, "/class/block/i2o!hd%c", &c) == 1 &&
       c >= 'a'
     ) {
       hd->slot = c - 'a';
       str_printf(&hd->device.name, 0, "I2O disk %u", hd->slot);
     }
     else if(
-      sscanf(hd->sysfs_id, "/block/dasd%c", &c) == 1 &&
+      sscanf(hd->sysfs_id, "/class/block/dasd%c", &c) == 1 &&
       c >= 'a'
     ) {
       hd->slot = c - 'a';
       hd->device.name = new_str("S390 Disk");
+      hd_set_hw_class(hd, hw_redasd);
     }
   }
 

--- a/src/hd/block.c
+++ b/src/hd/block.c
@@ -1222,7 +1222,8 @@ void read_partitions(hd_data_t *hd_data)
           hd_data->flags.list_md ||
           (
             strncmp(name, "md", sizeof "md" - 1) &&
-            strncmp(name, "dm-", sizeof "dm-" - 1)
+            strncmp(name, "dm-", sizeof "dm-" - 1) &&
+            strncmp(name, "bcache", sizeof "bcache" - 1)
           )
         )
       ) {

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -4783,13 +4783,6 @@ void assign_hw_class(hd_data_t *hd_data, hd_t *hd)
   ) {
     hd_set_hw_class(hd, hw_tape);
   }
-
-  if(
-    hd->base_class.id == bc_storage_device &&
-    hd->sub_class.id == sc_sdev_disk
-  ) {
-    hd_set_hw_class(hd, hw_redasd);
-  }
 }
 
 


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1136475

Also non-DASD devices (all disks) show up as DASDs.

### Solution

The code accidentally made all disks DASDs. The 'real' detection however (based on the file name), stopped working with the `/block` -> `/class/block` move in sysfs (i.e. long long ago...).

And, while we're at it: keep bcache devices out of the regular disk list.