### PR TITLE
the /sbin/udevadm compat symlink is gone

### DIFF
--- a/src/hd/hd_int.h
+++ b/src/hd/hd_int.h
@@ -43,7 +43,7 @@
 #define PROG_RMMOD		"/sbin/rmmod"
 #define PROG_CARDCTL		"/sbin/cardctl"
 #define PROG_UDEVINFO		"/usr/bin/udevinfo"
-#define PROG_UDEVADM		"/sbin/udevadm"
+#define PROG_UDEVADM		"/usr/bin/udevadm"
 
 #define KLOG_BOOT		"/var/log/boot.msg"
 #define ISAPNP_CONF		"/etc/isapnp.conf"


### PR DESCRIPTION
## Problem

Latest udev package no longer contains the `/sbin/udevadm` symlink.

## Solution

Don't use it.