### PR TITLE
fix xen detection (bsc#1167561)

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -3152,6 +3152,8 @@ int hd_is_sgi_altix(hd_data_t *hd_data)
 
 /*
  * check for xen hypervisor
+ *
+ * see https://www.sandpile.org/x86/cpuid.htm#level_4000_0000h
  */
 int hd_is_xen(hd_data_t *hd_data)
 {


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1167561

The old code in `hd_is_xen()` had unwanted side effects (the push/pop sequence messed up local variables) and the `asm()` call did not specify the clobbered registers correctly.

## Solution

Fix `hd_is_xen()` - it's also smaller now.

## See also

- `cpuid` instruction: https://www.sandpile.org/x86/cpuid.htm#level_4000_0000h