### PR TITLE
update pci and usb ids (bsc#1169682)

### DIFF
--- a/src/hd/pppoe.c
+++ b/src/hd/pppoe.c
@@ -199,10 +199,10 @@ open_interfaces (int n, PPPoEConnection* conns)
 	}
 
 	/* Fill in hardware address */
-	struct ifreq ifr;
+	struct ifreq ifr = {};
 	struct sockaddr_ll sa;
 	memset (&sa, 0, sizeof (sa));
-	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name));
+	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name) - 1);
 	if (ioctl (conn->fd, SIOCGIFHWADDR, &ifr) < 0) {
 	    ADD2LOG ("%s: ioctl (SIOCGIFHWADDR) failed: %m\n", conn->ifname);
 	    goto error;
@@ -221,7 +221,7 @@ open_interfaces (int n, PPPoEConnection* conns)
 	}
 
 	/* Sanity check on MTU */
-	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name));
+	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name) - 1);
 	if (ioctl (conn->fd, SIOCGIFMTU, &ifr) < 0) {
 	    ADD2LOG ("%s: ioctl (SIOCGIFMTU) failed: %m\n", conn->ifname);
 	    goto error;
@@ -232,7 +232,7 @@ open_interfaces (int n, PPPoEConnection* conns)
 	}
 
 	/* Skip interfaces that have the SLAVE flag set */
-	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name));
+	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name) - 1);
 	if (ioctl (conn->fd, SIOCGIFFLAGS, &ifr) < 0) {
 		ADD2LOG ("%s: ioctl (SIOCGIFFLAGS) failed: %m\n", conn->ifname);
 		goto error;
@@ -245,7 +245,7 @@ open_interfaces (int n, PPPoEConnection* conns)
 	/* Get interface index */
 	sa.sll_family = AF_PACKET;
 	sa.sll_protocol = htons (ETH_PPPOE_DISCOVERY);
-	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name));
+	strncpy (ifr.ifr_name, conn->ifname, sizeof (ifr.ifr_name) - 1);
 	if (ioctl (conn->fd, SIOCGIFINDEX, &ifr) < 0) {
 	    ADD2LOG ("%s: ioctl (SIOCFIGINDEX) failed: Could not get interface "
 		     "index\n", conn->ifname);

--- a/src/hd/wlan.c
+++ b/src/hd/wlan.c
@@ -63,7 +63,7 @@ iw_get_ext(int                  skfd,           /* Socket to the kernel */
            struct iwreq *       pwrq)           /* Fixed part of the request */
 {
   /* Set device name */
-  strncpy(pwrq->ifr_name, ifname, IFNAMSIZ);
+  strncpy(pwrq->ifr_name, ifname, IFNAMSIZ - 1);
   /* Do the request */
   return(ioctl(skfd, request, pwrq));
 }

--- a/src/ids/src/pci
+++ b/src/ids/src/pci
@@ -140,6 +140,9 @@
 &device.id		pci 0x0106
 +device.name		FPC-0106TX misprogrammed [RTL81xx]
 
+ vendor.id		pci 0x01de
++vendor.name		Oxide Computer Company
+
  vendor.id		pci 0x021b
 +vendor.name		Compaq Computer Corporation
 
@@ -227,6 +230,9 @@
 
  vendor.id		pci 0x07d1
 +vendor.name		D-Link System Inc
+
+ vendor.id		pci 0x0824
++vendor.name		T1042 [Freescale]
 
  vendor.id		pci 0x0925
 +vendor.name		VIA Technologies, Inc. (Wrong ID)
@@ -1005,6 +1011,18 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x0014
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1f3a
++subdevice.name		PERC H745 Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0014
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1f3b
++subdevice.name		PERC H745 Front
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0014
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1fd4
 +subdevice.name		PERC H745P MX
 
@@ -1053,6 +1071,18 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x0015
 +device.name		MegaRAID Tri-Mode SAS3416
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0015
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1f3c
++subdevice.name		PERC H345 Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0015
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1f3d
++subdevice.name		PERC H345 Front
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0015
@@ -1922,6 +1952,18 @@
 
  vendor.id		pci 0x1000
 &device.id		pci 0x005d
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0014
++subdevice.name		12G SAS3108 2G
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x005d
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0015
++subdevice.name		12G SAS3108 4G
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x005d
 &subvendor.id		pci 0x1d49
 &subdevice.id		pci 0x0600
 +subdevice.name		ThinkSystem RAID 730-8i 1GB Cache PCIe 12Gb Adapter
@@ -2011,6 +2053,12 @@
 &subvendor.id		pci 0x1054
 &subdevice.id		pci 0x306a
 +subdevice.name		SAS 3004 iMR ROMB
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x005f
+&subvendor.id		pci 0x1734
+&subdevice.id		pci 0x1211
++subdevice.name		PRAID CP400i [D3307-A12]
 
  vendor.id		pci 0x1000
 &device.id		pci 0x005f
@@ -2259,6 +2307,12 @@
 +subdevice.name		SAS9211-4i
 
  vendor.id		pci 0x1000
+&device.id		pci 0x0070
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x040e
++subdevice.name		ServeRAID H1110
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x0071
 +device.name		MR SAS HBA 2004
 
@@ -2319,6 +2373,36 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1f22
 +subdevice.name		PERC H200 Internal Tape Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0072
+&subvendor.id		pci 0x1734
+&subdevice.id		pci 0x1177
++subdevice.name		HBA Ctrl SAS 6G 0/1 [D2607]
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0072
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x000d
++subdevice.name		6G SAS2008IT
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0072
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x000e
++subdevice.name		6G SAS2008IR
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0072
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x000f
++subdevice.name		6G SAS2008IT SA5248
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0072
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0010
++subdevice.name		6G SAS2008IR SA5248
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0072
@@ -2910,6 +2994,12 @@
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0087
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3060
++subdevice.name		SAS9217-4i4e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0087
 &subvendor.id		pci 0x1014
 &subdevice.id		pci 0x0472
 +subdevice.name		N2125 External Host Bus Adapter
@@ -2917,8 +3007,32 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x0087
 &subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0041
++subdevice.name		H220i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0087
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0042
++subdevice.name		H221 / 9207-8e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0087
+&subvendor.id		pci 0x1590
 &subdevice.id		pci 0x0044
 +subdevice.name		H220i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0087
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0009
++subdevice.name		6G SAS2308IR
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0087
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x000a
++subdevice.name		6G SAS2308IT
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0087
@@ -3071,12 +3185,72 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x0097
 &subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0008
++subdevice.name		12G SAS3008IMR Onboard
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x000b
++subdevice.name		12G SAS3008IR
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x000c
++subdevice.name		12G SAS3008IT
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
 &subdevice.id		pci 0x0011
 +subdevice.name		Inspur 12Gb 8i-3008 IT SAS HBA
 
  vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0012
++subdevice.name		12Gb SAS3008IR UDM
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x001f
++subdevice.name		12G SAS3008IR Onboard
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0020
++subdevice.name		12G SAS3008IT Onboard
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0026
++subdevice.name		12G SAS3008IT RACK
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0027
++subdevice.name		12G SAS3008IMR RACK
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0097
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0028
++subdevice.name		12G SAS3008IR RACK
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x00ab
 +device.name		SAS3516 Fusion-MPT Tri-Mode RAID On Chip (ROC)
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00ab
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3040
++subdevice.name		HBA 9400-8i8e
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00ab
@@ -3087,6 +3261,30 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x00ac
 +device.name		SAS3416 Fusion-MPT Tri-Mode I/O Controller Chip (IOC)
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00ac
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3000
++subdevice.name		HBA 9400-16i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00ac
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3020
++subdevice.name		HBA 9400-16e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00ac
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1fe3
++subdevice.name		HBA345 Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00ac
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1fe4
++subdevice.name		HBA345 Front
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00ac
@@ -3125,6 +3323,12 @@
 &subvendor.id		pci 0x1000
 &subdevice.id		pci 0x3010
 +subdevice.name		HBA 9400-8i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00af
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3030
++subdevice.name		HBA 9400-8e
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00af
@@ -3223,8 +3427,32 @@
 +device.name		SAS3716 Fusion-MPT Tri-Mode RAID Controller Chip (ROC)
 
  vendor.id		pci 0x1000
+&device.id		pci 0x00d0
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3050
++subdevice.name		HBA 9405W-16i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00d0
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3070
++subdevice.name		HBA 9405W-8i8e
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x00d1
 +device.name		SAS3616 Fusion-MPT Tri-Mode I/O Controller Chip (IOC)
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00d1
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3080
++subdevice.name		HBA 9405W-16e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00d1
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x3090
++subdevice.name		HBA 9405W-16i
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00d3
@@ -3251,16 +3479,136 @@
 +device.name		Fusion-MPT 12GSAS/PCIe Unsupported SAS38xx
 
  vendor.id		pci 0x1000
+&device.id		pci 0x00e4
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200b
++subdevice.name		HBA355i Adapter Invalid
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e4
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200c
++subdevice.name		HBA355i Front Invalid
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e4
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200d
++subdevice.name		HBA355e Adapter Invalid
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e4
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200e
++subdevice.name		HBA350i MX Invalid
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x00e5
 +device.name		Fusion-MPT 12GSAS/PCIe SAS38xx
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e5
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200b
++subdevice.name		HBA355i Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e5
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200c
++subdevice.name		HBA355i Front
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e5
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200d
++subdevice.name		HBA355e Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e5
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200e
++subdevice.name		HBA350i MX
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e5
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0205
++subdevice.name		ThinkSystem 440-16i SAS/SATA PCIe Gen4 12Gb Internal HBA
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e5
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0206
++subdevice.name		ThinkSystem 440-16e SAS/SATA PCIe Gen4 12Gb HBA
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00e6
 +device.name		Fusion-MPT 12GSAS/PCIe Secure SAS38xx
 
  vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200b
++subdevice.name		HBA355i Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200c
++subdevice.name		HBA355i Front
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200d
++subdevice.name		HBA355e Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200e
++subdevice.name		HBA355i MX
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0205
++subdevice.name		ThinkSystem 440-16i SAS/SATA PCIe Gen4 12Gb Internal HBA
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0206
++subdevice.name		ThinkSystem 440-16e SAS/SATA PCIe Gen4 12Gb HBA
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x00e7
 +device.name		Fusion-MPT 12GSAS/PCIe Unsupported SAS38xx
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e7
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200b
++subdevice.name		HBA355i Adapter Tampered
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e7
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200c
++subdevice.name		HBA355i Front Tampered
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e7
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200d
++subdevice.name		HBA355e Adapter Tampered
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e7
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200e
++subdevice.name		HBA350i MX Tampered
 
  vendor.id		pci 0x1000
 &device.id		pci 0x02b0
@@ -3663,16 +4011,184 @@
 +device.name		MegaRAID 12GSAS/PCIe Unsupported SAS39xx
 
  vendor.id		pci 0x1000
+&device.id		pci 0x10e0
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae0
++subdevice.name		PERC H755 Adapter - Invalid Device
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e0
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae1
++subdevice.name		PERC H755 Front - Invalid Device
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e0
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae2
++subdevice.name		PERC H755N Front - Invalid Device
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e0
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae3
++subdevice.name		PERC H755 MX - Invalid Device
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x10e1
 +device.name		MegaRAID 12GSAS/PCIe SAS39xx
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae0
++subdevice.name		PERC H755 Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae1
++subdevice.name		PERC H755 Front
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae2
++subdevice.name		PERC H755N Front
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae3
++subdevice.name		PERC H755 MX
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060a
++subdevice.name		ThinkSystem RAID 940-8i 4GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060b
++subdevice.name		ThinkSystem RAID 940-8i 8GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060c
++subdevice.name		ThinkSystem RAID 940-16i 8GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060d
++subdevice.name		ThinkSystem RAID 940-16i 8GB Flash PCIe Gen4 12Gb Internal Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060e
++subdevice.name		ThinkSystem RAID 940-32i 8GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e1
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060f
++subdevice.name		ThinkSystem RAID 940-8e 4GB Flash PCIe Gen4 12Gb Adapter
 
  vendor.id		pci 0x1000
 &device.id		pci 0x10e2
 +device.name		MegaRAID 12GSAS/PCIe Secure SAS39xx
 
  vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae0
++subdevice.name		PERC H755 Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae1
++subdevice.name		PERC H755 Front
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae2
++subdevice.name		PERC H755N Front
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae3
++subdevice.name		PERC H755 MX
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060a
++subdevice.name		ThinkSystem RAID 940-8i 4GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060b
++subdevice.name		ThinkSystem RAID 940-8i 8GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060c
++subdevice.name		ThinkSystem RAID 940-16i 8GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060d
++subdevice.name		ThinkSystem RAID 940-16i 8GB Flash PCIe Gen4 12Gb Internal Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060e
++subdevice.name		ThinkSystem RAID 940-32i 8GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x060f
++subdevice.name		ThinkSystem RAID 940-8e 4GB Flash PCIe Gen4 12Gb Adapter
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x10e3
 +device.name		MegaRAID 12GSAS/PCIe Unsupported SAS39xx
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e3
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae0
++subdevice.name		PERC H755 Adapter - Tampered Device
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e3
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae1
++subdevice.name		PERC H755 Front - Tampered Device
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e3
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae2
++subdevice.name		PERC H755N Front - Tampered Device
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e3
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1ae3
++subdevice.name		PERC H755 MX - Tampered Device
 
  vendor.id		pci 0x1000
 &device.id		pci 0x10e4
@@ -3837,8 +4353,20 @@
 +device.name		Kaveri HDMI/DP Audio Controller
 
  vendor.id		pci 0x1002
+&device.id		pci 0x1308
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x1309
 +device.name		Kaveri [Radeon R6/R7 Graphics]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x1309
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3830
++subdevice.name		Z50-75
 
  vendor.id		pci 0x1002
 &device.id		pci 0x130a
@@ -3923,6 +4451,14 @@
 +device.name		Ariel
 
  vendor.id		pci 0x1002
+&device.id		pci 0x1478
++device.name		Navi 10 XL Upstream Port of PCI Express Switch
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x1479
++device.name		Navi 10 XL Downstream Port of PCI Express Switch
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x154c
 +device.name		Kryptos
 
@@ -3947,6 +4483,18 @@
 +device.name		Picasso
 
  vendor.id		pci 0x1002
+&device.id		pci 0x15d8
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15d8
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x15dd
 +device.name		Raven Ridge [Radeon Vega Series / Radeon Vega Mobile Series]
 
@@ -3967,8 +4515,26 @@
 +device.name		Raven/Raven2/Fenghuang HDMI/DP Audio Controller
 
  vendor.id		pci 0x1002
+&device.id		pci 0x15de
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15de
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x15df
 +device.name		Raven/Raven2/Fenghuang/Renoir Cryptographic Coprocessor
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15df
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
 
  vendor.id		pci 0x1002
 &device.id		pci 0x15ff
@@ -4864,7 +5430,7 @@
 &device.id		pci 0x4383
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1611
-+subdevice.name		Pavilion DM1Z-3000
++subdevice.name		Pavilion dm1z-3000
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4383
@@ -4919,6 +5485,12 @@
 &subvendor.id		pci 0x1458
 &subdevice.id		pci 0xa022
 +subdevice.name		GA-MA770-DS3rev2.0 Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4383
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0xa102
++subdevice.name		GA-880GMA-USB3
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4383
@@ -5281,6 +5853,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x4391
 &subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4391
+&subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1611
 +subdevice.name		Pavilion DM1Z-3000
 
@@ -5307,6 +5885,12 @@
 &subvendor.id		pci 0x105b
 &subdevice.id		pci 0x0e13
 +subdevice.name		N15235/A74MX mainboard / AMD SB700
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4391
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0xb002
++subdevice.name		GA-880GMA-USB3
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4391
@@ -5349,6 +5933,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x4396
 &subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4396
+&subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1611
 +subdevice.name		Pavilion DM1Z-3000
 
@@ -5369,6 +5959,12 @@
 &subvendor.id		pci 0x105b
 &subdevice.id		pci 0x0e13
 +subdevice.name		N15235/A74MX mainboard / AMD SB700
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4396
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x5004
++subdevice.name		GA-880GMA-USB3
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4396
@@ -5395,6 +5991,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x4397
 &subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4397
+&subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1611
 +subdevice.name		Pavilion DM1Z-3000
 
@@ -5415,6 +6017,12 @@
 &subvendor.id		pci 0x105b
 &subdevice.id		pci 0x0e13
 +subdevice.name		N15235/A74MX mainboard / AMD SB700
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4397
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x5004
++subdevice.name		GA-880GMA-USB3
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4397
@@ -5486,6 +6094,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4399
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x5004
++subdevice.name		GA-880GMA-USB3
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4399
 &subvendor.id		pci 0x174b
 &subdevice.id		pci 0x1001
 +subdevice.name		PURE Fusion Mini
@@ -5508,6 +6122,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x439c
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x439c
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x82ef
 +subdevice.name		M3A78-EH Motherboard
@@ -5527,6 +6147,12 @@
 &subvendor.id		pci 0x1019
 &subdevice.id		pci 0x2120
 +subdevice.name		A785GM-M
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x439d
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
 
  vendor.id		pci 0x1002
 &device.id		pci 0x439d
@@ -7478,7 +8104,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5246
-+device.name		Rage 4 [Rage Fury/Xpert 128/Xpert 2000 AGP]
++device.name		Rage 128 (Rage 4) series
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5246
@@ -7490,7 +8116,7 @@
 &device.id		pci 0x5246
 &subvendor.id		pci 0x1002
 &subdevice.id		pci 0x0008
-+subdevice.name		Magnum/Xpert128/X99/Xpert2000
++subdevice.name		Rage 128 AGP 2x
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5246
@@ -8786,13 +9412,19 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6611
-+device.name		Oland [Radeon HD 8570 / R7 240/340 OEM]
++device.name		Oland [Radeon HD 8570 / R7 240/340 / Radeon 520 OEM]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6611
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x210b
 +subdevice.name		Radeon R5 240 OEM
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6611
+&subvendor.id		pci 0x1642
+&subdevice.id		pci 0x1869
++subdevice.name		Radeon 520 OEM
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6611
@@ -8905,6 +9537,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x6658
 +device.name		Bonaire XTX [Radeon R7 260X/360]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6658
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x048f
++subdevice.name		R7260X-DC2OC-2GD5
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6658
@@ -9136,7 +9774,7 @@
 &device.id		pci 0x6665
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x1309
-+subdevice.name		Radeon R7 M260DX
++subdevice.name		Z50-75 Radeon R7 M260DX
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6665
@@ -12652,6 +13290,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x840e
++subdevice.name		Radeon RX 580 4GB
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x04a8
 +subdevice.name		Radeon RX 480
@@ -12737,6 +13381,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
 &subvendor.id		pci 0x1462
+&subdevice.id		pci 0x341e
++subdevice.name		Radeon RX 570 Armor 4G OC
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x1462
 &subdevice.id		pci 0x8a92
 +subdevice.name		Radeon RX 580
 
@@ -12744,7 +13394,7 @@
 &device.id		pci 0x67df
 &subvendor.id		pci 0x148c
 &subdevice.id		pci 0x2372
-+subdevice.name		Radeon RX 480
++subdevice.name		Radeon RX 480 [Red Dragon]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
@@ -12808,6 +13458,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x5030
++subdevice.name		Phantom Gaming D Radeon RX580 8G OC
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
 &subvendor.id		pci 0x1da2
 &subdevice.id		pci 0xe353
 +subdevice.name		Radeon RX 570 Pulse 4GB
@@ -12816,7 +13472,7 @@
 &device.id		pci 0x67df
 &subvendor.id		pci 0x1da2
 &subdevice.id		pci 0xe366
-+subdevice.name		Nitro+ Radeon RX 570/580
++subdevice.name		Nitro+ Radeon RX 570/580/590
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67e0
@@ -12905,6 +13561,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x67ef
 +device.name		Baffin [Radeon RX 460/560D / Pro 450/455/460/555/555X/560/560X]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67ef
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1703
++subdevice.name		RX 560D OEM OC 2 GB
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67ef
@@ -12998,6 +13660,12 @@
 &device.id		pci 0x67ff
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x04bc
++subdevice.name		Radeon RX 560
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67ff
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x052f
 +subdevice.name		Radeon RX 560
 
  vendor.id		pci 0x1002
@@ -14234,7 +14902,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6864
-+device.name		Vega
++device.name		Vega 10 [Radeon Pro V340]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6867
@@ -16972,7 +17640,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6900
-+device.name		Topaz XT [Radeon R7 M260/M265 / M340/M360 / M440/M445]
++device.name		Topaz XT [Radeon R7 M260/M265 / M340/M360 / M440/M445 / 530/535 / 620/625 Mobile]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6900
@@ -17003,6 +17671,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x0767
 +subdevice.name		Radeon R7 M445
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6900
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0810
++subdevice.name		Radeon 530
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6900
@@ -17252,7 +17926,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6981
-+device.name		Polaris12
++device.name		Lexa XT [Radeon PRO WX 3200]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6985
@@ -17264,7 +17938,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6987
-+device.name		Lexa [Radeon E9171 MCM]
++device.name		Lexa [Radeon 540X/550X/630 / RX 640 / E9171 MCM]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6995
@@ -17272,7 +17946,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x699f
-+device.name		Lexa PRO [Radeon RX 550/550X]
++device.name		Lexa PRO [Radeon 540/540X/550/550X / RX 540X/550/550X]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x699f
@@ -17993,8 +18667,28 @@
 +device.name		Navi 10
 
  vendor.id		pci 0x1002
+&device.id		pci 0x7312
++device.name		Navi 10 [Radeon Pro W5700]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x731f
-+device.name		Navi 10
++device.name		Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x7340
++device.name		Navi 14 [Radeon RX 5500/5500M / Pro 5500M]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x7341
++device.name		Navi 14 [Radeon Pro W5500]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x7347
++device.name		Navi 14 [Radeon Pro W5500M]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x734f
++device.name		Navi 14 [Radeon Pro W5300M]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x7833
@@ -19089,6 +19783,12 @@
 +device.name		RS880M [Mobility Radeon HD 4225/4250]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x9712
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x9713
 +device.name		RS880M [Mobility Radeon HD 4100]
 
@@ -19161,6 +19861,12 @@
 +device.name		Kabini [Radeon HD 8330]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x9832
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x9832
++subdevice.name		QC5000-ITX/PH
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x9833
 +device.name		Kabini [Radeon HD 8330E]
 
@@ -19195,6 +19901,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x9840
 +device.name		Kabini HDMI/DP Audio
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x9840
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x9840
++subdevice.name		QC5000-ITX/PH
 
  vendor.id		pci 0x1002
 &device.id		pci 0x9850
@@ -19550,7 +20262,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x999c
-+device.name		Richland
++device.name		Richland [Radeon HD 8650D]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x999d
@@ -19705,6 +20417,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0xaac0
 +device.name		Tobago HDMI Audio [Radeon R7 360 / R9 360 OEM]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0xaac0
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0xaac0
++subdevice.name		R7260X-DC2OC-2GD5
 
  vendor.id		pci 0x1002
 &device.id		pci 0xaac8
@@ -22709,6 +23427,12 @@
 +device.name		Starship/Matisse Root Complex
 
  vendor.id		pci 0x1022
+&device.id		pci 0x1480
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7c37
++subdevice.name		X570-A PRO motherboard
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x1481
 +device.name		Starship/Matisse IOMMU
 
@@ -22735,6 +23459,12 @@
  vendor.id		pci 0x1022
 &device.id		pci 0x1487
 +device.name		Starship/Matisse HD Audio Controller
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x1487
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x9c37
++subdevice.name		X570-A PRO motherboard
 
  vendor.id		pci 0x1022
 &device.id		pci 0x1488
@@ -22821,6 +23551,12 @@
 +device.name		Matisse USB 3.0 Host Controller
 
  vendor.id		pci 0x1022
+&device.id		pci 0x149c
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7c37
++subdevice.name		X570-A PRO motherboard
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x1510
 +device.name		Family 14h Processor Root Complex
 
@@ -22877,6 +23613,12 @@
  vendor.id		pci 0x1022
 &device.id		pci 0x1536
 +device.name		Family 16h Processor Root Complex
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x1536
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x1536
++subdevice.name		QC5000-ITX/PH
 
  vendor.id		pci 0x1022
 &device.id		pci 0x1537
@@ -23151,8 +23893,20 @@
 +device.name		Raven/Raven2 Root Complex
 
  vendor.id		pci 0x1022
+&device.id		pci 0x15d0
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x15d1
 +device.name		Raven/Raven2 IOMMU
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15d1
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15d2
@@ -23191,20 +23945,68 @@
 +device.name		Family 17h (Models 10h-1fh) Platform Security Processor
 
  vendor.id		pci 0x1022
+&device.id		pci 0x15df
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x15e0
 +device.name		Raven USB 3.1
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e0
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e0
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e1
 +device.name		Raven USB 3.1
 
  vendor.id		pci 0x1022
+&device.id		pci 0x15e1
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e1
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x15e2
 +device.name		Raven/Raven2/FireFlight/Renoir Audio Processor
 
  vendor.id		pci 0x1022
+&device.id		pci 0x15e2
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x15e3
 +device.name		Family 17h (Models 10h-1fh) HD Audio Controller
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e3
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e3
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e4
@@ -23217,6 +24019,12 @@
  vendor.id		pci 0x1022
 &device.id		pci 0x15e6
 +device.name		Raven/Raven2/Renoir Non-Sensor Fusion Hub KMDF driver
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e6
+&subvendor.id		pci 0x1022
+&subdevice.id		pci 0x15e4
++subdevice.name		Raven/Raven2/Renoir Sensor Fusion Hub
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e8
@@ -23847,6 +24655,18 @@
 +device.name		400 Series Chipset USB 3.1 XHCI Controller
 
  vendor.id		pci 0x1022
+&device.id		pci 0x57a3
++device.name		Matisse PCIe GPP Bridge
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x57a4
++device.name		Matisse PCIe GPP Bridge
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x57ad
++device.name		Matisse Switch Upstream
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x7006
 +device.name		AMD-751 [Irongate] System Controller
 
@@ -24101,6 +24921,18 @@
 +subdevice.name		ProBook 455 G1 Notebook
 
  vendor.id		pci 0x1022
+&device.id		pci 0x7801
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7801
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x7801
++subdevice.name		QC5000-ITX/PH
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x7802
 +device.name		FCH SATA Controller [RAID mode]
 
@@ -24143,6 +24975,18 @@
 +subdevice.name		Pavilion 17-e163sg Notebook PC
 
  vendor.id		pci 0x1022
+&device.id		pci 0x7807
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7807
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x7807
++subdevice.name		QC5000-ITX/PH
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x7808
 +device.name		FCH USB EHCI Controller
 
@@ -24159,6 +25003,18 @@
 +subdevice.name		Pavilion 17-e163sg Notebook PC
 
  vendor.id		pci 0x1022
+&device.id		pci 0x7808
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7808
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x7808
++subdevice.name		QC5000-ITX/PH
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x7809
 +device.name		FCH USB OHCI Controller
 
@@ -24167,6 +25023,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x194e
 +subdevice.name		ProBook 455 G1 Notebook
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7809
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
 
  vendor.id		pci 0x1022
 &device.id		pci 0x780a
@@ -24187,6 +25049,18 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1985
 +subdevice.name		Pavilion 17-e163sg Notebook PC
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780b
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780b
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x780b
++subdevice.name		QC5000-ITX/PH
 
  vendor.id		pci 0x1022
 &device.id		pci 0x780c
@@ -24215,6 +25089,18 @@
 +subdevice.name		F2A85-M Series
 
  vendor.id		pci 0x1022
+&device.id		pci 0x780d
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780d
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x8892
++subdevice.name		QC5000-ITX/PH
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x780e
 +device.name		FCH LPC Bridge
 
@@ -24229,6 +25115,18 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1985
 +subdevice.name		Pavilion 17-e163sg Notebook PC
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780e
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780e
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x780e
++subdevice.name		QC5000-ITX/PH
 
  vendor.id		pci 0x1022
 &device.id		pci 0x780f
@@ -24259,12 +25157,36 @@
 +subdevice.name		Pavilion 17-e163sg Notebook PC
 
  vendor.id		pci 0x1022
+&device.id		pci 0x7814
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3988
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7814
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x7814
++subdevice.name		QC5000-ITX/PH
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x7900
 +device.name		FCH SATA Controller [IDE mode]
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7901
 +device.name		FCH SATA Controller [AHCI mode]
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7901
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7901
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7c37
++subdevice.name		X570-A PRO motherboard
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7902
@@ -24291,8 +25213,44 @@
 +device.name		FCH SMBus Controller
 
  vendor.id		pci 0x1022
+&device.id		pci 0x790b
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790b
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7c37
++subdevice.name		X570-A PRO motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790b
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x790e
 +device.name		FCH LPC Bridge
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790e
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790e
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7c37
++subdevice.name		X570-A PRO motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790e
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
 
  vendor.id		pci 0x1022
 &device.id		pci 0x790f
@@ -24330,6 +25288,18 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x9601
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x9601
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x83a2
++subdevice.name		M4A785-M Mainboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x9601
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x843e
 +subdevice.name		M5A88-V EVO
@@ -24343,6 +25313,12 @@
 +device.name		RS780 PCI to PCI bridge (ext gfx port 0)
 
  vendor.id		pci 0x1022
+&device.id		pci 0x9603
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x9604
 +device.name		RS780/RS880 PCI to PCI bridge (PCIE port 0)
 
@@ -24353,6 +25329,12 @@
  vendor.id		pci 0x1022
 &device.id		pci 0x9606
 +device.name		RS780 PCI to PCI bridge (PCIE port 2)
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x9606
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
 
  vendor.id		pci 0x1022
 &device.id		pci 0x9607
@@ -29134,6 +30116,12 @@
 &device.id		pci 0x9602
 +device.name		AMD RS780/RS880 PCI to PCI bridge (int gfx)
 
+ vendor.id		pci 0x103c
+&device.id		pci 0x9602
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1609
++subdevice.name		ProLiant MicroServer N36L
+
  vendor.id		pci 0x103e
 +vendor.name		Solliday Engineering
 
@@ -31335,6 +32323,10 @@
 +device.name		PS3 TOOL MRP
 
  vendor.id		pci 0x104d
+&device.id		pci 0x8200
++device.name		PS3 TOOL RSX Tracing FPGA
+
+ vendor.id		pci 0x104d
 &device.id		pci 0x820e
 +device.name		CXD9208GP [PS3 PS2 emulation subsystem adapter]
 
@@ -31975,6 +32967,10 @@
  vendor.id		pci 0x1057
 &device.id		pci 0x4806
 +device.name		CPX8216
+
+ vendor.id		pci 0x1057
+&device.id		pci 0x480b
++device.name		MPC7410
 
  vendor.id		pci 0x1057
 &device.id		pci 0x4d68
@@ -33335,6 +34331,10 @@
 +device.name		T2 Secure Enclave Processor
 
  vendor.id		pci 0x106b
+&device.id		pci 0x1803
++device.name		Apple Audio Device
+
+ vendor.id		pci 0x106b
 &device.id		pci 0x2001
 +device.name		S1X NVMe Controller
 
@@ -33645,6 +34645,12 @@
 +subdevice.name		Synergy 6810C 25/50Gb Ethernet Adapter
 
  vendor.id		pci 0x1077
+&device.id		pci 0x1654
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0287
++subdevice.name		Synergy 6820C 25/50Gb CNA
+
+ vendor.id		pci 0x1077
 &device.id		pci 0x1656
 +device.name		FastLinQ QL45000 Series 25GbE Controller
 
@@ -33673,6 +34679,12 @@
 +subdevice.name		FastLinQ QL45212H 25GbE Adapter
 
  vendor.id		pci 0x1077
+&device.id		pci 0x1656
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0245
++subdevice.name		10/20/25GbE 2P 4820c CNA
+
+ vendor.id		pci 0x1077
 &device.id		pci 0x165c
 +device.name		FastLinQ QL45000 Series 10/25/40/50GbE Controller (FCoE)
 
@@ -33695,6 +34707,12 @@
 +subdevice.name		FastLinQ QL45461H 40GbE FCoE Adapter
 
  vendor.id		pci 0x1077
+&device.id		pci 0x165c
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0245
++subdevice.name		10/20/25GbE 2P 4820c CNA FCoE
+
+ vendor.id		pci 0x1077
 &device.id		pci 0x165e
 +device.name		FastLinQ QL45000 Series 10/25/40/50GbE Controller (iSCSI)
 
@@ -33715,6 +34733,12 @@
 &subvendor.id		pci 0x1077
 &subdevice.id		pci 0xe4f2
 +subdevice.name		FastLinQ QL45461H 40GbE iSCSI Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x165e
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0245
++subdevice.name		10/20/25GbE 2P 4820c CNA iSCSI
 
  vendor.id		pci 0x1077
 &device.id		pci 0x1664
@@ -33761,6 +34785,12 @@
 &subvendor.id		pci 0x1077
 &subdevice.id		pci 0xe4f8
 +subdevice.name		FastLinQ QL45611H 100GbE Adapter (SR-IOV VF)
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x1664
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0245
++subdevice.name		10/20/25GbE 2P 4820c CNA SRIOV
 
  vendor.id		pci 0x1077
 &device.id		pci 0x2020
@@ -33947,6 +34977,12 @@
 +subdevice.name		StoreFabric SN1600Q 32Gb Dual Port Fibre Channel Host Bus Adapter
 
  vendor.id		pci 0x1077
+&device.id		pci 0x2261
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x022d
++subdevice.name		5830C 32Gb Dual Port Fibre Channel Adapter
+
+ vendor.id		pci 0x1077
 &device.id		pci 0x2281
 +device.name		ISP2812-based 64/32G Fibre Channel to PCIe Controller
 
@@ -33973,6 +35009,30 @@
 &subvendor.id		pci 0x1077
 &subdevice.id		pci 0x02f0
 +subdevice.name		QLE2770 Single Port 32GFC PCIe Gen4 x8 Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2281
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02f2
++subdevice.name		QLogic 1x32Gb QLE2770 FC HBA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2281
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02f3
++subdevice.name		QLogic 2x32Gb QLE2772 FC HBA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2281
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x02d3
++subdevice.name		SN1610Q - 1P Enhanced 32GFC Single Port Fibre Channel Host Bus Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2281
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x02d4
++subdevice.name		SN1610Q – 2P Enhanced 32GFC Dual Port Fibre Channel Host Bus Adapter
 
  vendor.id		pci 0x1077
 &device.id		pci 0x2300
@@ -34350,6 +35410,90 @@
 
  vendor.id		pci 0x1077
 &device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0053
++subdevice.name		QLogic 2x25GE QL41232HQCU NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0054
++subdevice.name		2x10GE QL41132HQRJ NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0055
++subdevice.name		QLogic 2x10GE QL41132HQCU NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0056
++subdevice.name		2x10GE QL41132HxRJ NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0057
++subdevice.name		2x25GE QL41232HxCU NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0065
++subdevice.name		QLogic 4x10GE QL41154HQRJ CNA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0066
++subdevice.name		QLogic 4x10GE QL41154HQCU CNA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0068
++subdevice.name		10GbE 2p SFP+ QL41132HLCU-HC Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0069
++subdevice.name		10GbE 2p BASE-T QL41132HQRJ-HC OCP3 Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0070
++subdevice.name		10GbE 2p BASE-T QL41132HLRJ-HC Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0071
++subdevice.name		10GbE 2p SFP+ QL41132HQCU-HC OCP3 Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0072
++subdevice.name		10GbE 4p SFP+ QL41134HLCU-HC Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0073
++subdevice.name		10/25GbE 2p SFP28 QL41232HQCU-HC OCP3 Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0074
++subdevice.name		10/25GbE 2p SFP28 QL41232HLCU-HC Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x021a
 +subdevice.name		10GbE 2P QL41162HLRJ-HP Adapter
@@ -34383,6 +35527,12 @@
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x0220
 +subdevice.name		10/25GbE 2P QL41122HLRJ-HP Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x02bd
++subdevice.name		10Gb 2P 524SFP+ NIC
 
  vendor.id		pci 0x1077
 &device.id		pci 0x8080
@@ -34556,6 +35706,18 @@
 
  vendor.id		pci 0x1077
 &device.id		pci 0x8084
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0065
++subdevice.name		QLogic 4x10GE QL41154HQRJ CNA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8084
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0066
++subdevice.name		QLogic 4x10GE QL41154HQCU CNA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8084
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x021a
 +subdevice.name		10GbE 2P QL41162HLRJ-HP Adapter
@@ -34668,6 +35830,48 @@
 
  vendor.id		pci 0x1077
 &device.id		pci 0x8090
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0053
++subdevice.name		QLogic 2x25GE QL41232HQCU NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0054
++subdevice.name		QLogic 2x10GE QL41132HQRJ NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0055
++subdevice.name		QLogic 2x10GE QL41132HQCU NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0056
++subdevice.name		2x10GE QL41132HxRJ NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0057
++subdevice.name		2x25GE QL41232HxCU NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0065
++subdevice.name		QLogic 4x10GE QL41154HQRJ CNA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0066
++subdevice.name		QLogic 4x10GE QL41154HQCU CNA
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x021a
 +subdevice.name		10GbE 2P QL41162HLRJ-HP Adapter
@@ -34689,6 +35893,12 @@
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x021f
 +subdevice.name		10/25GbE 2P QL41262HMCU-HP Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8090
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x02bd
++subdevice.name		10Gb 2P 524SFP+ NIC
 
  vendor.id		pci 0x1077
 &device.id		pci 0x8430
@@ -38589,8 +39799,74 @@
  vendor.id		pci 0x1093
 &device.id		pci 0xc4c4
 &subvendor.id		pci 0x1093
+&subdevice.id		pci 0x786f
++subdevice.name		PXIe-4163
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
 &subdevice.id		pci 0x788e
 +subdevice.name		PXIe-4304
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x78f8
++subdevice.name		NI FlexRIO Module (KU035)
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x78f9
++subdevice.name		NI FlexRIO Module (KU040)
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x78fa
++subdevice.name		NI FlexRIO Module (KU060)
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x78ff
++subdevice.name		PXIe-4162
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x7995
++subdevice.name		PXIe-7911R
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x7996
++subdevice.name		PXIe-7912R
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x7997
++subdevice.name		PXIe-7915R
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x79d3
++subdevice.name		NI FlexRIO PCIe Module (KU035)
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x79d4
++subdevice.name		NI FlexRIO PCIe Module (KU040)
+
+ vendor.id		pci 0x1093
+&device.id		pci 0xc4c4
+&subvendor.id		pci 0x1093
+&subdevice.id		pci 0x79d5
++subdevice.name		NI FlexRIO PCIe Module (KU060)
 
  vendor.id		pci 0x1093
 &device.id		pci 0xc801
@@ -41081,6 +42357,12 @@
  vendor.id		pci 0x10b5
 &device.id		pci 0x9056
 &subvendor.id		pci 0x10b5
+&subdevice.id		pci 0x3334
++subdevice.name		Cambridge Pixel HPx Radar Input Card
+
+ vendor.id		pci 0x10b5
+&device.id		pci 0x9056
+&subvendor.id		pci 0x10b5
 &subdevice.id		pci 0x3352
 +subdevice.name		Alpermann+Velte PCL PCIe HD: Timecode Reader Board
 
@@ -41113,6 +42395,12 @@
 &subvendor.id		pci 0x10b5
 &subdevice.id		pci 0x3493
 +subdevice.name		Alpermann+Velte PCL PCIe 3G: Timecode Reader Board
+
+ vendor.id		pci 0x10b5
+&device.id		pci 0x9056
+&subvendor.id		pci 0x10b5
+&subdevice.id		pci 0x3565
++subdevice.name		Cambridge Pixel HPx Radar Output Card
 
  vendor.id		pci 0x10b5
 &device.id		pci 0x9056
@@ -46176,7 +47464,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x01a0
-+device.name		nForce 220/420 NV11 [GeForce2 MX]
++device.name		nForce 220/420 NV1A [GeForce2 MX]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x01a4
@@ -46418,7 +47706,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x01f0
-+device.name		C17 [GeForce4 MX IGP]
++device.name		NV1F C17 [GeForce4 MX IGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x01f0
@@ -52802,7 +54090,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0e1a
-+device.name		GK110 HDMI Audio
++device.name		GK110 High Definition Audio Controller
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0e1b
@@ -52903,6 +54191,10 @@
 +device.name		GM204 High Definition Audio Controller
 
  vendor.id		pci 0x10de
+&device.id		pci 0x0fbc
++device.name		GM107 High Definition Audio Controller [GeForce 940MX]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x0fc0
 +device.name		GK107 [GeForce GT 640 OEM]
 
@@ -52916,7 +54208,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0fc5
-+device.name		GK107
++device.name		GK107 [GeForce GT 1030]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0fc6
@@ -53300,7 +54592,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1024
-+device.name		GK110BGL [Tesla K40c]
++device.name		GK180GL [Tesla K40c]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1026
@@ -53699,6 +54991,10 @@
  vendor.id		pci 0x10de
 &device.id		pci 0x10f7
 +device.name		TU102 High Definition Audio Controller
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x10f8
++device.name		TU104 HD Audio Controller
 
  vendor.id		pci 0x10de
 &device.id		pci 0x10f9
@@ -55930,7 +57226,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x11b0
-+device.name		GK104GL [GRID K240Q\K260Q vGPU]
++device.name		GK104GL [GRID K240Q / K260Q vGPU]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x11b0
@@ -56931,6 +58227,12 @@
 +device.name		GM206M [GeForce GTX 965M]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1427
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1430
 +device.name		GM206GL [Quadro M2000]
 
@@ -57011,6 +58313,12 @@
 +device.name		GM107 [GeForce 940MX]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x179c
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x1094
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x17c2
 +device.name		GM200 [GeForce GTX TITAN X]
 
@@ -57023,6 +58331,12 @@
 +device.name		GM200GL [Quadro M6000]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x17f0
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x1141
++subdevice.name		VCA 6000
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x17f1
 +device.name		GM200GL [Quadro M6000 24GB]
 
@@ -57032,11 +58346,19 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1ad6
-+device.name		TU102 USB 3.1 Controller
++device.name		TU102 USB 3.1 Host Controller
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1ad7
-+device.name		TU102 UCSI Controller
++device.name		TU102 USB Type-C UCSI Controller
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ad8
++device.name		TU104 USB 3.1 Host Controller
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ad9
++device.name		TU104 USB Type-C UCSI Controller
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1ada
@@ -57050,13 +58372,25 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1adb
-+device.name		TU106 USB Type-C Port Policy Controller
++device.name		TU106 USB Type-C UCSI Controller
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1adb
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8673
 +subdevice.name		TURBO-RTX2070-8G
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1aeb
++device.name		TU116 High Definition Audio Controller
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1aec
++device.name		TU116 USB 3.1 Host Controller
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1aed
++device.name		TU116 USB Type-C UCSI Controller
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1b00
@@ -57327,6 +58661,10 @@
 +device.name		GP106GL [Quadro P2000]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1c31
++device.name		GP106GL [Quadro P2200]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1c35
 +device.name		GP106
 
@@ -57361,6 +58699,18 @@
 +device.name		GP107 [GeForce GTX 1050 Ti]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1c82
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8613
++subdevice.name		PH-GTX1050TI-4G
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1c82
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x3763
++subdevice.name		GV-N105TOC-4GD
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1c83
 +device.name		GP107 [GeForce GTX 1050 3GB]
 
@@ -57381,8 +58731,24 @@
 +device.name		GP107M [GeForce GTX 1050 Ti Max-Q]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1c90
++device.name		GP107M [GeForce MX150]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1c91
++device.name		GP107M [GeForce GTX 1050 3 GB Max-Q]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1c92
 +device.name		GP107M [GeForce GTX 1050 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1c94
++device.name		GP107M [GeForce MX350]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1c96
++device.name		GP107M [GeForce MX350]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1ca7
@@ -57461,12 +58827,24 @@
 +device.name		GP107GLM [Quadro P600 Mobile]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1cbd
++device.name		GP107GLM [Quadro P620]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1ccc
 +device.name		GP107BM [GeForce GTX 1050 Ti Mobile]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1ccd
 +device.name		GP107BM [GeForce GTX 1050 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1cfa
++device.name		GP107GL [Quadro P2000]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1cfb
++device.name		GP107GL [Quadro P1000]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1d01
@@ -57501,8 +58879,16 @@
 +device.name		GP108M [GeForce MX250]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1d16
++device.name		GP108M [GeForce MX330]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1d33
 +device.name		GP108GLM [Quadro P500 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1d34
++device.name		GP108GLM [Quadro P520]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1d52
@@ -57518,7 +58904,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1db2
-+device.name		GV100GL [Tesla V100-DGXS-16GB]
++device.name		GV100GL [Tesla V100 DGXS 16GB]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1db3
@@ -57541,6 +58927,16 @@
 +device.name		GV100GL [Tesla V100 DGXS 32GB]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1db8
++device.name		GV100GL [Tesla V100 SXM3 32GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1db8
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x131d
++subdevice.name		Tesla V100-SXM3-32GB-H
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1dba
 +device.name		GV100GL [Quadro GV100]
 
@@ -57549,6 +58945,22 @@
 &subvendor.id		pci 0x10de
 &subdevice.id		pci 0x12eb
 +subdevice.name		TITAN V CEO Edition
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1df0
++device.name		GV100GL [Tesla PG500-216]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1df2
++device.name		GV100GL [Tesla PG503-216]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1df5
++device.name		GV100GL [Tesla V100 SXM2 16GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1df6
++device.name		GV100GL [Tesla V100S PCIe 32GB]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1e02
@@ -57593,6 +59005,32 @@
 +subdevice.name		Quadro RTX 6000
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1e36
++device.name		TU102GL
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e37
++device.name		TU102GL [GRID RTX T10-4/T10-8/T10-16]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e37
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x1347
++subdevice.name		GRID RTX T10-8
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e37
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x1348
++subdevice.name		GRID RTX T10-4
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e37
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x1370
++subdevice.name		GRID RTX T10-16
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1e38
 +device.name		TU102GL
 
@@ -57609,16 +59047,52 @@
 +device.name		TU102GL
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1e78
++device.name		TU102GL [Quadro RTX 6000/8000]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e78
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x13d8
++subdevice.name		Quadro RTX 8000
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e78
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x13d9
++subdevice.name		Quadro RTX 6000
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e81
++device.name		TU104 [GeForce RTX 2080 SUPER]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1e82
 +device.name		TU104 [GeForce RTX 2080]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e84
++device.name		TU104 [GeForce RTX 2070 SUPER]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1e87
 +device.name		TU104 [GeForce RTX 2080 Rev. A]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1e89
++device.name		TU104 [GeForce RTX 2060]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1e90
 +device.name		TU104M [GeForce RTX 2080 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e91
++device.name		TU104M [GeForce RTX 2070 SUPER Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1e93
++device.name		TU104M [GeForce RTX 2080 SUPER Mobile / Max-Q]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1eab
@@ -57637,12 +59111,44 @@
 +device.name		TU104GL [Quadro RTX 4000]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1eb5
++device.name		TU104GLM [Quadro RTX 5000 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1eb6
++device.name		TU104GLM [Quadro RTX 4000 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1eb8
 +device.name		TU104GL [Tesla T4]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1eb9
++device.name		TU104GL
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ebe
++device.name		TU104GL
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ec2
++device.name		TU104 [GeForce RTX 2070 SUPER]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ec7
++device.name		TU104 [GeForce RTX 2070 SUPER]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1ed0
-+device.name		TU104M [GeForce RTX 2080 Mobile]
++device.name		TU104BM [GeForce RTX 2080 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ed1
++device.name		TU104BM [GeForce RTX 2070 SUPER Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ed3
++device.name		TU104BM [GeForce RTX 2080 SUPER Mobile / Max-Q]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f02
@@ -57659,12 +59165,20 @@
 +device.name		TU106
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1f06
++device.name		TU106 [GeForce RTX 2060 SUPER]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1f07
 +device.name		TU106 [GeForce RTX 2070 Rev. A]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f08
 +device.name		TU106 [GeForce RTX 2060 Rev. A]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f09
++device.name		TU106 [GeForce GTX 1660 SUPER]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f10
@@ -57675,28 +59189,84 @@
 +device.name		TU106M [GeForce RTX 2060 Mobile]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1f12
++device.name		TU106M [GeForce RTX 2060 Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f15
++device.name		TU106M [GeForce RTX 2060 Mobile]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1f2e
 +device.name		TU106M
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1f36
++device.name		TU106GLM [Quadro RTX 3000 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f42
++device.name		TU106 [GeForce RTX 2060 SUPER]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f47
++device.name		TU106 [GeForce RTX 2060 SUPER]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1f50
-+device.name		TU106M [GeForce RTX 2070 Mobile]
++device.name		TU106BM [GeForce RTX 2070 Mobile / Max-Q]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f51
-+device.name		TU106M [GeForce RTX 2060 Mobile]
++device.name		TU106BM [GeForce RTX 2060 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f81
++device.name		TU117
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f82
-+device.name		TU107
++device.name		TU117 [GeForce GTX 1650]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f91
++device.name		TU117M [GeForce GTX 1650 Mobile / Max-Q]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f92
-+device.name		TU107M [GeForce GTX 1650 Mobile]
++device.name		TU117M [GeForce GTX 1650 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f94
++device.name		TU117M
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f95
++device.name		TU117M [GeForce GTX 1650 Ti Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f96
++device.name		TU117M [GeForce GTX 1650 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f99
++device.name		TU117M
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fae
++device.name		TU117GL
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fb8
++device.name		TU117GLM [Quadro T2000 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fb9
++device.name		TU117GLM [Quadro T1000 Mobile]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1fbf
-+device.name		TU107GL
++device.name		TU117GL
 
  vendor.id		pci 0x10de
 &device.id		pci 0x2182
@@ -57711,8 +59281,16 @@
 +device.name		TU116 [GeForce GTX 1660]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x2187
++device.name		TU116 [GeForce GTX 1650 SUPER]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x2191
-+device.name		TU116M [GeForce GTX 1660 Mobile]
++device.name		TU116M [GeForce GTX 1660 Ti Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2192
++device.name		TU116M [GeForce GTX 1650 Ti Mobile]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x21ae
@@ -57723,8 +59301,12 @@
 +device.name		TU116GL
 
  vendor.id		pci 0x10de
+&device.id		pci 0x21c4
++device.name		TU116 [GeForce GTX 1660 SUPER]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x21d1
-+device.name		TU116M [GeForce GTX 1660 Mobile]
++device.name		TU116BM [GeForce GTX 1660 Ti Mobile]
 
  vendor.id		pci 0x10df
 +vendor.name		Emulex Corporation
@@ -57839,13 +59421,37 @@
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe200
-+device.name		LightPulse LPe16002
++device.name		LPe15000/LPe16000 Series 8Gb/16Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe200
 &subvendor.id		pci 0x1014
 &subdevice.id		pci 0x03f1
-+subdevice.name		PCIe2 16 Gb 2-port Fibre Channel Adapter (FC EL5B; CCIN 577F)
++subdevice.name		PCIe2 2-Port 16Gb Fibre Channel Adapter for POWER (FC EL5B; CCIN 577F)
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe200
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x04e3
++subdevice.name		PCIe3 4-Port 10GbE SR Adapter for POWER (FC EN15/EN16; CCIN 2CE3)
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe200
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x04e4
++subdevice.name		PCIe3 4-Port 10GbE SFP+ Adapter for POWER (FC EN18; CCIN 2CE4)
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe200
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe280
++subdevice.name		LPe16002B-M6 2-Port 16Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe200
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe281
++subdevice.name		LPe16000B-M6 1-Port 16Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe200
@@ -57887,47 +59493,139 @@
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe300
-+device.name		Lancer Gen6: LPe32000 Fibre Channel Host Adapter
++device.name		LPe31000/LPe32000 Series 16Gb/32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0614
++subdevice.name		PCIe3 4-Port 16Gb Fibre Channel Adapter for POWER (FC EN1C/EN1D; CCIN 578E)
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0615
++subdevice.name		PCIe3 2-Port 32Gb Fibre Channel Adapter for POWER (FC EN1A/EN1B; CCIN 578F)
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe300
++subdevice.name		LPe32002-M2 2-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe301
++subdevice.name		LPe32000-M2 1-Port 32Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe300
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xe310
-+subdevice.name		Lancer Gen6: LPe31000 Fibre Channel Host Adapter
++subdevice.name		LPe31002-M6 2-Port 16Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe300
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xe311
-+subdevice.name		Lancer Gen6: LPe31000 Fibre Channel Host Adapter
++subdevice.name		LPe31000-M6 1-Port 16Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe300
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xe312
-+subdevice.name		Lancer Gen6: LPe31000 Fibre Channel Host Adapter
++subdevice.name		LPe31004-M6 4-Port 16Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe320
++subdevice.name		LPe32002-M2-D 2-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe321
++subdevice.name		LPe32000-M2-D 1-Port 32Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe300
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xe322
-+subdevice.name		Lancer Gen6: LPe31000 Fibre Channel Host Adapter
++subdevice.name		LPe31002-M6-D 2-Port 16Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe300
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xe323
-+subdevice.name		Lancer Gen6: LPe31000 Fibre Channel Host Adapter
++subdevice.name		LPe31000-M6-D 1-Port 16Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe324
++subdevice.name		LPm32002-D 2-Port 32Gb Fibre Channel Mezz Card
 
  vendor.id		pci 0x10df
 &device.id		pci 0xe300
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xe325
-+subdevice.name		Lancer Gen6: LPe31000 Fibre Channel Host Adapter
++subdevice.name		LPm31002-D 2-Port 16Gb Fibre Channel Mezz Card
 
  vendor.id		pci 0x10df
-&device.id		pci 0xe333
-+device.name		Lancer Gen6: LPe32000 Fibre Channel Host Adapter
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe330
++subdevice.name		LPe32002-M2-L 2-Port 32Gb PCIe Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe331
++subdevice.name		LPe32000-M2-L 1-Port 32Gb PCIe Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe332
++subdevice.name		LPe31002-M6-L 2-Port 16Gb PCIe Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xe333
++subdevice.name		LPe31000-M6-L 1-Port 16Gb PCIe Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0201
++subdevice.name		StoreFabric SN1600E 1-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0202
++subdevice.name		StoreFabric SN1600E 2-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0213
++subdevice.name		StoreFabric SN1200E 1-Port 16Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0214
++subdevice.name		StoreFabric SN1200E 2-Port 16Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x022e
++subdevice.name		Synergy 5330C 2-Port 32Gb Fibre Channel Mezz Card
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf011
@@ -57983,7 +59681,7 @@
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf100
-+device.name		Saturn-X: LightPulse Fibre Channel Host Adapter
++device.name		LPe12000 Series 8Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf100
@@ -57996,6 +59694,18 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x3282
 +subdevice.name		8Gb Dual-port PCI-e FC HBA
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf100
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf140
++subdevice.name		LPe12000-M8-L 1-Port 8Gb PCIe Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf100
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf141
++subdevice.name		LPe12002-M8-L 2-Port 8Gb PCIe Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf111
@@ -58011,25 +59721,79 @@
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf400
-+device.name		LPe36000 Fibre Channel Host Adapter [Prism]
++device.name		LPe35000/LPe36000 Series 32Gb/64Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf400
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xf401
-+subdevice.name		LPe35000 Fibre Channel Host Adapter [Prism]
++subdevice.name		LPe35000-M2 1-Port 32Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf400
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xf402
-+subdevice.name		LPe35000 Fibre Channel Host Adapter [Prism]
++subdevice.name		LPe35002-M2 2-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf403
++subdevice.name		LPe36000-M64 1-Port 64Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf404
++subdevice.name		LPe36002-M64 2-Port 64Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf405
++subdevice.name		LPe35004-M2 4-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf406
++subdevice.name		LPe35004-X6 4-Port Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf400
 &subvendor.id		pci 0x10df
 &subdevice.id		pci 0xf410
 +subdevice.name		LPe35002-M2-D 2-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf411
++subdevice.name		LPe35000-M2-D 1-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf418
++subdevice.name		LPe35000-M2-L 1-Port 32Gb PCIe Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x10df
+&subdevice.id		pci 0xf419
++subdevice.name		LPe35002-M2-L 2-Port 32Gb PCIe Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x02d5
++subdevice.name		StoreFabric SN1610E 1-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf400
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x02d6
++subdevice.name		StoreFabric SN1610E 2-Port 32Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf700
@@ -58509,6 +60273,18 @@
 +subdevice.name		EliteBook 840 G3
 
  vendor.id		pci 0x10ec
+&device.id		pci 0x522a
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x522a
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x10ec
 &device.id		pci 0x5249
 +device.name		RTS5249 PCI Express Card Reader
 
@@ -58533,6 +60309,12 @@
  vendor.id		pci 0x10ec
 &device.id		pci 0x525a
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x525a
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06dc
 +subdevice.name		Latitude E7470
 
@@ -58549,12 +60331,22 @@
 +subdevice.name		ThinkPad X1 Carbon 5th Gen
 
  vendor.id		pci 0x10ec
+&device.id		pci 0x5260
++device.name		RTS5260 PCI Express Card Reader
+
+ vendor.id		pci 0x10ec
 &device.id		pci 0x5286
 +device.name		RTS5286 PCI Express Card Reader
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x5287
 +device.name		RTL8411B PCI Express Card Reader
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x5287
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x1094
++subdevice.name		Acer Aspire E5-575G
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x5288
@@ -58609,6 +60401,10 @@
 &subvendor.id		pci 0x1af4
 &subdevice.id		pci 0x1100
 +subdevice.name		QEMU Virtual Machine
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8125
++device.name		RTL8125 2.5GbE Controller
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8129
@@ -58730,7 +60526,7 @@
 &device.id		pci 0x8139
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x1045
-+subdevice.name		L8400B or L3C/S notebook
++subdevice.name		L8400B, L3C/S, X58LE notebook
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8139
@@ -59024,6 +60820,12 @@
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x1094
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x0283
 +subdevice.name		Vostro 220
@@ -59043,8 +60845,20 @@
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06f2
++subdevice.name		Latitude 3470
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06f3
 +subdevice.name		Latitude 3570
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
@@ -59063,6 +60877,24 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x2a6f
 +subdevice.name		Asus IPIBL-LB Motherboard
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x8615
++subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x11f5
++subdevice.name		Notebook motherboard (one of many models)
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
@@ -59156,9 +60988,33 @@
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7c37
++subdevice.name		X570-A PRO motherboard
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
 &subvendor.id		pci 0x1775
 &subdevice.id		pci 0x11cc
 +subdevice.name		CC11/CL11
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3814
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3823
++subdevice.name		Lenovo V130-15IGM Laptop - Type 81HL
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
@@ -59413,12 +61269,40 @@
 +subdevice.name		Dell Wireless 1801
 
  vendor.id		pci 0x10ec
+&device.id		pci 0xb723
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0xb736
++subdevice.name		Z50-75
+
+ vendor.id		pci 0x10ec
 &device.id		pci 0xb822
 +device.name		RTL8822BE 802.11a/b/g/n/ac WiFi adapter
 
  vendor.id		pci 0x10ec
+&device.id		pci 0xb822
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x831b
++subdevice.name		Realtek RTL8822BE 802.11ac 2 × 2 Wi-Fi + Bluetooth 4.2 Combo Adapter (MU-MIMO supported)
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0xb822
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x5124
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0xb822
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0xb023
++subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x10ec
 &device.id		pci 0xc821
 +device.name		RTL8821CE 802.11ac PCIe Wireless Network Adapter
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0xc822
++device.name		RTL8822CE 802.11ac PCIe Wireless Network Adapter
 
  vendor.id		pci 0x10ec
 &device.id		pci 0xd723
@@ -59889,6 +61773,24 @@
 +device.name		SB AWE64(D)
 
  vendor.id		pci 0x1102
+&device.id		pci 0x0003
+&subvendor.id		pci 0x1102
+&subdevice.id		pci 0x0010
++subdevice.name		CT4600 AWE64D
+
+ vendor.id		pci 0x1102
+&device.id		pci 0x0003
+&subvendor.id		pci 0x1102
+&subdevice.id		pci 0x0030
++subdevice.name		CT4650 AWE64D
+
+ vendor.id		pci 0x1102
+&device.id		pci 0x0003
+&subvendor.id		pci 0x1102
+&subdevice.id		pci 0x0031
++subdevice.name		CT4655 AWE64D
+
+ vendor.id		pci 0x1102
 &device.id		pci 0x0004
 +device.name		EMU10k2/CA0100/CA0102/CA10200 [Sound Blaster Audigy Series]
 
@@ -60126,7 +62028,25 @@
 
  vendor.id		pci 0x1102
 &device.id		pci 0x0006
-+device.name		EMU10k1X [SB Live! Value/OEM Series]
++device.name		EMU10k1X / CA0103 [SB Live! OEM / SB 5.1 / Ectiva 5.1]
+
+ vendor.id		pci 0x1102
+&device.id		pci 0x0006
+&subvendor.id		pci 0x1102
+&subdevice.id		pci 0x1001
++subdevice.name		SB0680 Sound Blaster 5.1
+
+ vendor.id		pci 0x1102
+&device.id		pci 0x0006
+&subvendor.id		pci 0x1102
+&subdevice.id		pci 0x1003
++subdevice.name		SB0203 SB Live! 5.1 (Dell)
+
+ vendor.id		pci 0x1102
+&device.id		pci 0x0006
+&subvendor.id		pci 0x1102
+&subdevice.id		pci 0x1004
++subdevice.name		TP0033 Ectiva Audio 5.1
 
  vendor.id		pci 0x1102
 &device.id		pci 0x0007
@@ -67357,7 +69277,7 @@
 
  vendor.id		pci 0x1148
 &device.id		pci 0x4320
-+device.name		SK-9871 V2.0 Gigabit Ethernet 1000Base-ZX Adapter, PCI64, Fiber ZX/SC
++device.name		SK-98xx V2.0 Gigabit Ethernet Adapter [Marvell 88E8001]
 
  vendor.id		pci 0x1148
 &device.id		pci 0x4320
@@ -67468,6 +69388,12 @@
 +subdevice.name		SK-9521 10/100/1000Base-T Adapter
 
  vendor.id		pci 0x1148
+&device.id		pci 0x4320
+&subvendor.id		pci 0x1259
+&subdevice.id		pci 0x2916
++subdevice.name		AT-2916T
+
+ vendor.id		pci 0x1148
 &device.id		pci 0x4400
 +device.name		SK-9Dxx Gigabit Ethernet Adapter
 
@@ -67477,7 +69403,85 @@
 
  vendor.id		pci 0x1148
 &device.id		pci 0x9000
-+device.name		SK-9S21 10/100/1000Base-T Server Adapter, PCI-X, Copper RJ-45
++device.name		SK-9Sxx Gigabit Ethernet Server Adapter PCI-X [Marvell 88E8022]
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x2100
++subdevice.name		SK-9S21 10/100/1000Base-T Server Adapter, PCI-X, Copper RJ-45
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x2200
++subdevice.name		SK-9S22 10/100/1000Base-T Dual Port Server Adapter, PCI-X, 2 Copper RJ-45
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x2210
++subdevice.name		SK-9P22 10/100/1000 Base-T Dual Port PMC card
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x2220
++subdevice.name		TPMC-GBE-CO
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x8100
++subdevice.name		SK-9S81 1000Base-SX Server Adapter,PCI-X, Fiber SX/LC
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x8200
++subdevice.name		SK-9S82 1000Base-SX Dual Port Server Adapter, PCI-X, 2 Fiber SX/LC
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x8210
++subdevice.name		SK-9P82 1000 Base-SX Dual Port PMC card
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x8220
++subdevice.name		TPMC-GBE-FI
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x9100
++subdevice.name		SK-9S91 1000Base-LX Server Adapter,PCI-X, Fiber LX/LC
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1148
+&subdevice.id		pci 0x9200
++subdevice.name		SK-9S92 1000Base-LX Dual Port Server Adapter, PCI-X, 2 Fiber LX/LC
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1259
+&subdevice.id		pci 0x2973
++subdevice.name		AT-2971SX v2 Gigabit Adapter
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1259
+&subdevice.id		pci 0x2974
++subdevice.name		AT-2971T v2 Gigabit Adapter
+
+ vendor.id		pci 0x1148
+&device.id		pci 0x9000
+&subvendor.id		pci 0x1259
+&subdevice.id		pci 0x2978
++subdevice.name		AT-2971LX Gigabit Adapter
 
  vendor.id		pci 0x1148
 &device.id		pci 0x9843
@@ -68612,7 +70616,7 @@
 +device.name		Fast Ethernet Adapter
 
  vendor.id		pci 0x1179
-+vendor.name		Toshiba America Info Systems
++vendor.name		Toshiba Corporation
 
  vendor.id		pci 0x1179
 &device.id		pci 0x0102
@@ -68656,6 +70660,18 @@
 
  vendor.id		pci 0x1179
 &device.id		pci 0x0110
+&subvendor.id		pci 0x1179
+&subdevice.id		pci 0x0001
++subdevice.name		KIOXIA CM5-R series SSD
+
+ vendor.id		pci 0x1179
+&device.id		pci 0x0110
+&subvendor.id		pci 0x1179
+&subdevice.id		pci 0x0021
++subdevice.name		KIOXIA CD5 series SSD
+
+ vendor.id		pci 0x1179
+&device.id		pci 0x0110
 &subvendor.id		pci 0x1d49
 &subdevice.id		pci 0x4039
 +subdevice.name		Thinksystem U.2 CM5 NVMe SSD
@@ -68665,6 +70681,10 @@
 &subvendor.id		pci 0x1d49
 &subdevice.id		pci 0x403a
 +subdevice.name		Thinksystem AIC CM5 NVMe SSD
+
+ vendor.id		pci 0x1179
+&device.id		pci 0x0113
++device.name		BG3 NVMe SSD Controller
 
  vendor.id		pci 0x1179
 &device.id		pci 0x0115
@@ -69118,6 +71138,12 @@
  vendor.id		pci 0x1180
 &device.id		pci 0x0476
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x1180
+&device.id		pci 0x0476
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x1237
 +subdevice.name		A6J-Q008
 
@@ -69362,6 +71388,12 @@
  vendor.id		pci 0x1180
 &device.id		pci 0x0592
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x1180
+&device.id		pci 0x0592
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x1237
 +subdevice.name		A6J-Q008
 
@@ -69370,6 +71402,12 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x1967
 +subdevice.name		V6800V
+
+ vendor.id		pci 0x1180
+&device.id		pci 0x0592
+&subvendor.id		pci 0x104d
+&subdevice.id		pci 0x9035
++subdevice.name		VAIO VGN-FW11ZRU
 
  vendor.id		pci 0x1180
 &device.id		pci 0x0592
@@ -69468,6 +71506,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30cf
 +subdevice.name		Pavilion dv9668eg Laptop
+
+ vendor.id		pci 0x1180
+&device.id		pci 0x0822
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
 
  vendor.id		pci 0x1180
 &device.id		pci 0x0822
@@ -69648,6 +71692,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30cf
 +subdevice.name		Pavilion dv9500/9600/9700 series
+
+ vendor.id		pci 0x1180
+&device.id		pci 0x0843
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
 
  vendor.id		pci 0x1180
 &device.id		pci 0x0843
@@ -71262,6 +73312,18 @@
 +device.name		Yukon Optima 88E8059 [PCIe Gigabit Ethernet Controller with AVB]
 
  vendor.id		pci 0x11ab
+&device.id		pci 0x4381
+&subvendor.id		pci 0x1259
+&subdevice.id		pci 0x2803
++subdevice.name		AT-2814FX
+
+ vendor.id		pci 0x11ab
+&device.id		pci 0x4381
+&subvendor.id		pci 0x1259
+&subdevice.id		pci 0x2804
++subdevice.name		AT-2874xx
+
+ vendor.id		pci 0x11ab
 &device.id		pci 0x4611
 +device.name		GT-64115 System Controller
 
@@ -72259,9 +74321,21 @@
 
  vendor.id		pci 0x11c1
 &device.id		pci 0x5811
+&subvendor.id		pci 0x11bd
+&subdevice.id		pci 0x000e
++subdevice.name		LSI FW323
+
+ vendor.id		pci 0x11c1
+&device.id		pci 0x5811
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x524c
 +subdevice.name		D865PERL mainboard
+
+ vendor.id		pci 0x11c1
+&device.id		pci 0x5811
+&subvendor.id		pci 0x9005
+&subdevice.id		pci 0x0033
++subdevice.name		Adaptec AFW-2100 (HP) 2102900-R
 
  vendor.id		pci 0x11c1
 &device.id		pci 0x5811
@@ -72866,7 +74940,7 @@
 +vendor.name		High Street Consultants
 
  vendor.id		pci 0x11fe
-+vendor.name		Comtrol Corporation
++vendor.name		Pepperl+Fuchs Comtrol, Inc.
 
  vendor.id		pci 0x11fe
 &device.id		pci 0x0001
@@ -73918,7 +75992,7 @@
 +vendor.name		Power I/O, Inc.
 
  vendor.id		pci 0x1227
-+vendor.name		Tech-Source
++vendor.name		EIZO Rugged Solutions
 
  vendor.id		pci 0x1227
 &device.id		pci 0x0006
@@ -76576,7 +78650,7 @@
 +vendor.name		Natural Microsystems
 
  vendor.id		pci 0x12b7
-+vendor.name		Cognex Modular Vision Systems Div. - Acumen Inc.
++vendor.name		Cognex Corporation
 
  vendor.id		pci 0x12b8
 +vendor.name		Korg
@@ -77136,8 +79210,20 @@
 +device.name		7C21P100 2-port PCI-X to PCI-X Bridge
 
  vendor.id		pci 0x12d8
+&device.id		pci 0x0303
++device.name		PCI Express Switch 3-3
+
+ vendor.id		pci 0x12d8
+&device.id		pci 0x0508
++device.name		PI7C9X20508GP PCI Express Switch 5Port-8Lane
+
+ vendor.id		pci 0x12d8
 &device.id		pci 0x2304
 +device.name		PI7C9X2G304 EL/SL PCIe2 3-Port/4-Lane Packet Switch
+
+ vendor.id		pci 0x12d8
+&device.id		pci 0x2404
++device.name		PI7C9X2G404 EL/SL PCIe2 4-Port/4-Lane Packet Switch
 
  vendor.id		pci 0x12d8
 &device.id		pci 0x2608
@@ -84571,7 +86657,7 @@
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa808
-+device.name		NVMe SSD Controller SM981/PM981
++device.name		NVMe SSD Controller SM981/PM981/PM983
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa808
@@ -84800,6 +86886,70 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1ffa
 +subdevice.name		Express Flash PM1725b 12.8TB AIC
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
++device.name		NVMe SSD Controller PM173X
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2040
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 1.6TB / AGN MU U.2 Gen4 1.6TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2041
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 3.2TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2042
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 6.4TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2043
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 12.8TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2044
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 1.6TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2045
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 3.2TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2046
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 6.4TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2070
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 1.92TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2071
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 3.84TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2072
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 7.68TB
 
  vendor.id		pci 0x144e
 +vendor.name		OLITEC
@@ -86698,6 +88848,54 @@
 +subdevice.name		PowerEdge R320 server
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x08fd
++subdevice.name		PowerEdge R6515/R7515 LOM
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x08ff
++subdevice.name		PowerEdge Rx5xx LOM Board
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0900
++subdevice.name		PowerEdge C6525 LOM
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1786
++subdevice.name		NC332T Adapter
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x193d
++subdevice.name		NC332i Adapter
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x2133
++subdevice.name		NC332i Adapter
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x22e8
++subdevice.name		NC332i Adapter
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x22eb
++subdevice.name		NC332i Adapter
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x1662
 +device.name		NetXtreme II BCM57712 10 Gigabit Ethernet
 
@@ -86790,6 +88988,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x0187
 +subdevice.name		Precision M70
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1677
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x01a3
++subdevice.name		Latitude X1
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x1677
@@ -87848,6 +90052,24 @@
 +device.name		BCM57412 NetXtreme-E 10Gb RDMA Ethernet Controller
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x16d6
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x4120
++subdevice.name		NetXtreme E-Series Advanced Dual-port 10Gb SFP+ Ethernet Network Daughter Card
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16d6
+&subvendor.id		pci 0x152d
+&subdevice.id		pci 0x8b20
++subdevice.name		BCM57412 NetXtreme-E 10Gb RDMA Ethernet Controller
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16d6
+&subvendor.id		pci 0x152d
+&subdevice.id		pci 0x8b22
++subdevice.name		BCM57412 NetXtreme-E 25Gb RDMA Ethernet Controller
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x16d7
 +device.name		BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller
 
@@ -87868,6 +90090,12 @@
 &subvendor.id		pci 0x14e4
 &subdevice.id		pci 0x1404
 +subdevice.name		BCM957414M4142C OCP 2x25G Type1 wRoCE
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16d7
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x4140
++subdevice.name		NetXtreme E-Series Advanced Dual-port 25Gb SFP28 Network Daughter Card
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x16d7
@@ -88126,6 +90354,26 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3a23
 +subdevice.name		IdeaPad S10e
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1750
++device.name		BCM57508 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1751
++device.name		BCM57504 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1752
++device.name		BCM57502 NetXtreme-E 10Gb/25Gb/40Gb/50Gb Ethernet
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1806
++device.name		BCM5750X NetXtreme-E Ethernet Virtual Function
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1807
++device.name		BCM5750X NetXtreme-E RDMA Virtual Function
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x3352
@@ -89124,6 +91372,10 @@
 +device.name		BCM43570 802.11ac Wireless Network Adapter
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x43dc
++device.name		BCM4355 802.11ac Wireless LAN SoC
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x43df
 +device.name		BCM4354 802.11ac Wireless LAN SoC
 
@@ -89196,6 +91448,14 @@
  vendor.id		pci 0x14e4
 &device.id		pci 0x4432
 +device.name		BCM4432 CardBus 10/100BaseT
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x4464
++device.name		BCM4364 802.11ac Wireless Network Adapter
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x4488
++device.name		BCM4377b Wireless Network Adapter
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x4610
@@ -89384,6 +91644,10 @@
 +device.name		Valkyrie offload engine
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x5e88
++device.name		Viper Offload Engine
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x8602
 +device.name		BCM7400/BCM7405 Serial ATA Controller
 
@@ -89440,6 +91704,18 @@
 +device.name		Broadcom BCM56379 Switch ASIC
 
  vendor.id		pci 0x14e4
+&device.id		pci 0xb470
++device.name		BCM56470 SWITCH ASIC
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0xb471
++device.name		BCM56471 SWITCH ASIC
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0xb472
++device.name		BCM56472 SWITCH ASIC
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0xb800
 +device.name		BCM56800 StrataXGS 10GE Switch Controller
 
@@ -89458,6 +91734,10 @@
  vendor.id		pci 0x14e4
 &device.id		pci 0xb960
 +device.name		Broadcom BCM56960 Switch ASIC
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0xb990
++device.name		BCM56990 Switch ASIC
 
  vendor.id		pci 0x14e4
 &device.id		pci 0xd802
@@ -89486,6 +91766,12 @@
 &subvendor.id		pci 0x14e4
 &subdevice.id		pci 0x8028
 +subdevice.name		Stingray Dual-Port 25Gb Ethernet PCIe SmartNIC w8GB DRAM (Part No BCM958802A8048C)
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0xd802
+&subvendor.id		pci 0x1bb0
+&subdevice.id		pci 0x0021
++subdevice.name		HPE SimpliVity Accelerator
 
  vendor.id		pci 0x14e4
 &device.id		pci 0xd804
@@ -90938,6 +93224,12 @@
 
  vendor.id		pci 0x14f1
 &device.id		pci 0x8880
+&subvendor.id		pci 0x1461
+&subdevice.id		pci 0x3100
++subdevice.name		CE310B SD PCIe Video Capture Card
+
+ vendor.id		pci 0x14f1
+&device.id		pci 0x8880
 &subvendor.id		pci 0x5654
 &subdevice.id		pci 0x2389
 +subdevice.name		GoTView X5 DVD Hybrid PCI-E
@@ -91673,6 +93965,18 @@
 &device.id		pci 0x9290
 +device.name		FPGA Card
 
+ vendor.id		pci 0x1542
+&device.id		pci 0x9300
++device.name		Universal Exhaust Gas Oxygen Sensor Simulator
+
+ vendor.id		pci 0x1542
+&device.id		pci 0x9310
++device.name		Digital Programmable Resistor
+
+ vendor.id		pci 0x1542
+&device.id		pci 0x9350
++device.name		Analog Input Card
+
  vendor.id		pci 0x1543
 +vendor.name		SILICON Laboratories
 
@@ -91756,6 +94060,10 @@
  vendor.id		pci 0x1556
 &device.id		pci 0x1113
 +device.name		XpressSwitch
+
+ vendor.id		pci 0x1556
+&device.id		pci 0xbe00
++device.name		PCI Express Bridge
 
  vendor.id		pci 0x1557
 +vendor.name		MEDIASTAR Co Ltd
@@ -92302,12 +94610,56 @@
 +device.name		MT2892 Family [ConnectX-6 Dx Secure Flash Recovery]
 
  vendor.id		pci 0x15b3
+&device.id		pci 0x0214
++device.name		MT42822 Family [BlueField-2 SoC Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0215
++device.name		MT42822 Family [BlueField-2 Secure Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0216
++device.name		MT2894 Family [ConnectX-6 Lx Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0217
++device.name		MT2894 Family [ConnectX-6 Lx Secure Flash Recovery]
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0x024e
 +device.name		MT53100 [Spectrum-2, Flash recovery mode]
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x024f
 +device.name		MT53100 [Spectrum-2, Secure Flash recovery mode]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0250
++device.name		Spectrum-3, Flash recovery mode
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0251
++device.name		Spectrum-3, Secure Flash recovery mode
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0252
++device.name		Amos chiplet
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0254
++device.name		Spectrum-4, Flash recovery mode
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0255
++device.name		Spectrum-4, Secure Flash recovery mode
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0256
++device.name		Ofek chiplet
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0257
++device.name		Quantum-2 in Flash Recovery Mode
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x0262
@@ -92324,6 +94676,14 @@
  vendor.id		pci 0x15b3
 &device.id		pci 0x0281
 +device.name		NPS-600 Flash Recovery
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0538
++device.name		MT2910 Family [ConnectX-7 Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0539
++device.name		MT2910 Family [ConnectX-7 Secure Flash Recovery]
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x1002
@@ -92606,6 +94966,12 @@
  vendor.id		pci 0x15b3
 &device.id		pci 0x1013
 &subvendor.id		pci 0x15b3
+&subdevice.id		pci 0x0007
++subdevice.name		ConnectX-4 EN network interface card, 40/56GbE dual-port QSFP28, PCIe3.0 x16, tall bracket
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1013
+&subvendor.id		pci 0x15b3
 &subdevice.id		pci 0x0008
 +subdevice.name		ConnectX-4 Stand-up dual-port 100GbE MCX416A-CCAT
 
@@ -92692,12 +95058,36 @@
 +device.name		MT27800 Family [ConnectX-5]
 
  vendor.id		pci 0x15b3
+&device.id		pci 0x1017
+&subvendor.id		pci 0x15b3
+&subdevice.id		pci 0x0006
++subdevice.name		ConnectX®-5 EN network interface card, 100GbE single-port QSFP28, PCIe3.0 x16, tall bracket; MCX515A-CCAT
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1017
+&subvendor.id		pci 0x15b3
+&subdevice.id		pci 0x0020
++subdevice.name		ConnectX®-5 EN network interface card, 10/25GbE dual-port SFP28, PCIe3.0 x8, tall bracket ; MCX512A-ACAT
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1017
+&subvendor.id		pci 0x15b3
+&subdevice.id		pci 0x0068
++subdevice.name		ConnectX®-5 EN network interface card for OCP2.0, Type 1, with host management, 25GbE dual-port SFP28, PCIe3.0 x8, no bracket Halogen free ; MCX542B-ACAN
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0x1018
 +device.name		MT27800 Family [ConnectX-5 Virtual Function]
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x1019
 +device.name		MT28800 Family [ConnectX-5 Ex]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1019
+&subvendor.id		pci 0x15b3
+&subdevice.id		pci 0x0008
++subdevice.name		ConnectX-5 Ex EN network interface card, 100GbE dual-port QSFP28, PCIe4.0 x16, tall bracket; MCX516A-CDAT
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x101a
@@ -92721,7 +95111,7 @@
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x101f
-+device.name		MT28851
++device.name		MT2894 Family [ConnectX-6 Lx]
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x1020
@@ -92729,7 +95119,7 @@
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x1021
-+device.name		MT28861
++device.name		MT2910 Family [ConnectX-7]
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x1974
@@ -92740,6 +95130,22 @@
 +device.name		MT416842 Family [BlueField SoC PCIe Bridge]
 
  vendor.id		pci 0x15b3
+&device.id		pci 0x1976
++device.name		MT28908 Family [ConnectX-6 PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1977
++device.name		MT2892 Family [ConnectX-6 Dx PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1978
++device.name		MT42822 Family [BlueField-2 SoC PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1979
++device.name		MT2910 Family [ConnectX-7 PCIe Bridge]
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0x4117
 +device.name		MT27712A0-FDCF-AE
 
@@ -92748,6 +95154,12 @@
 &subvendor.id		pci 0x1bd4
 &subdevice.id		pci 0x0039
 +subdevice.name		SN10XMP2P25
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x4117
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x003a
++subdevice.name		25G SFP28 SP EO251FM9 Adapter
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x4117
@@ -92964,6 +95376,26 @@
 +device.name		MT416842 BlueField multicore SoC family VF
 
  vendor.id		pci 0x15b3
+&device.id		pci 0xa2d4
++device.name		MT42822 BlueField-2 SoC Crypto enabled
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xa2d5
++device.name		MT42822 BlueField-2 SoC Crypto disabled
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xa2d6
++device.name		MT42822 BlueField-2 integrated ConnectX-6 Dx network controller
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xc2d2
++device.name		MT416842 BlueField SoC management interfac
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xc2d3
++device.name		MT42822 BlueField-2 SoC Management Interface
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0xc738
 +device.name		MT51136
 
@@ -92989,15 +95421,27 @@
 
  vendor.id		pci 0x15b3
 &device.id		pci 0xcf08
-+device.name		MT53236
++device.name		Switch-IB2
 
  vendor.id		pci 0x15b3
 &device.id		pci 0xcf6c
 +device.name		MT53100 [Spectrum-2]
 
  vendor.id		pci 0x15b3
+&device.id		pci 0xcf70
++device.name		Spectrum-3
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xcf80
++device.name		Spectrum-4
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0xd2f0
 +device.name		Quantum HDR (200Gbps) switch
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xd2f2
++device.name		Quantum-2 NDR (400Gbps) switch
 
  vendor.id		pci 0x15b4
 +vendor.name		CCI/TRIAD
@@ -95257,6 +97701,12 @@
  vendor.id		pci 0x168c
 &device.id		pci 0x002a
 &subvendor.id		pci 0x1a3b
+&subdevice.id		pci 0x1071
++subdevice.name		AW-NE772 802.11abgn Wireless Mini PCIe Card [AR9280]
+
+ vendor.id		pci 0x168c
+&device.id		pci 0x002a
+&subvendor.id		pci 0x1a3b
 &subdevice.id		pci 0x1081
 +subdevice.name		AW-NE773 802.11abgn Wireless Half-size Mini PCIe Card [AR9280]
 
@@ -95471,6 +97921,12 @@
 +device.name		QCA9565 / AR9565 Wireless Network Adapter
 
  vendor.id		pci 0x168c
+&device.id		pci 0x0036
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x020e
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x168c
 &device.id		pci 0x0037
 +device.name		AR9485 Wireless Network Adapter
 
@@ -95511,6 +97967,12 @@
  vendor.id		pci 0x168c
 &device.id		pci 0x0042
 +device.name		QCA9377 802.11ac Wireless Network Adapter
+
+ vendor.id		pci 0x168c
+&device.id		pci 0x0042
+&subvendor.id		pci 0x11ad
+&subdevice.id		pci 0x08a6
++subdevice.name		Qualcomm Atheros QCA9377 802.11ac Wireless Network Adapter
 
  vendor.id		pci 0x168c
 &device.id		pci 0x0046
@@ -95637,7 +98099,7 @@
 
  vendor.id		pci 0x16c3
 &device.id		pci 0xabcd
-+device.name		DWC_usb3
++device.name		DWC_usb3 / PCIe bridge
 
  vendor.id		pci 0x16c3
 &device.id		pci 0xabce
@@ -97368,6 +99830,10 @@
 &device.id		pci 0x1884
 +device.name		ARC-1884 series PCIe 3.0 to SAS/SATA 12/6Gb RAID Controller
 
+ vendor.id		pci 0x17d3
+&device.id		pci 0x188a
++device.name		ARC-1886 series PCIe 4.0 to NVMe/SAS/SATA 16/12/6Gb RAID Controller
+
  vendor.id		pci 0x17d5
 +vendor.name		Exar Corp.
 
@@ -97796,8 +100262,36 @@
 +device.name		PCI/PCI-X to PCI-E Bridge
 
  vendor.id		pci 0x17f3
+&device.id		pci 0x1070
++device.name		CAN Bus Controller
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x1331
++device.name		Motion Control Interface
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x1930
++device.name		Hybrid Function Control Register
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x2010
++device.name		RDC M2010 VGA-compatible graphics adapter
+
+ vendor.id		pci 0x17f3
 &device.id		pci 0x2012
 +device.name		M2012/R3308 VGA-compatible graphics adapter
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x2015
++device.name		RDC M2015 VGA-compatible graphics adapter
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x6011
++device.name		R6011 ISA Bridge
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x6013
++device.name		R6013 ISA Bridge
 
  vendor.id		pci 0x17f3
 &device.id		pci 0x6020
@@ -97808,12 +100302,32 @@
 +device.name		R6021 Host Bridge
 
  vendor.id		pci 0x17f3
+&device.id		pci 0x6023
++device.name		R6023 Host Bridge
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x6025
++device.name		R6025 Host Bridge
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x6026
++device.name		R6026 Host Bridge
+
+ vendor.id		pci 0x17f3
 &device.id		pci 0x6030
 +device.name		R6030 ISA Bridge
 
  vendor.id		pci 0x17f3
 &device.id		pci 0x6031
 +device.name		R6031 ISA Bridge
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x6035
++device.name		R6035 ISA Bridge
+
+ vendor.id		pci 0x17f3
+&device.id		pci 0x6036
++device.name		R6036 ISA Bridge
 
  vendor.id		pci 0x17f3
 &device.id		pci 0x6040
@@ -97877,6 +100391,13 @@
 
  vendor.id		pci 0x1803
 +vendor.name		ProdaSafe GmbH
+
+ vendor.id		pci 0x1804
++vendor.name		Ralink corp. (wrong ID)
+
+ vendor.id		pci 0x1804
+&device.id		pci 0x3060
++device.name		RT3060 Wireless 802.11n 1T/1R
 
  vendor.id		pci 0x1805
 +vendor.name		Euresys S.A.
@@ -98390,6 +100911,22 @@
  vendor.id		pci 0x1830
 +vendor.name		Credence Systems Corporation
 
+ vendor.id		pci 0x1830
+&device.id		pci 0x8000
++device.name		CPIn
+
+ vendor.id		pci 0x1830
+&device.id		pci 0x8001
++device.name		CPId
+
+ vendor.id		pci 0x1830
+&device.id		pci 0x8002
++device.name		CPIx
+
+ vendor.id		pci 0x1830
+&device.id		pci 0x8003
++device.name		CPIq
+
  vendor.id		pci 0x183b
 +vendor.name		MikroM GmbH
 
@@ -98507,6 +101044,10 @@
  vendor.id		pci 0x186c
 &device.id		pci 0x0634
 +device.name		MF634 Multifunction I/O PCIe Card
+
+ vendor.id		pci 0x186c
+&device.id		pci 0x0644
++device.name		MF644 Multifunction I/O Thb Card
 
  vendor.id		pci 0x186f
 +vendor.name		WiNRADiO Communications
@@ -100657,7 +103198,7 @@
 &device.id		pci 0x1048
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8226
-+subdevice.name		P5KPL-VM Motherboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM Motherboard
 
  vendor.id		pci 0x1969
 &device.id		pci 0x1062
@@ -100958,6 +103499,10 @@
  vendor.id		pci 0x1987
 &device.id		pci 0x5012
 +device.name		E12 NVMe Controller
+
+ vendor.id		pci 0x1987
+&device.id		pci 0x5016
++device.name		E16 PCIe4 NVMe Controller
 
  vendor.id		pci 0x1989
 +vendor.name		Montilio Inc.
@@ -101302,24 +103847,122 @@
 +device.name		Hi1822 Family (2*100GE)
 
  vendor.id		pci 0x19e5
+&device.id		pci 0x0200
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd139
++subdevice.name		Hi1822 SP572 (2*100GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0200
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd13d
++subdevice.name		Hi1822 SC371 (2*100GE)
+
+ vendor.id		pci 0x19e5
 &device.id		pci 0x0202
 +device.name		Hi1822 Family (2*32G FC)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0202
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd302
++subdevice.name		Hi1822 SP521 (2*32G FC)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0202
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd304
++subdevice.name		Hi1822 SP526 (2*32G FC)
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x0203
 +device.name		Hi1822 Family (2*16G FC)
 
  vendor.id		pci 0x19e5
+&device.id		pci 0x0203
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd301
++subdevice.name		Hi1822 SP520 (2*16G FC)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0203
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd305
++subdevice.name		Hi1822 SP525 (2*16G FC)
+
+ vendor.id		pci 0x19e5
 &device.id		pci 0x0205
 +device.name		Hi1822 Family (2*100GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0205
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xdf27
++subdevice.name		Hi1822 MZ731 MEZZ (2*100GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0206
++device.name		Hi1822 Family (2*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0206
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd138
++subdevice.name		Hi1822 SP582 (2*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0206
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd13a
++subdevice.name		Hi1822 SC381 (2*25GE)
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x0210
 +device.name		Hi1822 Family (4*25GE)
 
  vendor.id		pci 0x19e5
+&device.id		pci 0x0210
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xdf2e
++subdevice.name		Hi1822 MZ532 MEZZ (4*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0211
++device.name		Hi1822 Family (4*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0211
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd12f
++subdevice.name		Hi1822 SP571 (4*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0211
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd137
++subdevice.name		Hi1822 SP581 (4*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0211
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd142
++subdevice.name		Hi1822 SP583 (4*25GE)
+
+ vendor.id		pci 0x19e5
 &device.id		pci 0x0212
 +device.name		Hi1822 Family (2*8G FC)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0212
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd303
++subdevice.name		Hi1822 SP522 (2*8G FC)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0212
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd306
++subdevice.name		Hi1822 SP523 (2*8G FC)
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x1710
@@ -101334,8 +103977,34 @@
 +device.name		Hi1822 Family (4*25GE)
 
  vendor.id		pci 0x19e5
+&device.id		pci 0x1822
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd129
++subdevice.name		Hi1822 SP570 (4*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x1822
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd136
++subdevice.name		Hi1822 SP580 (4*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x1822
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd141
++subdevice.name		Hi1822 SP583 (4*25GE)
+
+ vendor.id		pci 0x19e5
 &device.id		pci 0x371e
 +device.name		Hi1822 Family Virtual Bridge
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x375e
++device.name		Hi1822 Family Virtual Function
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x379e
++device.name		Hi1822 Family Virtual Function
 
  vendor.id		pci 0x19e5
 &device.id		pci 0xa120
@@ -101376,6 +104045,30 @@
  vendor.id		pci 0x19e5
 &device.id		pci 0xa221
 +device.name		HNS GE/10GE/25GE Network Controller
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0xa221
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x0454
++subdevice.name		TM280
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0xa221
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x04cc
++subdevice.name		TM210
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0xa221
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd14a
++subdevice.name		TM280 4*25G
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0xa221
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd14b
++subdevice.name		TM210 4*GE
 
  vendor.id		pci 0x19e5
 &device.id		pci 0xa222
@@ -101572,6 +104265,10 @@
  vendor.id		pci 0x1a29
 &device.id		pci 0x4e36
 +device.name		NP6 Network Processor
+
+ vendor.id		pci 0x1a29
+&device.id		pci 0x4e37
++device.name		NP7 Network Processor
 
  vendor.id		pci 0x1a2b
 +vendor.name		Ascom AG
@@ -101883,7 +104580,7 @@
 +vendor.name		Global Velocity, Inc.
 
  vendor.id		pci 0x1ab4
-+vendor.name		Distributed Management Task Force, Inc. (DMTF)Distributed Management Task Force, Inc. (DMTF)
++vendor.name		Distributed Management Task Force, Inc. (DMTF)
 
  vendor.id		pci 0x1ab6
 +vendor.name		CalDigit, Inc.
@@ -101909,6 +104606,13 @@
 
  vendor.id		pci 0x1ab9
 +vendor.name		Espia Srl
+
+ vendor.id		pci 0x1ac1
++vendor.name		Global Unichip Corp.
+
+ vendor.id		pci 0x1ac1
+&device.id		pci 0x089a
++device.name		Coral Edge TPU
 
  vendor.id		pci 0x1ac8
 +vendor.name		Aeroflex Gaisler
@@ -101952,6 +104656,13 @@
 
  vendor.id		pci 0x1ae0
 +vendor.name		Google, Inc.
+
+ vendor.id		pci 0x1ae0
+&device.id		pci 0x0042
++device.name		Compute Engine Virtual Ethernet [gVNIC]
+
+ vendor.id		pci 0x1ae3
++vendor.name		SANBlaze Technology, Inc.
 
  vendor.id		pci 0x1ae7
 +vendor.name		First Wise Media GmbH
@@ -102012,6 +104723,14 @@
  vendor.id		pci 0x1aea
 &device.id		pci 0x6601
 +device.name		AU6601 PCI-E Flash card reader controller
+
+ vendor.id		pci 0x1aea
+&device.id		pci 0x6621
++device.name		AU6621 PCI-E Flash card reader controller
+
+ vendor.id		pci 0x1aea
+&device.id		pci 0x6625
++device.name		AU6625 PCI-E Flash card reader controller
 
  vendor.id		pci 0x1aec
 +vendor.name		Wolfson Microelectronics
@@ -102691,8 +105410,20 @@
 +device.name		EJ168 USB 3.0 Host Controller
 
  vendor.id		pci 0x1b6f
+&device.id		pci 0x7023
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x5007
++subdevice.name		GA-880GMA-USB3
+
+ vendor.id		pci 0x1b6f
 &device.id		pci 0x7052
 +device.name		EJ188/EJ198 USB 3.0 Host Controller
+
+ vendor.id		pci 0x1b6f
+&device.id		pci 0x7052
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x7052
++subdevice.name		QC5000-ITX/PH
 
  vendor.id		pci 0x1b73
 +vendor.name		Fresco Logic
@@ -102784,6 +105515,14 @@
 
  vendor.id		pci 0x1bad
 +vendor.name		ReFLEX CES
+
+ vendor.id		pci 0x1bad
+&device.id		pci 0xc001
++device.name		XpressGXA10-LP1150
+
+ vendor.id		pci 0x1bad
+&device.id		pci 0xc002
++device.name		XpressGXA10-LP1151
 
  vendor.id		pci 0x1bb0
 +vendor.name		SimpliVity Corporation
@@ -102882,6 +105621,18 @@
  vendor.id		pci 0x1bb1
 &device.id		pci 0x0100
 &subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0107
++subdevice.name		Nytro 5320
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0108
++subdevice.name		Nytro 5320 TCG
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
 &subdevice.id		pci 0x0121
 +subdevice.name		Nytro XM1440
 
@@ -102902,6 +105653,54 @@
 &subvendor.id		pci 0x1bb1
 &subdevice.id		pci 0x0126
 +subdevice.name		Nytro 5020
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0127
++subdevice.name		Nytro 5320 M.2
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0128
++subdevice.name		Nytro 5320 M.2 TCG
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0131
++subdevice.name		Nytro 5320 M.2
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0132
++subdevice.name		Nytro 5320 M.2 TCG
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0141
++subdevice.name		Nytro 5320 E1.S
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0142
++subdevice.name		Nytro 5320 E1.S TCG
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0151
++subdevice.name		Nytro 5520
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x0100
+&subvendor.id		pci 0x1bb1
+&subdevice.id		pci 0x0152
++subdevice.name		Nytro 5520 TCG
 
  vendor.id		pci 0x1bb1
 &device.id		pci 0x0100
@@ -103003,6 +105802,10 @@
  vendor.id		pci 0x1bd4
 +vendor.name		Inspur Electronic Information Industry Co., Ltd.
 
+ vendor.id		pci 0x1bd4
+&device.id		pci 0x0911
++device.name		Arria10_PCIe_F10A1150
+
  vendor.id		pci 0x1bee
 +vendor.name		IXXAT Automation GmbH
 
@@ -103023,6 +105826,10 @@
  vendor.id		pci 0x1bf4
 &device.id		pci 0x0001
 +device.name		SentinelEX
+
+ vendor.id		pci 0x1bf4
+&device.id		pci 0x7011
++device.name		RX0xxx
 
  vendor.id		pci 0x1bfd
 +vendor.name		EeeTOP
@@ -103085,6 +105892,33 @@
 &device.id		pci 0x0001
 +device.name		82C101
 
+ vendor.id		pci 0x1c1f
++vendor.name		SoftLab-NSK
+
+ vendor.id		pci 0x1c1f
+&device.id		pci 0x0015
++device.name		FD842
+
+ vendor.id		pci 0x1c1f
+&device.id		pci 0x0019
++device.name		FD722
+
+ vendor.id		pci 0x1c1f
+&device.id		pci 0x001a
++device.name		FD788
+
+ vendor.id		pci 0x1c1f
+&device.id		pci 0x001b
++device.name		FD720
+
+ vendor.id		pci 0x1c1f
+&device.id		pci 0x001c
++device.name		FD922
+
+ vendor.id		pci 0x1c1f
+&device.id		pci 0x001d
++device.name		Vega
+
  vendor.id		pci 0x1c28
 +vendor.name		Lite-On IT Corp. / Plextor
 
@@ -103105,27 +105939,27 @@
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a0
-+device.name		FBC4G Capture 4x1Gb
++device.name		FBC4G Capture 4x1Gb [Herculaneum]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a1
-+device.name		FBC4XG Capture 4x10Gb
++device.name		FBC4XG Capture 4x10Gb [Ancona]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a2
-+device.name		FBC8XG Capture 8x10Gb
++device.name		FBC8XG Capture 8x10Gb [Livorno]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a3
-+device.name		FBC2XG Capture 2x10Gb
++device.name		FBC2XG Capture 2x10Gb [Genoa]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a4
-+device.name		FBC4XGG3 Capture 4x10Gb
++device.name		FBC4XGG3 Capture 4x10Gb [Livigno]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a5
-+device.name		FBC2XLG Capture 2x40Gb
++device.name		FBC2XLG Capture 2x40Gb [Livorno]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a6
@@ -103133,7 +105967,7 @@
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00a9
-+device.name		FBC2XGHH Capture 2x10Gb
++device.name		FBC2XGHH Capture 2x10Gb [Latina]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0x00ad
@@ -103152,8 +105986,40 @@
 +device.name		PacketMover 2x100Gb [Tivoli]
 
  vendor.id		pci 0x1c2c
+&device.id		pci 0x00e3
++device.name		PacketMover 2x10Gb [Tivoli]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0x00e5
++device.name		PacketMover 2x10Gb [Corfu]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa000
++device.name		FBC2CGG3 Capture 2x40Gb [Mango_02]
+
+ vendor.id		pci 0x1c2c
 &device.id		pci 0xa001
-+device.name		FBC2CGG3 Capture 2x100Gb [Mango]
++device.name		FBC2CGG3 Capture 2x100Gb [Mango_02]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa003
++device.name		FBC2CGG3 Capture 16x10Gb [Mango]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa007
++device.name		FBC2CGG3 Capture 2x40Gb [Mango]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa008
++device.name		FBC2CGG3 Capture 2x25Gb [Mango]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa009
++device.name		FBC2CGG3 Capture 16x10Gb [Mango]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa00a
++device.name		FBC2CGG3 Capture 8x10Gb [Mango]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0xa00e
@@ -103226,6 +106092,12 @@
 +subdevice.name		PCIe3 3.2TB NVMe Flash Adapter
 
  vendor.id		pci 0x1c58
+&device.id		pci 0x0003
+&subvendor.id		pci 0x1c58
+&subdevice.id		pci 0x0003
++subdevice.name		Ultrastar SN100/SN150 NVMe SSD
+
+ vendor.id		pci 0x1c58
 &device.id		pci 0x0023
 +device.name		Ultrastar SN200 Series NVMe SSD
 
@@ -103240,7 +106112,19 @@
 
  vendor.id		pci 0x1c5c
 &device.id		pci 0x1283
-+device.name		PC300 NVMe Solid State Drive
++device.name		PC300 NVMe Solid State Drive 256GB
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x1284
++device.name		PC300 NVMe Solid State Drive 512GB
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x1285
++device.name		PC300 NVMe Solid State Drive 1TB
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x1327
++device.name		BC501 NVMe Solid State Drive 512GB
 
  vendor.id		pci 0x1c5c
 &device.id		pci 0x1504
@@ -103250,8 +106134,36 @@
 +vendor.name		Beijing Memblaze Technology Co. Ltd.
 
  vendor.id		pci 0x1c5f
+&device.id		pci 0x000d
++device.name		PBlaze5 520/526 AIC
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x003d
++device.name		PBlaze5 920/926 AIC
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x010d
++device.name		PBlaze5 520/526 U.2
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x013d
++device.name		PBlaze5 920/926 U.2
+
+ vendor.id		pci 0x1c5f
 &device.id		pci 0x0540
 +device.name		PBlaze4 NVMe SSD
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x0550
++device.name		PBlaze5 700/900
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x0555
++device.name		PBlaze5 510/516
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x0557
++device.name		PBlaze5 910/916
 
  vendor.id		pci 0x1c63
 +vendor.name		Science and Research Centre of Computer Technology (JSC "NICEVT")
@@ -103284,6 +106196,49 @@
  vendor.id		pci 0x1c8c
 +vendor.name		Mobiveil, Inc.
 
+ vendor.id		pci 0x1cb0
++vendor.name		Shannon Systems
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
++device.name		Venice NVMe SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2f10
++subdevice.name		Venice-E Series U.2 SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2f11
++subdevice.name		Venice Series U.2 SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2f12
++subdevice.name		Venice-X Series U.2 SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0xaf10
++subdevice.name		Venice-E Series AIC SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0xaf11
++subdevice.name		Venice Series AIC SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0xaf12
++subdevice.name		Venice-X Series AIC SSD
+
  vendor.id		pci 0x1cb1
 +vendor.name		Collion UG & Co.KG
 
@@ -103296,6 +106251,20 @@
 
  vendor.id		pci 0x1cb8
 +vendor.name		Dawning Information Industry Co., Ltd.
+
+ vendor.id		pci 0x1cc1
++vendor.name		ADATA Technology Co., Ltd.
+
+ vendor.id		pci 0x1cc1
+&device.id		pci 0x8201
++device.name		XPG SX8200 Pro PCIe Gen3x4 M.2 2280 Solid State Drive
+
+ vendor.id		pci 0x1cc4
++vendor.name		Union Memory (Shenzhen)
+
+ vendor.id		pci 0x1cc4
+&device.id		pci 0x17ab
++device.name		NVMe 256G SSD device
 
  vendor.id		pci 0x1cc5
 +vendor.name		Embedded Intelligence, Inc.
@@ -103345,6 +106314,10 @@
 &device.id		pci 0x0305
 +device.name		Simulyzer-RT CompactPCI Serial CAN-1 card
 
+ vendor.id		pci 0x1cd2
+&device.id		pci 0x0306
++device.name		Simulyzer-RT CompactPCI Serial CAN-2 card (CAN-FD)
+
  vendor.id		pci 0x1cd7
 +vendor.name		Nanjing Magewell Electronics Co., Ltd.
 
@@ -103359,6 +106332,22 @@
  vendor.id		pci 0x1cd7
 &device.id		pci 0x0017
 +device.name		PRO CAPTURE AIO 4K
+
+ vendor.id		pci 0x1cd7
+&device.id		pci 0x0051
++device.name		Eco Capture Dual HDMI M.2
+
+ vendor.id		pci 0x1cd7
+&device.id		pci 0x0052
++device.name		Eco Capture HDMI 4K M.2
+
+ vendor.id		pci 0x1cd7
+&device.id		pci 0x0053
++device.name		Eco Capture Dual SDI M.2
+
+ vendor.id		pci 0x1cd7
+&device.id		pci 0x0054
++device.name		Eco Capture Quad SDI M.2
 
  vendor.id		pci 0x1cdd
 +vendor.name		secunet Security Networks AG
@@ -103401,6 +106390,14 @@
  vendor.id		pci 0x1ce4
 &device.id		pci 0x0009
 +device.name		ExaNIC X25
+
+ vendor.id		pci 0x1ce4
+&device.id		pci 0x000a
++device.name		ExaNIC X100
+
+ vendor.id		pci 0x1ce4
+&device.id		pci 0x000b
++device.name		ExaNIC V9P
 
  vendor.id		pci 0x1ce4
 &device.id		pci 0x0100
@@ -103470,35 +106467,35 @@
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x0717
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x0718
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x0719
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x071a
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x071b
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x071c
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x071d
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x071e
-+device.name		ZX-D PCI Express Root Port
++device.name		ZX-D/ZX-E PCI Express Root Port
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x071f
@@ -103522,7 +106519,11 @@
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x1001
-+device.name		ZX-D Miscellaneous Bus
++device.name		ZX-D/ZX-E Miscellaneous Bus
+
+ vendor.id		pci 0x1d17
+&device.id		pci 0x1003
++device.name		ZX-E Standard Host Bridge
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x3001
@@ -103534,11 +106535,11 @@
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x3038
-+device.name		ZX-100/ZX-200 Standard Universal PCI to USB Host Controller
++device.name		ZX-100/ZX-200/ZX-E Standard Universal PCI to USB Host Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x3104
-+device.name		ZX-100/ZX-200 Standard Enhanced PCI to USB Host Controller
++device.name		ZX-100/ZX-200/ZX-E Standard Enhanced PCI to USB Host Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x31b0
@@ -103566,7 +106567,7 @@
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x31b7
-+device.name		ZX-100/ZX-D Standard Host Bridge
++device.name		ZX-100/ZX-D/ZX-E Standard Host Bridge
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x31b8
@@ -103574,11 +106575,11 @@
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x3288
-+device.name		ZX-100/ZX-D High Definition Audio Controller
++device.name		ZX-100/ZX-D/ZX-E High Definition Audio Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x345b
-+device.name		ZX-100/ZX-D Miscellaneous Bus
++device.name		ZX-100/ZX-D/ZX-E Miscellaneous Bus
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x3a02
@@ -103589,24 +106590,28 @@
 +device.name		ZX-D C-860 GPU
 
  vendor.id		pci 0x1d17
+&device.id		pci 0x3a04
++device.name		ZX-E C-960 GPU
+
+ vendor.id		pci 0x1d17
 &device.id		pci 0x9002
 +device.name		ZX-100/ZX-200 EIDE Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x9003
-+device.name		ZX-100 EIDE Controller
++device.name		ZX-100/ZX-E EIDE Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x9045
-+device.name		ZX-100/ZX-D RAID Accelerator
++device.name		ZX-100/ZX-D/ZX-E RAID Accelerator 0
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x9046
-+device.name		ZX-D RAID Accelerator
++device.name		ZX-D/ZX-E RAID Accelerator 1
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x9083
-+device.name		ZX-100/ZX-200 StorX AHCI Controller
++device.name		ZX-100/ZX-200/ZX-E StorX AHCI Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x9084
@@ -103629,6 +106634,10 @@
 +device.name		ZX-D High Definition Audio Controller
 
  vendor.id		pci 0x1d17
+&device.id		pci 0x9144
++device.name		ZX-E High Definition Audio Controller
+
+ vendor.id		pci 0x1d17
 &device.id		pci 0x9180
 +device.name		ZX-200 Networking Gigabit Ethernet Adapter
 
@@ -103641,12 +106650,16 @@
 +device.name		ZX-200 USB eXtensible Host Controller
 
  vendor.id		pci 0x1d17
+&device.id		pci 0x9204
++device.name		ZX-E USB eXtensible Host Controller
+
+ vendor.id		pci 0x1d17
 &device.id		pci 0x9286
 +device.name		ZX-D eMMC Host Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x9300
-+device.name		ZX-D eSPI Host Controller
++device.name		ZX-D/ZX-E eSPI Host Controller
 
  vendor.id		pci 0x1d17
 &device.id		pci 0x95d0
@@ -103654,7 +106667,7 @@
 
  vendor.id		pci 0x1d17
 &device.id		pci 0xf410
-+device.name		ZX-100/ZX-D PCI Com Port
++device.name		ZX-100/ZX-D/ZX-E PCI Com Port
 
  vendor.id		pci 0x1d18
 +vendor.name		RME
@@ -103676,6 +106689,13 @@
 
  vendor.id		pci 0x1d21
 +vendor.name		Allo
+
+ vendor.id		pci 0x1d22
++vendor.name		Baidu Technology
+
+ vendor.id		pci 0x1d22
+&device.id		pci 0x1380
++device.name		Cloud Storage Device
 
  vendor.id		pci 0x1d26
 +vendor.name		Kalray Inc.
@@ -103699,6 +106719,25 @@
  vendor.id		pci 0x1d26
 &device.id		pci 0xe004
 +device.name		AB01/EMB01 Development Board
+
+ vendor.id		pci 0x1d37
++vendor.name		NovaSparks
+
+ vendor.id		pci 0x1d37
+&device.id		pci 0x0013
++device.name		PM3
+
+ vendor.id		pci 0x1d37
+&device.id		pci 0x0014
++device.name		PM4
+
+ vendor.id		pci 0x1d37
+&device.id		pci 0x0015
++device.name		PM4edge
+
+ vendor.id		pci 0x1d37
+&device.id		pci 0x0016
++device.name		PM4edge User Device
 
  vendor.id		pci 0x1d40
 +vendor.name		Techman Electronics (Changshu) Co., Ltd.
@@ -103845,6 +106884,30 @@
 +subdevice.name		DPDK-Aware Virtual Function [Arkville VF]
 
  vendor.id		pci 0x1d6c
+&device.id		pci 0x100f
++device.name		AR-ARKA-FX1 [Arkville 64B DPDK Data Mover for Versal]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1010
++device.name		AR-ARKA-FX1 [Arkville 64B DPDK Data Mover for Agilex]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1011
++device.name		AR-MAN-U50 [Manitou Class Accelerator for U50]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1012
++device.name		AR-MAN-U200 [Manitou Class Accelerator for U200]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1013
++device.name		AR-MAN-U250 [Manitou Class Accelerator for U250]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1014
++device.name		AR-MAN-U280 [Manitou Class Accelerator for U280]
+
+ vendor.id		pci 0x1d6c
 &device.id		pci 0x4200
 +device.name		A5PL-E1-10GETI [10 GbE Ethernet Traffic Instrument]
 
@@ -103860,6 +106923,18 @@
  vendor.id		pci 0x1d82
 +vendor.name		NETINT Technologies Inc.
 
+ vendor.id		pci 0x1d82
+&device.id		pci 0x0101
++device.name		Codensity D400 SSD
+
+ vendor.id		pci 0x1d82
+&device.id		pci 0x0102
++device.name		Codensity D408 PCIe Gen4 NVMe SSD
+
+ vendor.id		pci 0x1d82
+&device.id		pci 0x0202
++device.name		Codensity T408 Video Encoding-Decoding Accelerator
+
  vendor.id		pci 0x1d87
 +vendor.name		Fuzhou Rockchip Electronics Co., Ltd
 
@@ -103873,6 +106948,9 @@
 
  vendor.id		pci 0x1d8f
 +vendor.name		Enyx
+
+ vendor.id		pci 0x1d93
++vendor.name		YADRO (KNS Group)
 
  vendor.id		pci 0x1d94
 +vendor.name		Chengdu Haiguang IC Design Co., Ltd.
@@ -104021,6 +107099,17 @@
  vendor.id		pci 0x1da2
 +vendor.name		Sapphire Technology Limited
 
+ vendor.id		pci 0x1da3
++vendor.name		Habana Labs Ltd.
+
+ vendor.id		pci 0x1da3
+&device.id		pci 0x0001
++device.name		HL-1000 AI Inference Accelerator [Goya]
+
+ vendor.id		pci 0x1da3
+&device.id		pci 0x1000
++device.name		HL-2000 AI Training Accelerator [Gaudi]
+
  vendor.id		pci 0x1dbb
 +vendor.name		NGD Systems, Inc.
 
@@ -104030,6 +107119,154 @@
  vendor.id		pci 0x1dbf
 &device.id		pci 0x0401
 +device.name		StarDragon4800 PCI Express Root Port
+
+ vendor.id		pci 0x1dc5
++vendor.name		FADU Inc.
+
+ vendor.id		pci 0x1dcd
++vendor.name		Liqid Inc.
+
+ vendor.id		pci 0x1dd8
++vendor.name		Pensando Systems Inc
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
++device.name		DSC Capri Upstream Port
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4000
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 8GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4001
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4002
++subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
++device.name		DSC Virtual Downstream Port
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4000
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 8GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4001
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4002
++subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
++device.name		DSC Ethernet Controller
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4000
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 8GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4001
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4002
++subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
++device.name		DSC Ethernet Controller VF
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4000
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 8GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4001
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4002
++subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
++device.name		DSC Management Controller
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4000
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 8GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4001
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4002
++subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
++device.name		DSC Storage Accelerator
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4000
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 8GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4001
++subdevice.name		Naples 100Gb 2-port QSFP28 x16 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4002
++subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1de0
++vendor.name		Groq
+
+ vendor.id		pci 0x1de0
+&device.id		pci 0x0000
++device.name		Q100 Tensor Streaming Processor
 
  vendor.id		pci 0x1de1
 +vendor.name		Tekram Technology Co.,Ltd.
@@ -104144,6 +107381,12 @@
  vendor.id		pci 0x1df3
 &device.id		pci 0x0203
 &subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0000
++subdevice.name		Maintenance Mode
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0203
+&subvendor.id		pci 0x1df3
 &subdevice.id		pci 0x0001
 +subdevice.name		ENA2080F
 
@@ -104158,6 +107401,12 @@
 &subvendor.id		pci 0x1df3
 &subdevice.id		pci 0x0003
 +subdevice.name		ENA2100F
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0203
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0004
++subdevice.name		ENA2040F
 
  vendor.id		pci 0x1df3
 &device.id		pci 0x0204
@@ -104197,6 +107446,16 @@
 &device.id		pci 0x1181
 +device.name		TDM 8 Port E1/T1/J1 Adapter
 
+ vendor.id		pci 0x1e0f
++vendor.name		KIOXIA Corporation
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
++device.name		NVMe SSD Controller Cx6
+
+ vendor.id		pci 0x1e17
++vendor.name		Arnold & Richter Cine Technik GmbH & Co. Betriebs KG
+
  vendor.id		pci 0x1e24
 +vendor.name		Squirrels Research Labs
 
@@ -104216,11 +107475,82 @@
 &device.id		pci 0x1525
 +device.name		Xilinx BCU-1525
 
+ vendor.id		pci 0x1e24
+&device.id		pci 0x1533
++device.name		ForestKitten 33
+
+ vendor.id		pci 0x1e24
+&device.id		pci 0x1633
++device.name		JCM33
+
+ vendor.id		pci 0x1e24
+&device.id		pci 0x1635
++device.name		JCM35
+
+ vendor.id		pci 0x1e26
++vendor.name		Fujitsu Client Computing Limited
+
+ vendor.id		pci 0x1e36
++vendor.name		Shanghai Enflame Technology Co. Ltd
+
+ vendor.id		pci 0x1e36
+&device.id		pci 0x0001
++device.name		T10 [CloudBlazer]
+
  vendor.id		pci 0x1e38
-+vendor.name		Thinci, Inc
++vendor.name		Blaize, Inc
 
  vendor.id		pci 0x1e3d
 +vendor.name		Burlywood, Inc
+
+ vendor.id		pci 0x1e49
++vendor.name		Yangtze Memory Technologies Co.,Ltd
+
+ vendor.id		pci 0x1e4c
++vendor.name		GSI Technology
+
+ vendor.id		pci 0x1e4c
+&device.id		pci 0x0010
++device.name		Gemini [ Lida ]
+
+ vendor.id		pci 0x1e4c
+&device.id		pci 0x0010
+&subvendor.id		pci 0x1e4c
+&subdevice.id		pci 0x0120
++subdevice.name		SE120
+
+ vendor.id		pci 0x1e57
++vendor.name		Beijing Panyi Technology Co., Ltd
+
+ vendor.id		pci 0x1e57
+&device.id		pci 0x0100
++device.name		The device has already been deleted.
+
+ vendor.id		pci 0x1e57
+&device.id		pci 0x0100
+&subvendor.id		pci 0x0000
+&subdevice.id		pci 0x0100
++subdevice.name		PY8800 64GB Accelerator
+
+ vendor.id		pci 0x1e6b
++vendor.name		Axiado Corp.
+
+ vendor.id		pci 0x1e85
++vendor.name		Heitec AG
+
+ vendor.id		pci 0x1e89
++vendor.name		ID Quantique SA
+
+ vendor.id		pci 0x1e89
+&device.id		pci 0x0002
++device.name		Quantis-PCIe-40M
+
+ vendor.id		pci 0x1e89
+&device.id		pci 0x0003
++device.name		Quantis-PCIe-240M
+
+ vendor.id		pci 0x1e94
++vendor.name		Calian SED
 
  vendor.id		pci 0x1fc0
 +vendor.name		Ascom (Finland) Oy
@@ -104559,6 +107889,13 @@
 
  vendor.id		pci 0x21c3
 +vendor.name		21st Century Computer Corp.
+
+ vendor.id		pci 0x22b8
++vendor.name		Flex-Logix Technologies
+
+ vendor.id		pci 0x22b8
+&device.id		pci 0x22a0
++device.name		Flex Logix InferX X1 Inference Accelerator
 
  vendor.id		pci 0x22db
 +vendor.name		Missing Link Electronics, Inc.
@@ -106285,6 +109622,26 @@
 +device.name		DD-42924I5-300 (ARINC 429 Data Bus)
 
  vendor.id		pci 0x4ddc
+&device.id		pci 0x0300
++device.name		SB-3620 Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x0340
++device.name		SB-3623 Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x0400
++device.name		SB-3622 Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x0500
++device.name		SB-3621 Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x0510
++device.name		SB-3624 Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
 &device.id		pci 0x0801
 +device.name		BU-65570I1 MIL-STD-1553 Test and Simulation
 
@@ -106347,6 +109704,22 @@
  vendor.id		pci 0x4ddc
 &device.id		pci 0x0b04
 +device.name		BU-65569I4 MIL-STD-1553 Data Bus
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x0d01
++device.name		SB-3641 Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x0d10
++device.name		SB-365x Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x2f00
++device.name		SB-3642 Motion Feedback Device
+
+ vendor.id		pci 0x4ddc
+&device.id		pci 0x3000
++device.name		SB-3644 Motion Feedback Device
 
  vendor.id		pci 0x5045
 +vendor.name		University of Toronto
@@ -108001,6 +111374,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x0126
 &subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x21ce
++subdevice.name		ThinkPad T420
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0126
+&subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x21cf
 +subdevice.name		ThinkPad T520
 
@@ -108121,6 +111500,12 @@
 +subdevice.name		Zenbook Prime UX31A
 
  vendor.id		pci 0x8086
+&device.id		pci 0x0154
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16bf
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x0155
 +device.name		Xeon E3-1200 v2/3rd Gen Core processor PCI Express Root Port
 
@@ -108215,6 +111600,12 @@
 +subdevice.name		N56VZ
 
  vendor.id		pci 0x8086
+&device.id		pci 0x0166
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16c1
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x016a
 +device.name		Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
 
@@ -108231,6 +111622,42 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x0176
 +device.name		3rd Gen Core processor Graphics Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02a4
++device.name		Comet Lake SPI (flash) Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02a6
++device.name		Comet Lake North Peak
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02d3
++device.name		Comet Lake SATA AHCI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02e0
++device.name		Comet Lake Management Engine Interface
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02e8
++device.name		Serial IO I2C Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02e9
++device.name		Comet Lake Serial IO I2C Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02f0
++device.name		Wireless-AC 9462
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02f9
++device.name		Comet Lake Thermal Subsytem
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02fc
++device.name		Comet Lake Integrated Sensor Solution
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0309
@@ -108547,6 +111974,90 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x061f
 +device.name		80303 I/O Processor
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x068d
++device.name		Comet Lake LPC Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06a3
++device.name		Comet Lake PCH SMBus Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06a4
++device.name		Comet Lake PCH SPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06a8
++device.name		Comet Lake PCH Serial IO UART Host Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06a9
++device.name		Comet Lake PCH Serial IO UART Host Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06aa
++device.name		Comet Lake PCH Serial IO SPI Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06ab
++device.name		Comet Lake PCH Serial IO SPI Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06ac
++device.name		Comet Lake PCI Express Root Port #21
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06b0
++device.name		Comet Lake PCI Express Root Port #9
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06c0
++device.name		Comet Lake PCI Express Root Port #17
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06c8
++device.name		Comet Lake PCH cAVS
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06e0
++device.name		Comet Lake HECI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06e8
++device.name		Comet Lake PCH Serial IO I2C Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06e9
++device.name		Comet Lake PCH Serial IO I2C Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06ea
++device.name		Comet Lake PCH Serial IO I2C Controller #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06eb
++device.name		Comet Lake PCH Serial IO I2C Controller #3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06ed
++device.name		Comet Lake USB 3.1 xHCI Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06ef
++device.name		Comet Lake PCH Shared SRAM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06f0
++device.name		Wi-Fi 6 AX201
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06f9
++device.name		Comet Lake PCH Thermal Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06fb
++device.name		Comet Lake PCH Serial IO SPI Controller #2
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0700
@@ -110093,8 +113604,104 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x0a54
 &subvendor.id		pci 0x108e
+&subdevice.id		pci 0x4879
++subdevice.name		NVMe PCIe 3.0 SSD v2 6.4TB AIC (P4618)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x108e
 &subdevice.id		pci 0x487a
 +subdevice.name		NVMe PCIe 3.0 SSD v2 6.4TB 2.5-inch (P4610)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0227
++subdevice.name		NVMe Datacenter SSD [3DNAND] 1.6TB 2.5" U.2 (P4600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0228
++subdevice.name		NVMe Datacenter SSD [3DNAND] 2.0TB 2.5" U.2 (P4600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0229
++subdevice.name		NVMe Datacenter SSD [3DNAND] 3.2TB 2.5" U.2 (P4600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x022b
++subdevice.name		NVMe Datacenter SSD [3DNAND] 1.0TB 2.5" U.2 (P4500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x022c
++subdevice.name		NVMe Datacenter SSD [3DNAND] 2.0TB 2.5" U.2 (P4500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x022d
++subdevice.name		NVMe Datacenter SSD [3DNAND] 4.0TB 2.5" U.2 (P4500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0231
++subdevice.name		NVMe Datacenter SSD [3DNAND] 0.5TB 2.5" U.2 (P4501)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0232
++subdevice.name		NVMe Datacenter SSD [3DNAND] 1.0TB 2.5" U.2 (P4501)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0233
++subdevice.name		NVMe Datacenter SSD [3DNAND] 2.0TB 2.5" U.2 (P4501)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0258
++subdevice.name		NVMe Datacenter SSD [3DNAND] 1.6TB 2.5" U.2 (P4610)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x025a
++subdevice.name		NVMe Datacenter SSD [3DNAND] 3.2TB 2.5" U.2 (P4610)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x025b
++subdevice.name		NVMe Datacenter SSD [3DNAND] 1.0TB 2.5" U.2 (P4510)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x025c
++subdevice.name		NVMe Datacenter SSD [3DNAND] 2.0TB 2.5" U.2 (P4510)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x025d
++subdevice.name		NVMe Datacenter SSD [3DNAND] 4.0TB 2.5" U.2 (P4510)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x025e
++subdevice.name		NVMe Datacenter SSD [3DNAND] 8.0TB 2.5" U.2 (P4510)
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0a54
@@ -110137,6 +113744,30 @@
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x026c
 +subdevice.name		NVMe Datacenter SSD [3DNAND] 4.0TB AIC (P4500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x4702
++subdevice.name		Thinksystem Intel P4500 NVMe U.2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x4704
++subdevice.name		Thinksystem Intel P4500 NVMe AIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x4712
++subdevice.name		Thinksystem Intel P4600 NVMe U.2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0a54
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x4714
++subdevice.name		Thinksystem Intel P4600 NVMe AIC
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0a54
@@ -110607,12 +114238,28 @@
 +device.name		Crystal Well Integrated Graphics Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x0d4c
++device.name		Ethernet Connection (11) I219-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0d4d
++device.name		Ethernet Connection (11) I219-V
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x0d4e
 +device.name		Ethernet Connection (10) I219-LM
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0d4f
 +device.name		Ethernet Connection (10) I219-V
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0d53
++device.name		Ethernet Connection (12) I219-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0d55
++device.name		Ethernet Connection (12) I219-V
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0d58
@@ -112135,6 +115782,10 @@
 +subdevice.name		PRO/1000 MT Mobile Connection
 
  vendor.id		pci 0x8086
+&device.id		pci 0x101f
++device.name		Ethernet Controller V710 for 5GBASE-T
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1026
 +device.name		82545GM Gigabit Ethernet Controller
 
@@ -112481,6 +116132,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1050
 +device.name		82562EZ 10/100 Ethernet Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1050
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1050
@@ -115477,12 +119134,22 @@
 +subdevice.name		P8P67 Deluxe Motherboard
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1503
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x161c
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1507
 +device.name		Ethernet Express Module X520-P2
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1508
 +device.name		82598EB Gigabit BX Network Connection
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1509
++device.name		82580 Gigabit Network Connection
 
  vendor.id		pci 0x8086
 &device.id		pci 0x150a
@@ -115851,6 +119518,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1521
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0003
++subdevice.name		Ethernet Network Adapter I350-T4 for OCP NIC 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1521
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x00a1
 +subdevice.name		Ethernet Server Adapter I350-T4
 
@@ -115859,6 +119532,18 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x00a2
 +subdevice.name		Ethernet Server Adapter I350-T2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1521
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x00a3
++subdevice.name		Ethernet Network Adapter I350-T4 for OCP NIC 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1521
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x00aa
++subdevice.name		Ethernet Network Adapter I350-T4 for OCP NIC 3.0
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1521
@@ -116082,6 +119767,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1528
+&subvendor.id		pci 0x15d9
+&subdevice.id		pci 0x0734
++subdevice.name		AOC-STG-I2T
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1528
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x1073
 +subdevice.name		ThinkServer X540-T2 AnyFabric
@@ -116185,6 +119876,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x0003
 +subdevice.name		Ethernet I210-T1 GbE NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1533
+&subvendor.id		pci 0x1059
+&subdevice.id		pci 0x0180
++subdevice.name		RD10019 1GbE interface
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1533
@@ -116460,6 +120157,18 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1563
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02b2
++subdevice.name		X550-TX 10 Gig LOM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1563
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02b3
++subdevice.name		X550-TX 10 Gig LOM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1563
 &subvendor.id		pci 0x1170
 &subdevice.id		pci 0x0001
 +subdevice.name		Intel Ethernet Controller X550-T2 OCP card
@@ -116505,6 +120214,12 @@
 &subvendor.id		pci 0x193d
 &subdevice.id		pci 0x1009
 +subdevice.name		560T-L
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1563
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1011
++subdevice.name		UN-NIC-ETH563T-sL-2P
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1563
@@ -116793,6 +120508,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1572
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0011
++subdevice.name		Ethernet Network Adapter X710-2 for OCP NIC 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0012
++subdevice.name		Ethernet Network Adapter X710-4 for OCP NIC 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x0013
 +subdevice.name		Ethernet 10G 2P X710 OCP
 
@@ -116811,6 +120538,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1572
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x00a1
++subdevice.name		Ethernet Network Adapter X710-2 for OCP NIC 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x00a2
++subdevice.name		Ethernet Network Adapter X710-4 for OCP NIC 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4005
 +subdevice.name		Ethernet Controller X710 for 10GbE SFP+
 
@@ -116825,6 +120564,10 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4007
 +subdevice.name		Ethernet Controller X710 for 10GbE SFP+
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1574
++device.name		Ethernet Controller XL710 Emulation
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1575
@@ -116941,6 +120684,12 @@
 &subvendor.id		pci 0x108e
 &subdevice.id		pci 0x7b1b
 +subdevice.name		10 Gb/40 Gb Ethernet Adapter
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1583
+&subvendor.id		pci 0x108e
+&subdevice.id		pci 0x7b1d
++subdevice.name		10Gb/40Gb Ethernet Adapter
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1583
@@ -117077,6 +120826,18 @@
 +subdevice.name		Ethernet 10/20Gb 2-port 660M Adapter
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1588
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0000
++subdevice.name		Ethernet Network Adapter XXV710
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1588
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02b4
++subdevice.name		Ethernet Network Adapter XXV710 OCP 2.0
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1589
 +device.name		Ethernet Controller X710/X557-AT 10GBASE-T
 
@@ -117147,6 +120908,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x158a
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0000
++subdevice.name		Ethernet Controller XXV710 for 25GbE backplane
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158a
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x000a
 +subdevice.name		Ethernet 25G 2P XXV710 Mezz
 
@@ -117165,6 +120932,72 @@
 &subvendor.id		pci 0x1137
 &subdevice.id		pci 0x0225
 +subdevice.name		Ethernet Network Adapter XXV710
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02b4
++subdevice.name		Ethernet Network Adapter XXV710 OCP 2.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x0230
++subdevice.name		Single Port 25 Gigabit Ethernet PCI Express Server Adapter (PE325G1I71)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x0231
++subdevice.name		Single Port 25 Gigabit Ethernet PCI Express Server Adapter (PE325G1I71EU)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x0234
++subdevice.name		Dual Port 25 Gigabit Ethernet PCI Express Server Adapter (PE325G2I71)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x0235
++subdevice.name		Dual Port 25 Gigabit Ethernet PCI Express Server Adapter (PE325G2I71EU)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x0238
++subdevice.name		Quad Port 25 Gigabit Ethernet PCI Express Server Adapter (PE325G4I71L)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x0239
++subdevice.name		Quad Port 25 Gigabit Ethernet PCI Express Server Adapter (PE325G4I71LEU)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x023a
++subdevice.name		Quad Port 25 Gigabit Ethernet PCI Express Server Adapter (PE31625G4I71L)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1374
+&subdevice.id		pci 0x023b
++subdevice.name		Quad Port 25 Gigabit Ethernet PCI Express Server Adapter (PE31625G4I71LEU)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0000
++subdevice.name		Ethernet Network Adapter XXV710-2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x1590
+&subdevice.id		pci 0x0253
++subdevice.name		Ethernet 10/25/Gb 2-port 661SFP28 Adapter
 
  vendor.id		pci 0x8086
 &device.id		pci 0x158b
@@ -117229,6 +121062,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x158b
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000a
++subdevice.name		Ethernet 25G 2P XXV710 OCP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000c
++subdevice.name		Ethernet Network Adapter XXV710-DA2 for OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x158b
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4001
 +subdevice.name		Ethernet Network Adapter XXV710-2
 
@@ -117241,8 +121086,140 @@
 +device.name		Ethernet Controller E810-C for QSFP
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02bf
++subdevice.name		E810CQDA2 2x100 GbE QSFP28 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0002
++subdevice.name		Ethernet Network Adapter E810-C-Q2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0004
++subdevice.name		Ethernet Network Adapter E810-C-Q2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0005
++subdevice.name		Ethernet Network Adapter E810-C-Q1 for OCP3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0006
++subdevice.name		Ethernet Network Adapter E810-C-Q2 for OCP3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0009
++subdevice.name		Ethernet Network Adapter E810-C-Q1
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1593
 +device.name		Ethernet Controller E810-C for SFP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02c3
++subdevice.name		E810XXVDA4 4x25/10 GbE SFP28 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0002
++subdevice.name		Ethernet Network Adapter E810-L-2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0005
++subdevice.name		Ethernet Network Adapter E810-XXV-4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0006
++subdevice.name		Ethernet Network Adapter E810-XXV-4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0007
++subdevice.name		Ethernet Network Adapter E810-XXV-4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0008
++subdevice.name		Ethernet Network Adapter E810-XXV-2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0009
++subdevice.name		Ethernet Network Adapter E810-XXV-2 for OCP 2.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1599
++device.name		Ethernet Controller E810-XXV for backplane
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159a
++device.name		Ethernet Controller E810-XXV for QSFP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
++device.name		Ethernet Controller E810-XXV for SFP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02be
++subdevice.name		E810XXVDA2 2x25/10 GbE SFP28 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0001
++subdevice.name		Ethernet 25G 2P E810-XXV OCP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0002
++subdevice.name		Ethernet 25G 2P E810-XXV Adapter
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0003
++subdevice.name		Ethernet Network Adapter E810-XXV-2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0005
++subdevice.name		Ethernet Network Adapter E810-XXV-2 for OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4001
++subdevice.name		Ethernet Network Adapter E810-XXV-2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4002
++subdevice.name		Ethernet Network Adapter E810-XXV-2 for OCP 3.0
 
  vendor.id		pci 0x8086
 &device.id		pci 0x15a0
@@ -117371,6 +121348,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x15c0
 +device.name		JHL6240 Thunderbolt 3 Bridge (Low Power) [Alpine Ridge LP 2016]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15c1
++device.name		JHL6240 Thunderbolt 3 USB 3.1 Controller (Low Power) [Alpine Ridge LP 2016]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x15c2
@@ -117573,12 +121554,60 @@
 +device.name		JHL7540 Thunderbolt 3 USB Controller [Titan Ridge DD 2018]
 
  vendor.id		pci 0x8086
+&device.id		pci 0x15f4
++device.name		Ethernet Connection (15) I219-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15f5
++device.name		Ethernet Connection (15) I219-V
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x15f6
 +device.name		I210 Gigabit Ethernet Connection
 
  vendor.id		pci 0x8086
+&device.id		pci 0x15f9
++device.name		Ethernet Connection (14) I219-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15fa
++device.name		Ethernet Connection (14) I219-V
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15fb
++device.name		Ethernet Connection (13) I219-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15fc
++device.name		Ethernet Connection (13) I219-V
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x15ff
 +device.name		Ethernet Controller X710 for 10GBASE-T
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0000
++subdevice.name		X710TLG GbE RJ45 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02c1
++subdevice.name		X710T2LG 2x10 GbE RJ45 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02c2
++subdevice.name		X710T4LG 4x10 GbE RJ45 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0000
++subdevice.name		Ethernet Network Adapter X710-TL
 
  vendor.id		pci 0x8086
 &device.id		pci 0x15ff
@@ -117627,6 +121656,36 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x0008
 +subdevice.name		Ethernet 10G 4P X710-T4L-t OCP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0009
++subdevice.name		Ethernet Network Adapter X710-T4L for OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000a
++subdevice.name		Ethernet Network Adapter X710-T4L for OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000b
++subdevice.name		Ethernet Network Adapter X710-T2L for OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000c
++subdevice.name		Ethernet Network Adapter X710-T2L for OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000f
++subdevice.name		Ethernet Network Adapter X710-T2L for OCP 3.0
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1600
@@ -117787,6 +121846,14 @@
 +device.name		Ethernet Adaptive Virtual Function
 
  vendor.id		pci 0x8086
+&device.id		pci 0x18a0
++device.name		C4xxx Series QAT
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x18a1
++device.name		C4XXX Series QAT Virtual Function
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1900
 +device.name		Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 
@@ -117805,6 +121872,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1903
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1903
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06dc
 +subdevice.name		Latitude E7470
 
@@ -117813,6 +121886,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06e4
 +subdevice.name		XPS 15 9550
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1903
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1903
@@ -117875,6 +121954,12 @@
 +device.name		Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 
  vendor.id		pci 0x8086
+&device.id		pci 0x190c
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x190f
 +device.name		Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 
@@ -117889,8 +121974,20 @@
 +subdevice.name		XPS 15 9550
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1910
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1911
-+device.name		Xeon E3-1200 v5/v6 / E3-1500 v5 / 6th/7th Gen Core Processor Gaussian Mixture Model
++device.name		Xeon E3-1200 v5/v6 / E3-1500 v5 / 6th/7th/8th Gen Core Processor Gaussian Mixture Model
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1911
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1911
@@ -117945,6 +122042,12 @@
 +device.name		Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Imaging Unit
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1919
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x191b
 +device.name		HD Graphics 530
 
@@ -117955,12 +122058,24 @@
 +subdevice.name		XPS 15 9550
 
  vendor.id		pci 0x8086
+&device.id		pci 0x191b
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x191d
 +device.name		HD Graphics P530
 
  vendor.id		pci 0x8086
 &device.id		pci 0x191e
 +device.name		HD Graphics 515
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x191e
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
 &device.id		pci 0x191f
@@ -118165,6 +122280,54 @@
 +device.name		80960RN (i960RN) Microprocessor
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1980
++device.name		Atom Processor C3000 Series System Agent
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a1
++device.name		Atom Processor C3000 Series Error Registers
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a2
++device.name		Atom Processor C3000 Series Root Complex Event Collector
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a3
++device.name		Atom Processor C3000 Series Integrated QAT Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a4
++device.name		Atom Processor C3000 Series PCI Express Root Port #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a5
++device.name		Atom Processor C3000 Series PCI Express Root Port #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a6
++device.name		Atom Processor C3000 Series PCI Express Root Port #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a7
++device.name		Atom Processor C3000 Series PCI Express Root Port #3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a8
++device.name		Atom Processor C3000 Series PCI Express Root Port #4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19a9
++device.name		Atom Processor C3000 Series PCI Express Root Port #5
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19aa
++device.name		Atom Processor C3000 Series PCI Express Root Port #6
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19ab
++device.name		Atom Processor C3000 Series PCI Express Root Port #7
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x19ac
 +device.name		Atom Processor C3000 Series SMBus Contoller - Host
 
@@ -118253,8 +122416,44 @@
 +device.name		Atom Processor C3000 Series USB 3.0 xHCI Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x19d1
++device.name		Atom Processor C3000 Series Integrated LAN Root Port #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19d2
++device.name		Atom Processor C3000 Series Integrated LAN Root Port #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19d3
++device.name		Atom Processor C3000 Series ME HECI 1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19d4
++device.name		Atom Processor C3000 Series ME HECI 2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19d5
++device.name		Atom Processor C3000 Series ME KT Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19d6
++device.name		Atom Processor C3000 Series ME HECI 3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19d8
++device.name		Atom Processor C3000 Series HSUART Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x19dc
 +device.name		Atom Processor C3000 Series LPC or eSPI
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19dd
++device.name		Atom Processor C3000 Series Primary to Side Band (P2SB) Bridge
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x19de
++device.name		Atom Processor C3000 Series Power Management Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x19df
@@ -118267,6 +122466,22 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x19e2
 +device.name		Atom Processor C3000 Series QuickAssist Technology
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1a1c
++device.name		Ethernet Connection (17) I219-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1a1d
++device.name		Ethernet Connection (17) I219-V
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1a1e
++device.name		Ethernet Connection (16) I219-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1a1f
++device.name		Ethernet Connection (16) I219-V
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1a21
@@ -119486,6 +123701,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e03
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e2
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e03
 &subvendor.id		pci 0x144d
 &subdevice.id		pci 0xc652
 +subdevice.name		NP300E5C series laptop
@@ -119554,6 +123775,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e10
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e9
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e10
 &subvendor.id		pci 0x144d
 &subdevice.id		pci 0xc652
 +subdevice.name		NP300E5C series laptop
@@ -119589,6 +123816,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1e14
 +device.name		7 Series/C210 Series Chipset Family PCI Express Root Port 3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e14
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e9
++subdevice.name		LIFEBOOK E752
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e16
@@ -119654,6 +123887,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e1e
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e9
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e1e
 &subvendor.id		pci 0x1849
 &subdevice.id		pci 0x1e1e
 +subdevice.name		Motherboard
@@ -119700,6 +123939,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e20
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x1757
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e20
 &subvendor.id		pci 0x144d
 &subdevice.id		pci 0xc652
 +subdevice.name		NP300E5C series laptop
@@ -119737,6 +123982,12 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x84ca
 +subdevice.name		P8 series motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e22
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e6
++subdevice.name		LIFEBOOK E752
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e22
@@ -119794,6 +124045,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e26
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e8
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e26
 &subvendor.id		pci 0x144d
 &subdevice.id		pci 0xc652
 +subdevice.name		NP300E5C series laptop
@@ -119831,6 +124088,12 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x84ca
 +subdevice.name		P8 series motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e2d
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e8
++subdevice.name		LIFEBOOK E752
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e2d
@@ -119886,6 +124149,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e31
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16ee
++subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e31
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x21f3
 +subdevice.name		ThinkPad T430
@@ -119927,6 +124196,12 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x84ca
 +subdevice.name		P8 series motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e3a
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16ea
++subdevice.name		LIFEBOOK E752
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e3a
@@ -120081,6 +124356,12 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x1517
 +subdevice.name		Zenbook Prime UX31A
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1e59
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x16e0
++subdevice.name		LIFEBOOK E752
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1e5a
@@ -120377,6 +124658,10 @@
 +device.name		Sky Lake-E Non-Transparent Bridge Registers
 
  vendor.id		pci 0x8086
+&device.id		pci 0x201d
++device.name		Volume Management Device NVMe RAID Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x2020
 +device.name		Sky Lake-E DMI3 Registers
 
@@ -120575,6 +124860,10 @@
 +device.name		Sky Lake-E PCU Registers
 
  vendor.id		pci 0x8086
+&device.id		pci 0x2088
++device.name		Sky Lake-E DDRIO Registers
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x208d
 +device.name		Sky Lake-E CHA Registers
 
@@ -120601,6 +124890,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x225e
 +device.name		Xeon Phi coprocessor 31S1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2262
++device.name		Xeon Phi coprocessor 7220
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2280
@@ -120660,7 +124953,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x22b0
-+device.name		Atom/Celeron/Pentium Processor x5-E8000/J3xxx/N3xxx Series PCI Configuration Registers
++device.name		Atom/Celeron/Pentium Processor x5-E8000/J3xxx/N3xxx Integrated Graphics Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x22b1
@@ -121390,6 +125683,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2448
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2448
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x902d
 +subdevice.name		VAIO VGN-NR120E
@@ -121827,6 +126126,12 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x844d
 +subdevice.name		P8 series motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x244e
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8534
++subdevice.name		ASUS B85-PLUS
 
  vendor.id		pci 0x8086
 &device.id		pci 0x244e
@@ -123543,6 +127848,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x24d2
 &subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24d2
+&subvendor.id		pci 0x1014
 &subdevice.id		pci 0x02dd
 +subdevice.name		eServer xSeries server mainboard
 
@@ -123679,6 +127990,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x24d3
 &subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24d3
+&subvendor.id		pci 0x1014
 &subdevice.id		pci 0x02dd
 +subdevice.name		eServer xSeries server mainboard
 
@@ -123787,6 +128104,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x24d4
 +device.name		82801EB/ER (ICH5/ICH5R) USB UHCI Controller #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24d4
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
 
  vendor.id		pci 0x8086
 &device.id		pci 0x24d4
@@ -123938,6 +128261,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x24d5
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24d5
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x0168
 +subdevice.name		Precision Workstation 670 Mainboard
@@ -124033,6 +128362,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x24d7
 +device.name		82801EB/ER (ICH5/ICH5R) USB UHCI Controller #3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24d7
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
 
  vendor.id		pci 0x8086
 &device.id		pci 0x24d7
@@ -124157,6 +128492,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x24db
 +device.name		82801EB/ER (ICH5/ICH5R) IDE Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24db
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
 
  vendor.id		pci 0x8086
 &device.id		pci 0x24db
@@ -124307,6 +128648,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x24dd
 &subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24dd
+&subvendor.id		pci 0x1014
 &subdevice.id		pci 0x02dd
 +subdevice.name		eServer xSeries server mainboard
 
@@ -124427,6 +128774,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x24de
 +device.name		82801EB/ER (ICH5/ICH5R) USB UHCI Controller #4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24de
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
 
  vendor.id		pci 0x8086
 &device.id		pci 0x24de
@@ -124971,6 +129324,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2572
 +device.name		82865G Integrated Graphics Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2572
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x0287
++subdevice.name		ThinkCentre S50
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2572
@@ -127424,6 +131783,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2701
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x200a
++subdevice.name		Express Flash NVMe [Optane] 375GB AIC (P4800X)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2701
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x3904
 +subdevice.name		NVMe Datacenter SSD [Optane] x4 AIC (P4800X)
@@ -127433,6 +131798,16 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x3905
 +subdevice.name		NVMe Datacenter SSD [Optane] 15mm 2.5" U.2 (P4800X)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2723
++device.name		Wi-Fi 6 AX200
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2723
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x2723
++subdevice.name		Wireless AX200
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2770
@@ -127832,7 +132207,7 @@
 &device.id		pci 0x27b8
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM Motherboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM Motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27b8
@@ -127992,7 +132367,7 @@
 &device.id		pci 0x27c0
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM Motherboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM Motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27c0
@@ -128250,7 +132625,7 @@
 &device.id		pci 0x27c8
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM,P5LD2-VM Mainboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM, P5LD2-VM Mainboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27c8
@@ -128398,7 +132773,7 @@
 &device.id		pci 0x27c9
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM,P5LD2-VM Mainboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM, P5LD2-VM Mainboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27c9
@@ -128546,7 +132921,7 @@
 &device.id		pci 0x27ca
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM,P5LD2-VM Mainboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM, P5LD2-VM Mainboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27ca
@@ -128682,7 +133057,7 @@
 &device.id		pci 0x27cb
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM,P5LD2-VM Mainboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM, P5LD2-VM Mainboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27cb
@@ -128830,7 +133205,7 @@
 &device.id		pci 0x27cc
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM,P5LD2-VM Mainboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM, P5LD2-VM Mainboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27cc
@@ -129167,6 +133542,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x27d8
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8249
++subdevice.name		P5B-MX/WiFi-AP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x27d8
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8290
 +subdevice.name		P5KPL-VM Motherboard
 
@@ -129346,7 +133727,7 @@
 &device.id		pci 0x27da
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM Motherboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM Motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27da
@@ -129524,7 +133905,7 @@
 &device.id		pci 0x27df
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x8179
-+subdevice.name		P5KPL-VM Motherboard
++subdevice.name		P5B-MX/WiFi-AP, P5KPL-VM Motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x27df
@@ -129665,6 +134046,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30d9
 +subdevice.name		Presario C700
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2815
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2815
@@ -129882,6 +134269,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2829
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2829
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x9005
 +subdevice.name		Vaio VGN-FZ260E
@@ -129981,6 +134374,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2830
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2830
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x81ec
 +subdevice.name		P5B
 
@@ -130071,6 +134470,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30d9
 +subdevice.name		Presario C700
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2831
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2831
@@ -130169,6 +134574,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2832
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2832
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x81ec
 +subdevice.name		P5B
 
@@ -130257,6 +134668,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30cc
 +subdevice.name		Pavilion dv6700
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2834
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2834
@@ -130349,6 +134766,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2835
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2835
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x81ec
 +subdevice.name		P5B
 
@@ -130433,6 +134856,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30d9
 +subdevice.name		Presario C700
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2836
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2836
@@ -130525,6 +134954,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x283a
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x283a
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x81ec
 +subdevice.name		P5B
 
@@ -130595,6 +135030,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x283e
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x283e
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x81ec
 +subdevice.name		P5B
 
@@ -130658,6 +135099,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x283f
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x283f
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x902d
 +subdevice.name		VAIO VGN-NR120E
@@ -130686,6 +135133,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2841
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2841
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x902d
 +subdevice.name		VAIO VGN-NR120E
@@ -130708,6 +135161,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2843
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2843
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x902d
 +subdevice.name		VAIO VGN-NR120E
@@ -130727,6 +135186,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2845
 +device.name		82801H (ICH8 Family) PCI Express Port 4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2845
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2845
@@ -130863,6 +135328,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x284b
 &subvendor.id		pci 0x1043
+&subdevice.id		pci 0x17f3
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x284b
+&subvendor.id		pci 0x1043
 &subdevice.id		pci 0x81ec
 +subdevice.name		P5B
 
@@ -130972,6 +135443,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2850
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2850
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x9005
 +subdevice.name		Vaio VGN-FZ260E
@@ -130999,6 +135476,10 @@
 &subvendor.id		pci 0xe4bf
 &subdevice.id		pci 0xcc47
 +subdevice.name		CCG-RUMBA
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x28c0
++device.name		Volume Management Device NVMe RAID Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2912
@@ -132413,12 +136894,24 @@
 +device.name		82946GZ/PL/GL Memory Controller Hub
 
  vendor.id		pci 0x8086
+&device.id		pci 0x2970
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x823b
++subdevice.name		P5B-MX/WiFi-AP
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x2971
 +device.name		82946GZ/PL/GL PCI Express Root Port
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2972
 +device.name		82946GZ/GL Integrated Graphics Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2972
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x823b
++subdevice.name		P5B-MX/WiFi-AP
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2973
@@ -132884,6 +137377,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2a00
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1017
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2a00
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x9005
 +subdevice.name		Vaio VGN-FZ260E
@@ -132958,6 +137457,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2a02
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x14e2
++subdevice.name		X58LE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2a02
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x902d
 +subdevice.name		VAIO VGN-NR120E
@@ -133007,6 +137512,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30d9
 +subdevice.name		Presario C700
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2a03
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x14e2
++subdevice.name		X58LE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2a03
@@ -134825,7 +139336,17 @@
 +device.name		Dual Band Wireless-AC 3165 Plus Bluetooth
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3166
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4210
++subdevice.name		Dual Band Wireless-AC 3165
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x3184
++device.name		UHD Graphics 605
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3185
 +device.name		UHD Graphics 605
 
  vendor.id		pci 0x8086
@@ -134837,12 +139358,20 @@
 +device.name		Celeron/Pentium Silver Processor NorthPeak
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3192
++device.name		Gemini Lake P2SB
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x3197
 +device.name		Celeron/Pentium Silver Processor PCI-default ISA-bridge
 
  vendor.id		pci 0x8086
 &device.id		pci 0x319a
 +device.name		Celeron/Pentium Silver Processor Trusted Execution Engine Interface
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31a2
++device.name		Celeron/Pentium Silver Processor Integrated Sensor Solution
 
  vendor.id		pci 0x8086
 &device.id		pci 0x31ac
@@ -134885,8 +139414,36 @@
 +device.name		Celeron/Pentium Silver Processor Gaussian Mixture Model
 
  vendor.id		pci 0x8086
+&device.id		pci 0x31d6
++device.name		Gemini Lake PCI Express Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31d7
++device.name		Gemini Lake PCI Express Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31d8
++device.name		Gemini Lake PCI Express Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31d9
++device.name		Gemini Lake PCI Express Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31da
++device.name		Gemini Lake PCI Express Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31db
++device.name		Gemini Lake PCI Express Root Port
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x31ee
 +device.name		Celeron/Pentium Silver Processor Serial IO UART Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31f0
++device.name		Gemini Lake Host Bridge
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3200
@@ -135279,8 +139836,16 @@
 +device.name		Ice Lake-LP Serial IO I2c Controller #5
 
  vendor.id		pci 0x8086
+&device.id		pci 0x34c8
++device.name		Smart Sound Technology Audio Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x34d3
 +device.name		Ice Lake-LP SATA Controller [AHCI mode]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x34e0
++device.name		Management Engine Interface
 
  vendor.id		pci 0x8086
 &device.id		pci 0x34e8
@@ -135301,6 +139866,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x34ed
 +device.name		Ice Lake-LP USB 3.1 xHCI Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x34f0
++device.name		Killer Wi-Fi 6 AX1650i 160MHz Wireless Network Adapter (201NGW)
 
  vendor.id		pci 0x8086
 &device.id		pci 0x34f8
@@ -136265,6 +140834,10 @@
 +device.name		C62x Chipset QuickAssist Technology
 
  vendor.id		pci 0x8086
+&device.id		pci 0x37cc
++device.name		Ethernet Connection X722
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x37cd
 +device.name		Ethernet Virtual Function 700 Series
 
@@ -136283,6 +140856,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x4023
 +subdevice.name		Intel Ethernet Connection X722 for 10GbE backplane
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x37ce
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x4025
++subdevice.name		Ethernet Connection X722 for 10GbE backplane
 
  vendor.id		pci 0x8086
 &device.id		pci 0x37cf
@@ -136381,8 +140960,20 @@
 +subdevice.name		Ethernet Connection X722 for 1GbE
 
  vendor.id		pci 0x8086
+&device.id		pci 0x37d1
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x4024
++subdevice.name		Ethernet Connection X722 for 1GbE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x37d2
 +device.name		Ethernet Connection X722 for 10GBASE-T
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x37d2
+&subvendor.id		pci 0x1059
+&subdevice.id		pci 0x0180
++subdevice.name		RD10019 10GbE interface
 
  vendor.id		pci 0x8086
 &device.id		pci 0x37d2
@@ -136421,6 +141012,18 @@
 +subdevice.name		Ethernet Connection X722 for 10GBASE-T
 
  vendor.id		pci 0x8086
+&device.id		pci 0x37d2
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x4024
++subdevice.name		Ethernet Connection X722 for 10GBASE-T
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x37d2
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x4025
++subdevice.name		Ethernet Connection X722 for 10GBASE-T
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x37d3
 +device.name		Ethernet Connection X722 for 10GbE SFP+
 
@@ -136440,6 +141043,12 @@
 &device.id		pci 0x37d3
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x4021
++subdevice.name		Ethernet Connection X722 for 10GbE SFP+
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x37d3
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x4025
 +subdevice.name		Ethernet Connection X722 for 10GbE SFP+
 
  vendor.id		pci 0x8086
@@ -137710,6 +142319,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3b42
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1521
++subdevice.name		EliteBook 8540p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3b42
 &subvendor.id		pci 0x144d
 &subdevice.id		pci 0xc06a
 +subdevice.name		R730 Laptop
@@ -138257,8 +142872,22 @@
 +device.name		8th Gen Core 4-core Desktop Processor Host Bridge/DRAM Registers [Coffee Lake S]
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3e1f
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x5000
++subdevice.name		Z370 AORUS Gaming K3-CF
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x3e30
 +device.name		8th Gen Core 8-core Desktop Processor Host Bridge/DRAM Registers [Coffee Lake S]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3e33
++device.name		8th/9th Gen Core Processor Host Bridge/DRAM Registers [Coffee Lake]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3e34
++device.name		Coffee Lake HOST and DRAM Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e81
@@ -138281,8 +142910,18 @@
 +device.name		UHD Graphics 630 (Desktop)
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3e92
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x3e93
 +device.name		UHD Graphics 610
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3e96
++device.name		HD Graphics P630
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e98
@@ -138309,6 +142948,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x3ec2
 +device.name		8th Gen Core Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3ec2
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3ec2
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8694
++subdevice.name		PRIME H310M-D
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3ec4
@@ -138959,6 +143610,14 @@
 +device.name		Turbo Memory Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x467f
++device.name		Volume Management Device NVMe RAID Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4c3d
++device.name		Volume Management Device NVMe RAID Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x5001
 +device.name		LE80578
 
@@ -139192,6 +143851,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x5904
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x5904
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x2247
 +subdevice.name		ThinkPad T570
@@ -139219,6 +143884,12 @@
 +device.name		Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 
  vendor.id		pci 0x8086
+&device.id		pci 0x590f
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a68
++subdevice.name		B250 KRAIT GAMING (MS-7A68)
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x5910
 +device.name		Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 
@@ -139243,6 +143914,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x5916
 +device.name		HD Graphics 620
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x5916
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x1094
++subdevice.name		Aspire E5-575G
 
  vendor.id		pci 0x8086
 &device.id		pci 0x5916
@@ -139305,6 +143982,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x5a84
 +device.name		Celeron N3350/Pentium N4200/Atom E3900 Series Integrated Graphics Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x5a85
++device.name		HD Graphics 500
 
  vendor.id		pci 0x8086
 &device.id		pci 0x5a88
@@ -139853,6 +144534,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x6f54
 +device.name		Xeon Processor D Family QuickAssist Technology
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x6f55
++device.name		Xeon Processor D Family QuickAssist Technology Virtual Fuction
 
  vendor.id		pci 0x8086
 &device.id		pci 0x6f60
@@ -140639,6 +145324,10 @@
 +subdevice.name		CC7/CR7/CP7/VC7/VP7/VR7 mainboard
 
  vendor.id		pci 0x8086
+&device.id		pci 0x7360
++device.name		XMM7360 LTE Advanced Modem
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x7600
 +device.name		82372FB PIIX5 ISA
 
@@ -140977,6 +145666,54 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x8819
 +device.name		Platform Controller Hub EG20T IEEE 1588 Hardware Assist
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a0d
++device.name		Ice Lake Thunderbolt 3 NHI #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a13
++device.name		Ice Lake Thunderbolt 3 USB Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a17
++device.name		Ice Lake Thunderbolt 3 NHI #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a1d
++device.name		Ice Lake Thunderbolt 3 PCI Express Root Port #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a1f
++device.name		Ice Lake Thunderbolt 3 PCI Express Root Port #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a21
++device.name		Ice Lake Thunderbolt 3 PCI Express Root Port #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a23
++device.name		Ice Lake Thunderbolt 3 PCI Express Root Port #3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a51
++device.name		Intel Iris Plus Graphics G7 (Ice Lake)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a52
++device.name		Iris Plus Graphics G7
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a56
++device.name		Iris Plus Graphics G1 (Ice Lake)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a5a
++device.name		Iris Plus Graphics G4 (Ice Lake)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a5c
++device.name		Intel Iris Plus Graphics G4 (Ice Lake)
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c00
@@ -141921,6 +146658,70 @@
 +device.name		Integrated RAID
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9a09
++device.name		11th Gen Core Processor PCIe Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a0b
++device.name		Volume Management Device NVMe RAID Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a13
++device.name		Tiger Lake-LP Thunderbolt USB Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a14
++device.name		11th Gen Core Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a1b
++device.name		Tiger Lake-LP Thunderbolt NHI #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a1d
++device.name		Tiger Lake-LP Thunderbolt NHI #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a23
++device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a25
++device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a27
++device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a29
++device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a33
++device.name		Tiger Lake Trace Hub
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a49
++device.name		UHD Graphics
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b41
++device.name		UHD Graphics
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b54
++device.name		10th Gen Core Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b64
++device.name		10th Gen Core Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9bc4
++device.name		UHD Graphics
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9c00
 +device.name		8 Series SATA Controller 1 [IDE mode]
 
@@ -142364,6 +147165,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d03
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d03
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06dc
 +subdevice.name		Latitude E7470
@@ -142460,6 +147267,18 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d21
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d21
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d21
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06dc
 +subdevice.name		Latitude E7470
@@ -142497,6 +147316,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d23
 +device.name		Sunrise Point-LP SMBus
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d23
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d23
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d23
@@ -142566,6 +147397,18 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d2f
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d2f
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d2f
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06dc
 +subdevice.name		Latitude E7470
@@ -142603,6 +147446,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d31
 +device.name		Sunrise Point-LP Thermal subsystem
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d31
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d31
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d31
@@ -142647,12 +147502,40 @@
 +subdevice.name		B51-80 Laptop
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9d32
++device.name		CSI-2 Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d32
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9d35
 +device.name		Sunrise Point-LP Integrated Sensor Hub
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9d35
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9d3a
 +device.name		Sunrise Point-LP CSME HECI #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d3a
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d3a
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d3a
@@ -142717,6 +147600,16 @@
 +subdevice.name		B51-80 Laptop
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9d46
++device.name		LPC/eSPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d46
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9d48
 +device.name		Sunrise Point-LP LPC Controller
 
@@ -142762,6 +147655,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d58
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d58
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x2247
 +subdevice.name		ThinkPad T570
@@ -142775,6 +147674,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d60
 +device.name		Sunrise Point-LP Serial IO I2C Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d60
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x115f
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d60
@@ -142805,8 +147716,20 @@
 +device.name		Sunrise Point-LP Serial IO I2C Controller #1
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9d61
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9d62
 +device.name		Sunrise Point-LP Serial IO I2C Controller #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d62
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d63
@@ -142827,6 +147750,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d70
 +device.name		Sunrise Point-LP HD Audio
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d70
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06d6
++subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d70
@@ -142858,6 +147787,18 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d71
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x1094
++subdevice.name		Acer Aspire E5-575G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d71
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x224f
++subdevice.name		ThinkPad X1 Carbon 5th Gen
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d71
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x225d
 +subdevice.name		ThinkPad T480
@@ -142885,6 +147826,14 @@
 +device.name		Cannon Point-LP PCI Express Root Port #9
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9db1
++device.name		Cannon Point-LP PCI Express Root Port #10
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9db2
++device.name		Cannon Point-LP PCI Express Root Port #1
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9db4
 +device.name		Cannon Point-LP PCI Express Root Port #13
 
@@ -142907,6 +147856,18 @@
 +device.name		Cannon Point-LP PCI Express Root Port #5
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9dbe
++device.name		Cannon Point-LP PCI Express Root Port #7
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9dbf
++device.name		Cannon Point PCI Express Root Port #8
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9dc5
++device.name		Cannon Point-LP Serial IO I2C Host Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9dc8
 +device.name		Cannon Point-LP High Definition Audio Controller
 
@@ -142923,6 +147884,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9de0
 +device.name		Cannon Point-LP MEI Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9de3
++device.name		Cannon Point-LP Keyboard and Text (KT) Redirection
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9de8
@@ -142955,6 +147920,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9df0
 +device.name		Cannon Point-LP CNVi [Wireless-AC]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9df5
++device.name		BayHubTech Integrated SD controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9df9
@@ -143069,6 +148038,90 @@
 +device.name		Atom Processor D4xx/D5xx/N4xx/N5xx CHAPS counter
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa082
++device.name		Tiger Lake-LP LPC Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0a3
++device.name		Tiger Lake-LP SMBus Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0a4
++device.name		Tiger Lake-LP SPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0a6
++device.name		Tiger Lake-LP Trace Hub
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0a8
++device.name		Tiger Lake-LP Serial IO UART Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0a9
++device.name		Tiger Lake-LP Serial IO UART Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0ab
++device.name		Tiger Lake-LP Serial IO SPI Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0b0
++device.name		Tiger Lake-LP PCI Express Root Port #9
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0bf
++device.name		Tiger Lake-LP PCI Express Root Port #8
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0c5
++device.name		Tiger Lake-LP Serial IO I2C Controller #4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0c6
++device.name		Tiger Lake-LP Serial IO I2C Controller #5
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0c8
++device.name		Tiger Lake-LP Smart Sound Technology Audio Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0e0
++device.name		Tiger Lake-LP Management Engine Interface
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0e8
++device.name		Tiger Lake-LP Serial IO I2C Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0e9
++device.name		Tiger Lake-LP Serial IO I2C Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0ea
++device.name		Tiger Lake-LP Serial IO I2C Controller #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0eb
++device.name		Tiger Lake-LP Serial IO I2C Controller #3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0ed
++device.name		Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0ef
++device.name		Tiger Lake-LP Shared SRAM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0f0
++device.name		Wi-Fi 6 AX201
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0fc
++device.name		Tiger Lake-LP Integrated Sensor Hub
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa102
 +device.name		Q170/Q150/B150/H170/H110/Z170/CM236 Chipset SATA Controller [AHCI Mode]
 
@@ -143081,6 +148134,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06e4
 +subdevice.name		XPS 15 9550
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa103
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa105
@@ -143177,6 +148236,12 @@
 +subdevice.name		XPS 15 9550
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa121
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa122
 +device.name		Sunrise Point-H cAVS
 
@@ -143189,6 +148254,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06e4
 +subdevice.name		XPS 15 9550
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa123
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa124
@@ -143229,6 +148300,12 @@
 +subdevice.name		XPS 15 9550
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa12f
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa130
 +device.name		100 Series/C230 Series Chipset Family USB Device Controller (OTG)
 
@@ -143241,6 +148318,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06e4
 +subdevice.name		XPS 15 9550
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa131
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa133
@@ -143259,6 +148342,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06e4
 +subdevice.name		XPS 15 9550
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa13a
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa13b
@@ -143343,6 +148432,12 @@
 +subdevice.name		XPS 15 9550
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa14e
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa14f
 +device.name		Sunrise Point-H LPC Controller
 
@@ -143421,6 +148516,12 @@
 +subdevice.name		XPS 15 9550
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa160
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa161
 +device.name		100 Series/C230 Series Chipset Family Serial IO I2C Controller #1
 
@@ -143461,6 +148562,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0xa170
 +device.name		100 Series/C230 Series Chipset Family HD Audio Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa170
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e4
++subdevice.name		XPS 15 9550
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa170
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x825b
++subdevice.name		OMEN-17-w001nv
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa171
@@ -143977,6 +149090,12 @@
 +device.name		H370 Chipset LPC/eSPI Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa304
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa305
 +device.name		Z390 Chipset LPC/eSPI Controller
 
@@ -143985,16 +149104,44 @@
 +device.name		Q370 Chipset LPC/eSPI Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa309
++device.name		Cannon Point-LP LPC Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa30c
 +device.name		QM370 Chipset LPC/eSPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa30d
++device.name		HM470 Chipset LPC/eSPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa30e
++device.name		Cannon Lake LPC Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa323
 +device.name		Cannon Lake PCH SMBus Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa323
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa324
 +device.name		Cannon Lake PCH SPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa324
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa328
++device.name		Cannon Lake PCH Serial IO UART Host Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa32c
@@ -144097,8 +149244,20 @@
 +device.name		Cannon Lake PCH cAVS
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa348
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa352
 +device.name		Cannon Lake PCH SATA AHCI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa352
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa353
@@ -144109,8 +149268,18 @@
 +device.name		Cannon Lake PCH HECI Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa360
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa363
 +device.name		Cannon Lake PCH Active Management Technology - SOL
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa364
++device.name		Cannon Lake PCH HECI Controller #2
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa368
@@ -144133,6 +149302,12 @@
 +device.name		Cannon Lake PCH USB 3.1 xHCI Host Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa36d
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa36f
 +device.name		Cannon Lake PCH Shared SRAM
 
@@ -144143,6 +149318,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0xa379
 +device.name		Cannon Lake PCH Thermal Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa379
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0869
++subdevice.name		Vostro 3470
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa620
@@ -144329,14 +149510,123 @@
 +device.name		SSD Pro 7600p/760p/E 6100p Series
 
  vendor.id		pci 0x8086
-&device.id		pci 0xf1a8
-+device.name		SSDPEKNW020T8 [660p, 2TB]
+&device.id		pci 0xf1a6
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x390b
++subdevice.name		Intel Corporation SSD Pro 7600p/760p/E 6100p Series [NVM Express]
 
  vendor.id		pci 0x8086
 &device.id		pci 0xf1a8
-&subvendor.id		pci 0x8086
-&subdevice.id		pci 0x390d
-+subdevice.name		SSDPEKNW020T8 [660p, 2TB]
++device.name		SSD 660P Series
+
+ vendor.id		pci 0x8088
++vendor.name		Beijing Wangxun Technology Co., Ltd.
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0101
++device.name		WX1860A2 Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0101
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0201
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200T
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0102
++device.name		WX1860A2S Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0102
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0210
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200T-S
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0103
++device.name		WX1860A4 Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0103
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0401
++subdevice.name		Qual-Port Ethernet Network Adaptor SF400T
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0103
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0440
++subdevice.name		Qual-Port Ethernet Network Adaptor SF400-OCP
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0104
++device.name		WX1860A4S Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0104
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0410
++subdevice.name		Qual-Port Ethernet Network Adaptor SF400T-S
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0105
++device.name		WX1860AL2 Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0105
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0202
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200HT
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0106
++device.name		WX1860AL2S Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0106
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0220
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200HT-S
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0107
++device.name		WX1860AL4 Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0107
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0402
++subdevice.name		Qual-Port Ethernet Network Adaptor SF400HT
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0108
++device.name		WX1860AL4S Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0108
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0420
++subdevice.name		Qual-Port Ethernet Network Adaptor SF400HT-S
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x1001
++device.name		Ethernet Controller RP1000 for 10GbE SFP+
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x1001
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0000
++subdevice.name		Ethernet Network Adaptor RP1000 for 10GbE SFP+
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x2001
++device.name		Ethernet Controller RP2000 for 10GbE SFP+
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x2001
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x2000
++subdevice.name		Ethernet Network Adaptor RP2000 for 10GbE SFP+
 
  vendor.id		pci 0x80ee
 +vendor.name		InnoTek Systemberatung GmbH
@@ -146084,6 +151374,24 @@
 
  vendor.id		pci 0x9005
 &device.id		pci 0x028f
+&subvendor.id		pci 0x105b
+&subdevice.id		pci 0x1211
++subdevice.name		HBA 8238-16i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x105b
+&subdevice.id		pci 0x1321
++subdevice.name		HBA 8242-24i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x13fe
+&subdevice.id		pci 0x8312
++subdevice.name		SKY-9200 MIC-8312BridgeB
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
 &subvendor.id		pci 0x152d
 &subdevice.id		pci 0x8a22
 +subdevice.name		QS-8204-8i
@@ -146111,6 +151419,126 @@
 &subvendor.id		pci 0x152d
 &subdevice.id		pci 0x8a37
 +subdevice.name		QS-8242-24i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x8460
++subdevice.name		HBA H460-M1
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x8461
++subdevice.name		HBA H460-B1
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0xc460
++subdevice.name		RAID P460-M2
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0xc461
++subdevice.name		RAID P460-B2
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0xf460
++subdevice.name		RAID P460-M4
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0xf461
++subdevice.name		RAID P460-B4
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd227
++subdevice.name		SmartROC-HD SR465C-M 4G
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd228
++subdevice.name		SmartROC SR455C-M 2G
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd229
++subdevice.name		SmartIOC SR155-M
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd22a
++subdevice.name		SmartIOC-HD SR765-M
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd22b
++subdevice.name		SmartROC-e SR455C-ME 4G
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd22c
++subdevice.name		SmartROC SR455C-M 4G
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0045
++subdevice.name		SMART-HBA 8242-24i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0046
++subdevice.name		RAID 8236-16i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0047
++subdevice.name		RAID 8240-24i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0048
++subdevice.name		SMART-HBA 8238-16i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x004a
++subdevice.name		PM8222-SHBA
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x004b
++subdevice.name		RAID PM8204-2GB
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x004c
++subdevice.name		RAID PM8204-4GB
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x004f
++subdevice.name		PM8222-HBA
 
  vendor.id		pci 0x9005
 &device.id		pci 0x028f
@@ -147048,6 +152476,10 @@
 +device.name		DeckLink 8K Pro
 
  vendor.id		pci 0xbdbd
+&device.id		pci 0xa14e
++device.name		DeckLink Quad HDMI Recorder
+
+ vendor.id		pci 0xbdbd
 &device.id		pci 0xa1ff
 +device.name		eGPU RX580
 
@@ -147057,11 +152489,18 @@
  vendor.id		pci 0xc0a9
 +vendor.name		Micron/Crucial Technology
 
+ vendor.id		pci 0xc0a9
+&device.id		pci 0x2263
++device.name		P1 NVMe PCIe SSD
+
  vendor.id		pci 0xc0de
 +vendor.name		Motorola
 
  vendor.id		pci 0xc0fe
 +vendor.name		Motion Engineering, Inc.
+
+ vendor.id		pci 0xca3b
++vendor.name		Cambrionix Ltd.
 
  vendor.id		pci 0xca50
 +vendor.name		Varian Australia Pty Ltd
@@ -147264,6 +152703,21 @@
  vendor.id		pci 0xd161
 &device.id		pci 0xb410
 +device.name		Wildcard B410 quad-BRI card
+
+ vendor.id		pci 0xd209
++vendor.name		Ultimarc
+
+ vendor.id		pci 0xd209
+&device.id		pci 0x1500
++device.name		PAC Drive
+
+ vendor.id		pci 0xd209
+&device.id		pci 0x15a2
++device.name		SpinTrak
+
+ vendor.id		pci 0xd209
+&device.id		pci 0x1601
++device.name		AimTrak
 
  vendor.id		pci 0xd4d4
 +vendor.name		Dy4 Systems Inc
@@ -147952,16 +153406,56 @@
 +device.name		Xena LS/SD-22-DA/SD-DA
 
  vendor.id		pci 0xf1d0
+&device.id		pci 0xdafe
++device.name		Corvid 1
+
+ vendor.id		pci 0xf1d0
 &device.id		pci 0xdaff
 +device.name		KONA LHi
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb00
++device.name		IoExpress
 
  vendor.id		pci 0xf1d0
 &device.id		pci 0xdb01
 +device.name		Corvid22
 
  vendor.id		pci 0xf1d0
+&device.id		pci 0xdb02
++device.name		Kona 3G
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb03
++device.name		Corvid 3G
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb04
++device.name		Kona 3G QUAD
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb05
++device.name		Kona LHe+
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb06
++device.name		IoXT
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb07
++device.name		Kona 3G P2P
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb08
++device.name		Kona 3G QUAD P2P
+
+ vendor.id		pci 0xf1d0
 &device.id		pci 0xdb09
 +device.name		Corvid 24
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xdb11
++device.name		T-Tap
 
  vendor.id		pci 0xf1d0
 &device.id		pci 0xdcaf
@@ -147972,6 +153466,22 @@
 +device.name		Xena HD-DA
 
  vendor.id		pci 0xf1d0
+&device.id		pci 0xeb07
++device.name		Io4K
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb0a
++device.name		Io4K UFC
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb0b
++device.name		Kona 4
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb0c
++device.name		Kona 4 UFC
+
+ vendor.id		pci 0xf1d0
 &device.id		pci 0xeb0d
 +device.name		Corvid 88
 
@@ -147980,8 +153490,50 @@
 +device.name		Corvid 44
 
  vendor.id		pci 0xf1d0
+&device.id		pci 0xeb16
++device.name		Corvid HEVC
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb16
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x1049
++subdevice.name		Corvid HEVC M31
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb18
++device.name		Corvid HB-R
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb1a
++device.name		Kona IP 1SFP
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb1c
++device.name		Kona IP 2SFP
+
+ vendor.id		pci 0xf1d0
 &device.id		pci 0xeb1d
++device.name		Io4KPlus
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb1e
++device.name		IoIP
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb1f
 +device.name		Kona 5
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb23
++device.name		Kona 1
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb24
++device.name		Kona HDMI
+
+ vendor.id		pci 0xf1d0
+&device.id		pci 0xeb25
++device.name		Corvid 44 12g
 
  vendor.id		pci 0xf1d0
 &device.id		pci 0xefac
@@ -148721,6 +154273,11 @@
 
  baseclass.id		0x00c
 &subclass.id		0x03
+&progif.id		0x40
++progif.name		USB4 Host Interface
+
+ baseclass.id		0x00c
+&subclass.id		0x03
 &progif.id		0x80
 +progif.name		Unspecified
 
@@ -148873,6 +154430,10 @@
  baseclass.id		0x012
 &subclass.id		0x00
 +subclass.name		Processing accelerators
+
+ baseclass.id		0x012
+&subclass.id		0x01
++subclass.name		AI Inference Accelerator
 
  baseclass.id		0x013
 +baseclass.name		Non-Essential Instrumentation

--- a/src/ids/src/usb
+++ b/src/ids/src/usb
@@ -62,12 +62,22 @@
 &device.id		usb 0x1844
 +device.name		Mayflash GameCube Controller
 
+ vendor.id		usb 0x0080
++vendor.name		Assmann Electronic GmbH
+
+ vendor.id		usb 0x0080
+&device.id		usb 0xa001
++device.name		Digitus DA-71114 SATA
+
  vendor.id		usb 0x0085
 +vendor.name		Boeye Technology Co., Ltd.
 
  vendor.id		usb 0x0085
 &device.id		usb 0x0600
 +device.name		eBook Reader
+
+ vendor.id		usb 0x0102
++vendor.name		miniSTREAK
 
  vendor.id		usb 0x0105
 +vendor.name		Trust International B.V.
@@ -185,6 +195,10 @@
  vendor.id		usb 0x03e7
 &device.id		usb 0x2485
 +device.name		Movidius MyriadX
+
+ vendor.id		usb 0x03e7
+&device.id		usb 0xf63b
++device.name		Myriad VPU [Movidius Neural Compute Stick]
 
  vendor.id		usb 0x03e8
 +vendor.name		EndPoints, Inc.
@@ -567,6 +581,14 @@
 +device.name		Airspy HF+
 
  vendor.id		usb 0x03eb
+&device.id		usb 0xff01
++device.name		WootingOne
+
+ vendor.id		usb 0x03eb
+&device.id		usb 0xff02
++device.name		WootingTwo
+
+ vendor.id		usb 0x03eb
 &device.id		usb 0xff07
 +device.name		Tux Droid fish dongle
 
@@ -645,6 +667,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0x002a
 +device.name		LaserJet P1102
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x0053
++device.name		DeskJet 2620 All-in-One Printer
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x0101
@@ -863,6 +889,10 @@
 +device.name		Bluetooth Interface
 
  vendor.id		usb 0x03f0
+&device.id		usb 0x052a
++device.name		LaserJet M1212nf MFP
+
+ vendor.id		usb 0x03f0
 &device.id		usb 0x0601
 +device.name		ScanJet 6300c
 
@@ -873,6 +903,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0x0605
 +device.name		ScanJet 2200c
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x0610
++device.name		Z24i Monitor Hub
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x0611
@@ -961,6 +995,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0x0924
 +device.name		Modular Smartcard Keyboard
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x0941
++device.name		X500 Optical Mouse
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x094a
@@ -1507,6 +1545,10 @@
 +device.name		LP1965 19" Monitor Hub
 
  vendor.id		usb 0x03f0
+&device.id		usb 0x2441
++device.name		Prime G2 [2AP18AA]
+
+ vendor.id		usb 0x03f0
 &device.id		usb 0x2502
 +device.name		PhotoSmart 7700 series
 
@@ -1785,6 +1827,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0x3611
 +device.name		PSC 2410 PhotoSmart
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x3612
++device.name		Officejet Pro 8000 A809
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x3617
@@ -2519,8 +2565,16 @@
 +device.name		PhotoSmart R837
 
  vendor.id		usb 0x03f0
+&device.id		usb 0x942a
++device.name		LaserJet Pro M12a
+
+ vendor.id		usb 0x03f0
 &device.id		usb 0x9502
 +device.name		PhotoSmart R840 series
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x952a
++device.name		LaserJet Pro M12w
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x9602
@@ -2649,6 +2703,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0xc202
 +device.name		PhotoSmart 8200 series
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0xc211
++device.name		Deskjet 2540 series
 
  vendor.id		usb 0x03f0
 &device.id		usb 0xc302
@@ -3004,6 +3062,10 @@
 +device.name		MGTimer - MGCC (Vic) Timing System
 
  vendor.id		usb 0x0403
+&device.id		usb 0x8348
++device.name		FT232BM [SIENNA Serial Interface]
+
+ vendor.id		usb 0x0403
 &device.id		usb 0x8370
 +device.name		7 Port Hub
 
@@ -3014,6 +3076,10 @@
  vendor.id		usb 0x0403
 &device.id		usb 0x8372
 +device.name		FT8U100AX Serial Port
+
+ vendor.id		usb 0x0403
+&device.id		usb 0x8508
++device.name		Selectronic SP PRO
 
  vendor.id		usb 0x0403
 &device.id		usb 0x87d0
@@ -3070,6 +3136,10 @@
  vendor.id		usb 0x0403
 &device.id		usb 0x9e90
 +device.name		Marvell OpenRD Base/Client
+
+ vendor.id		usb 0x0403
+&device.id		usb 0x9f08
++device.name		CIB-1894 Conclusion SmartLink Box:
 
  vendor.id		usb 0x0403
 &device.id		usb 0x9f80
@@ -3673,6 +3743,10 @@
  vendor.id		usb 0x0408
 &device.id		usb 0x3001
 +device.name		Optical Touch Screen
+
+ vendor.id		usb 0x0408
+&device.id		usb 0xa060
++device.name		HD Webcam
 
  vendor.id		usb 0x0409
 +vendor.name		NEC Corp.
@@ -4397,6 +4471,22 @@
 +device.name		805 Photo Printer
 
  vendor.id		usb 0x040a
+&device.id		usb 0x4035
++device.name		7000 Photo Printer
+
+ vendor.id		usb 0x040a
+&device.id		usb 0x4037
++device.name		7010 Photo Printer
+
+ vendor.id		usb 0x040a
+&device.id		usb 0x4038
++device.name		7015 Photo Printer
+
+ vendor.id		usb 0x040a
+&device.id		usb 0x404d
++device.name		8810 Photo Printer
+
+ vendor.id		usb 0x040a
 &device.id		usb 0x404f
 +device.name		305 Photo Printer
 
@@ -4456,6 +4546,10 @@
 +device.name		Func MS-3 gaming mouse [WT6573F MCU]
 
  vendor.id		usb 0x040b
+&device.id		usb 0x2000
++device.name		wired Keyboard [Dynex DX-WRK1401]
+
+ vendor.id		usb 0x040b
 &device.id		usb 0x2367
 +device.name		Human Interface Device [HP CalcPad 200 Calculator and Numeric Keypad]
 
@@ -4484,6 +4578,10 @@
  vendor.id		usb 0x040d
 &device.id		usb 0x3184
 +device.name		VNT VT6656 USB-802.11 Wireless LAN Adapter
+
+ vendor.id		usb 0x040d
+&device.id		usb 0x340f
++device.name		Audinst HUD-mx2
 
  vendor.id		usb 0x040d
 &device.id		usb 0x6205
@@ -4990,6 +5088,10 @@
 &device.id		usb 0x7723
 +device.name		SD Card Reader
 
+ vendor.id		usb 0x0416
+&device.id		usb 0xc141
++device.name		Barcode Scanner
+
  vendor.id		usb 0x0417
 +vendor.name		Symbios Logic
 
@@ -5006,6 +5108,10 @@
  vendor.id		usb 0x0419
 &device.id		usb 0x0600
 +device.name		Desktop Wireless 6000
+
+ vendor.id		usb 0x0419
+&device.id		usb 0x2694
++device.name		Laila
 
  vendor.id		usb 0x0419
 &device.id		usb 0x3001
@@ -5865,6 +5971,10 @@
 +device.name		C7-00 (Media transfer mode)
 
  vendor.id		usb 0x0421
+&device.id		usb 0x03c2
++device.name		Sim
+
+ vendor.id		usb 0x0421
 &device.id		usb 0x03cd
 +device.name		C7-00 (Nokia Suite mode)
 
@@ -6231,7 +6341,7 @@
 +device.name		Andromeda Hub
 
  vendor.id		usb 0x0424
-+vendor.name		Standard Microsystems Corp.
++vendor.name		Microchip Technology, Inc. (formerly SMSC)
 
  vendor.id		usb 0x0424
 &device.id		usb 0x0001
@@ -6282,10 +6392,6 @@
 +device.name		USB 2.0 Hub
 
  vendor.id		usb 0x0424
-&device.id		usb 0x2504
-+device.name		USB 2.0 Hub
-
- vendor.id		usb 0x0424
 &device.id		usb 0x2507
 +device.name		hub
 
@@ -6330,6 +6436,10 @@
 +device.name		HTC Hub Controller
 
  vendor.id		usb 0x0424
+&device.id		usb 0x2807
++device.name		Hub
+
+ vendor.id		usb 0x0424
 &device.id		usb 0x3fcc
 +device.name		RME MADIface
 
@@ -6346,6 +6456,98 @@
 +device.name		Ultra Fast Media Reader
 
  vendor.id		usb 0x0424
+&device.id		usb 0x4712
++device.name		USB4712 high-speed hub
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4713
++device.name		USB4715 high-speed hub (2 ports disabled)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4714
++device.name		USB4715 high-speed hub (1 port disabled)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4715
++device.name		USB4715 high-speed hub
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4910
++device.name		USB491x hub integrated functions (primary)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4912
++device.name		USB4912 high-speed hub (1 port disabled)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4914
++device.name		USB4914 high-speed hub
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4916
++device.name		USB4916 high-speed hub
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4920
++device.name		USB491x hub integrated functions (secondary)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4925
++device.name		USB4925 high-speed hub (primary upstream)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4927
++device.name		USB4927 high-speed hub (primary upstream)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4931
++device.name		USB4925/4927 high-speed hub (secondary upstream)
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4940
++device.name		USB47xx/49xx hub integrated WinUSB
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4942
++device.name		USB47xx/49xx hub integrated I2S audio port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4943
++device.name		USB47xx/49xx hub integrated I2S audio + HID port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4944
++device.name		USB47xx/49xx hub integrated serial port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4946
++device.name		USB47xx/49xx hub integrated serial + I2S audio port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x4947
++device.name		USB47xx/49xx hub integrated serial + I2S audio + HID port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x494a
++device.name		USB47xx/49xx hub integrated WinUSB + I2S audio port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x494b
++device.name		USB47xx/49xx hub integrated WinUSB + I2S audio + HID port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x494c
++device.name		USB47xx/49xx hub integrated WinUSB + serial port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x494e
++device.name		USB47xx/49xx hub integrated WinUSB + serial + I2S audio port
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x494f
++device.name		USB47xx/49xx hub integrated WinUSB + serial + I2S audio + HID port
+
+ vendor.id		usb 0x0424
 &device.id		usb 0x5434
 +device.name		Hub
 
@@ -6355,6 +6557,10 @@
 
  vendor.id		usb 0x0424
 &device.id		usb 0x5744
++device.name		Hub
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x5807
 +device.name		Hub
 
  vendor.id		usb 0x0424
@@ -6482,6 +6688,10 @@
 +device.name		3-button Mouse
 
  vendor.id		usb 0x0430
+&device.id		usb 0x0502
++device.name		Panasonic CF-19 HID Touch Panel
+
+ vendor.id		usb 0x0430
 &device.id		usb 0x100e
 +device.name		24.1" LCD Monitor v4 / FID-638 Mouse
 
@@ -6564,6 +6774,10 @@
 
  vendor.id		usb 0x0438
 +vendor.name		Advanced Micro Devices, Inc.
+
+ vendor.id		usb 0x0438
+&device.id		usb 0x7900
++device.name		Root Hub
 
  vendor.id		usb 0x0439
 +vendor.name		Voice Technologies Group
@@ -7000,6 +7214,10 @@
 +device.name		X422
 
  vendor.id		usb 0x043d
+&device.id		usb 0x0091
++device.name		Laser Printer E232
+
+ vendor.id		usb 0x043d
 &device.id		usb 0x0093
 +device.name		X5250
 
@@ -7169,6 +7387,10 @@
  vendor.id		usb 0x043e
 &device.id		usb 0x3004
 +device.name		TWFM-B003D 802.11abgn Wireless Module [Broadcom BCM43236B]
+
+ vendor.id		usb 0x043e
+&device.id		usb 0x3009
++device.name		VC400
 
  vendor.id		usb 0x043e
 &device.id		usb 0x3101
@@ -7484,6 +7706,10 @@
 +device.name		F16 MFD 2
 
  vendor.id		usb 0x044f
+&device.id		usb 0xb365
++device.name		UbiSoft UbiConnect
+
+ vendor.id		usb 0x044f
 &device.id		usb 0xb603
 +device.name		force feedback Wheel
 
@@ -7526,6 +7752,10 @@
 +vendor.name		Texas Instruments, Inc.
 
  vendor.id		usb 0x0451
+&device.id		usb 0x0422
++device.name		TUSB422 Port Controller with Power Delivery
+
+ vendor.id		usb 0x0451
 &device.id		usb 0x1234
 +device.name		Bluetooth Device
 
@@ -7538,8 +7768,20 @@
 +device.name		TUSB2040/2070 Hub
 
  vendor.id		usb 0x0451
+&device.id		usb 0x16a2
++device.name		CC Debugger
+
+ vendor.id		usb 0x0451
 &device.id		usb 0x16a6
 +device.name		BM-USBD1 BlueRobin RF heart rate sensor receiver
+
+ vendor.id		usb 0x0451
+&device.id		usb 0x16a8
++device.name		CC2531 ZigBee
+
+ vendor.id		usb 0x0451
+&device.id		usb 0x16ae
++device.name		CC2531 Dongle
 
  vendor.id		usb 0x0451
 &device.id		usb 0x2036
@@ -7650,8 +7892,48 @@
 +device.name		TI-84 Plus Silver Calculator
 
  vendor.id		usb 0x0451
+&device.id		usb 0xe00e
++device.name		TI-89 Titanium Presentation Link
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe00f
++device.name		TI-84 Plus Presentation Link
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe010
++device.name		TI SmartPad Keyboard
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe011
++device.name		Nspire CAS+ prototype
+
+ vendor.id		usb 0x0451
 &device.id		usb 0xe012
 +device.name		TI-Nspire Calculator
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe013
++device.name		Network Bridge
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe01c
++device.name		Data Collection Sled [Nspire Lab Cradle, Nspire Datatracker Cradle]
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe01e
++device.name		Nspire CX Navigator Access Point
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe01f
++device.name		Python Adapter (firmware install mode)
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe020
++device.name		Python Adapter
+
+ vendor.id		usb 0x0451
+&device.id		usb 0xe022
++device.name		Nspire CX II
 
  vendor.id		usb 0x0451
 &device.id		usb 0xf430
@@ -7763,6 +8045,10 @@
 +device.name		Easy Mouse+
 
  vendor.id		usb 0x0458
+&device.id		usb 0x0007
++device.name		Trackbar Emotion
+
+ vendor.id		usb 0x0458
 &device.id		usb 0x000b
 +device.name		NetMouse Wheel(P+U)
 
@@ -7869,6 +8155,10 @@
  vendor.id		usb 0x0458
 &device.id		usb 0x011b
 +device.name		NetScroll T220
+
+ vendor.id		usb 0x0458
+&device.id		usb 0x0186
++device.name		Genius DX-120 Mouse
 
  vendor.id		usb 0x0458
 &device.id		usb 0x1001
@@ -7999,6 +8289,10 @@
 +device.name		MaxFire G-12U Vibration
 
  vendor.id		usb 0x0458
+&device.id		usb 0x301c
++device.name		Genius MaxFighter F-16U
+
+ vendor.id		usb 0x0458
 &device.id		usb 0x301d
 +device.name		Genius MaxFire MiniPad
 
@@ -8017,6 +8311,18 @@
  vendor.id		usb 0x0458
 &device.id		usb 0x5004
 +device.name		G-pen Tablet
+
+ vendor.id		usb 0x0458
+&device.id		usb 0x5005
++device.name		Genius EasyPen M406
+
+ vendor.id		usb 0x0458
+&device.id		usb 0x5012
++device.name		Genius EasyPen M406W
+
+ vendor.id		usb 0x0458
+&device.id		usb 0x5014
++device.name		Genius EasyPen 340
 
  vendor.id		usb 0x0458
 &device.id		usb 0x505e
@@ -8560,6 +8866,10 @@
  vendor.id		usb 0x045e
 &device.id		usb 0x00d1
 +device.name		Optical Mouse with Tilt Wheel
+
+ vendor.id		usb 0x045e
+&device.id		usb 0x00d2
++device.name		Notebook Optical Mouse with Tilt Wheel
 
  vendor.id		usb 0x045e
 &device.id		usb 0x00da
@@ -9406,6 +9716,10 @@
 +device.name		2.4GHz Transceiver v8.0 used by mouse Wireless Desktop 900
 
  vendor.id		usb 0x045e
+&device.id		usb 0x07b6
++device.name		Comfort Curve Keyboard 3000
+
+ vendor.id		usb 0x045e
 &device.id		usb 0x07b9
 +device.name		Wired Keyboard 200
 
@@ -9428,6 +9742,10 @@
  vendor.id		usb 0x045e
 &device.id		usb 0x07fd
 +device.name		Nano Transceiver 1.1
+
+ vendor.id		usb 0x045e
+&device.id		usb 0x0810
++device.name		LifeCam HD-3000
 
  vendor.id		usb 0x045e
 &device.id		usb 0x0900
@@ -9736,6 +10054,10 @@
 +device.name		Dell N889 Optical Mouse
 
  vendor.id		usb 0x0461
+&device.id		usb 0x4d8a
++device.name		HP Multimedia Keyboard
+
+ vendor.id		usb 0x0461
 &device.id		usb 0x4d91
 +device.name		Laser mouse M-D16DL
 
@@ -9758,6 +10080,14 @@
  vendor.id		usb 0x0461
 &device.id		usb 0x4e04
 +device.name		Lenovo Keyboard KB1021
+
+ vendor.id		usb 0x0461
+&device.id		usb 0x4e22
++device.name		Dell Mouse, 2 Buttons, Modell: MS111-P
+
+ vendor.id		usb 0x0461
+&device.id		usb 0x4e6f
++device.name		Acer Wired Keyboard Model KBAY211
 
  vendor.id		usb 0x0463
 +vendor.name		MGE UPS Systems
@@ -9865,6 +10195,10 @@
  vendor.id		usb 0x046a
 &device.id		usb 0x010d
 +device.name		MX-Board 3.0 Keyboard
+
+ vendor.id		usb 0x046a
+&device.id		usb 0x0180
++device.name		Strait 3.0
 
  vendor.id		usb 0x046a
 &device.id		usb 0xb090
@@ -10492,6 +10826,10 @@
 +device.name		G933 Wireless Headset Dongle
 
  vendor.id		usb 0x046d
+&device.id		usb 0x0a5d
++device.name		G933 Headset Battery Charger
+
+ vendor.id		usb 0x046d
 &device.id		usb 0x0a66
 +device.name		[G533 Wireless Headset Dongle]
 
@@ -11008,6 +11346,10 @@
 +device.name		Gaming Mouse G300
 
  vendor.id		usb 0x046d
+&device.id		usb 0xc247
++device.name		G100S Optical Gaming Mouse
+
+ vendor.id		usb 0x046d
 &device.id		usb 0xc248
 +device.name		G105 Gaming Keyboard
 
@@ -11200,6 +11542,10 @@
 +device.name		Corded Keyboard K280e
 
  vendor.id		usb 0x046d
+&device.id		usb 0xc32b
++device.name		G910 Orion Spark Mechanical Keyboard
+
+ vendor.id		usb 0x046d
 &device.id		usb 0xc332
 +device.name		G502 Proteus Spectrum Optical Mouse
 
@@ -11362,6 +11708,14 @@
  vendor.id		usb 0x046d
 &device.id		usb 0xc534
 +device.name		Unifying Receiver
+
+ vendor.id		usb 0x046d
+&device.id		usb 0xc537
++device.name		Cordless Mouse Receiver
+
+ vendor.id		usb 0x046d
+&device.id		usb 0xc53a
++device.name		PowerPlay Wireless Charging System
 
  vendor.id		usb 0x046d
 &device.id		usb 0xc603
@@ -12495,6 +12849,10 @@
 +device.name		Bulk Driver
 
  vendor.id		usb 0x047f
+&device.id		usb 0x02ee
++device.name		BT600
+
+ vendor.id		usb 0x047f
 &device.id		usb 0x0301
 +device.name		Bulk Driver
 
@@ -12509,6 +12867,10 @@
  vendor.id		usb 0x047f
 &device.id		usb 0x4254
 +device.name		BUA-100 Bluetooth Adapter
+
+ vendor.id		usb 0x047f
+&device.id		usb 0xaa05
++device.name		DA45
 
  vendor.id		usb 0x047f
 &device.id		usb 0xac01
@@ -12529,6 +12891,10 @@
  vendor.id		usb 0x047f
 &device.id		usb 0xc00e
 +device.name		Blackwire C310 headset
+
+ vendor.id		usb 0x047f
+&device.id		usb 0xc03b
++device.name		HD1
 
  vendor.id		usb 0x0480
 +vendor.name		Toshiba America Inc
@@ -12560,6 +12926,14 @@
  vendor.id		usb 0x0480
 &device.id		usb 0x0820
 +device.name		Canvio Advance Disk
+
+ vendor.id		usb 0x0480
+&device.id		usb 0x0821
++device.name		Canvio Advance 2TB model DTC920
+
+ vendor.id		usb 0x0480
+&device.id		usb 0x0900
++device.name		MQ04UBF100
 
  vendor.id		usb 0x0480
 &device.id		usb 0xa006
@@ -12807,6 +13181,10 @@
 +device.name		Virtual COM Port
 
  vendor.id		usb 0x0483
+&device.id		usb 0x5750
++device.name		LED badge -- mini LED display -- 11x44
+
+ vendor.id		usb 0x0483
 &device.id		usb 0x7270
 +device.name		ST Micro Serial Bridge
 
@@ -12829,6 +13207,10 @@
  vendor.id		usb 0x0483
 &device.id		usb 0xa171
 +device.name		ThermaData WiFi
+
+ vendor.id		usb 0x0483
+&device.id		usb 0xa2e0
++device.name		BMeasure instrument
 
  vendor.id		usb 0x0483
 &device.id		usb 0xdf11
@@ -12938,6 +13320,10 @@
 +device.name		Flash Drive
 
  vendor.id		usb 0x048d
+&device.id		usb 0x1234
++device.name		Mass storage
+
+ vendor.id		usb 0x048d
 &device.id		usb 0x1336
 +device.name		SD/MMC Cardreader
 
@@ -12972,6 +13358,10 @@
  vendor.id		usb 0x048d
 &device.id		usb 0x9910
 +device.name		IT9910 chipset based grabber
+
+ vendor.id		usb 0x048d
+&device.id		usb 0xff59
++device.name		Hdmi-CEC Bridge
 
  vendor.id		usb 0x048f
 +vendor.name		Eicon Tech.
@@ -13230,6 +13620,10 @@
  vendor.id		usb 0x0499
 &device.id		usb 0x1613
 +device.name		Clavinova CLP535
+
+ vendor.id		usb 0x0499
+&device.id		usb 0x1617
++device.name		PSR-E353 digital keyboard
 
  vendor.id		usb 0x0499
 &device.id		usb 0x1704
@@ -14285,6 +14679,10 @@
 +device.name		PIXMA iX6850 Printer
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x12fe
++device.name		Printer in service mode
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x1404
 +device.name		W6400PG
 
@@ -14745,6 +15143,10 @@
 +device.name		PIXMA MG3000 series
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x1856
++device.name		PIXMA TS6250
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x1900
 +device.name		CanoScan LiDE 90
 
@@ -15017,6 +15419,10 @@
 +device.name		MPC190
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x2636
++device.name		LBP3200
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x2637
 +device.name		iR C6800
 
@@ -15073,12 +15479,20 @@
 +device.name		iR 3100C EUR
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x2654
++device.name		LBP3600
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x2655
 +device.name		FP-L170/MF350/L380/L398
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x2656
 +device.name		iR1510-1670 CAPT Printer
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x2657
++device.name		LBP3210
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x2659
@@ -15134,7 +15548,7 @@
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x266a
-+device.name		CAPT Device
++device.name		LBP3000
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x266b
@@ -15194,7 +15608,7 @@
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x2679
-+device.name		CAPT Device
++device.name		LBP5000
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x267a
@@ -15207,6 +15621,10 @@
  vendor.id		usb 0x04a9
 &device.id		usb 0x267d
 +device.name		MF7100 series
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x267e
++device.name		LBP3300
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x2684
@@ -15233,6 +15651,10 @@
 +device.name		LC310/L390/L408S
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x268b
++device.name		LBP3500
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x268c
 +device.name		iR C6870
 
@@ -15253,8 +15675,16 @@
 +device.name		iR7105
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x26a1
++device.name		LBP5300
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x26a3
 +device.name		MF4100 series
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x26a4
++device.name		LBP5100
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x26b0
@@ -15273,16 +15703,52 @@
 +device.name		FAX-L140/L130
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x26b9
++device.name		LBP3310
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x26ba
++device.name		LBP5050
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x26da
-+device.name		LBP3010B printer
++device.name		LBP3010/LBP3018/LBP3050
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x26db
++device.name		LBP3100/LBP3108/LBP3150
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x26e6
 +device.name		iR1024
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x26ea
++device.name		LBP9100C
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x26ee
++device.name		MF4320-4350
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x26f1
++device.name		LBP7200C
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x26ff
++device.name		LBP6300
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x271a
 +device.name		LBP6000
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x271b
++device.name		LBP6200
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x271c
++device.name		LBP7010C/7018C
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x2736
@@ -15291,6 +15757,14 @@
  vendor.id		usb 0x04a9
 &device.id		usb 0x2737
 +device.name		MF4410
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x2771
++device.name		LBP6020
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x2796
++device.name		LBP6230/6240
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x3041
@@ -16891,6 +17365,14 @@
 +device.name		D800 (ptp)
 
  vendor.id		usb 0x04b0
+&device.id		usb 0x0430
++device.name		D7100
+
+ vendor.id		usb 0x04b0
+&device.id		usb 0x0436
++device.name		D810
+
+ vendor.id		usb 0x04b0
 &device.id		usb 0x043f
 +device.name		D5600
 
@@ -17132,6 +17614,10 @@
 +device.name		DS-Xtreme Flash Card
 
  vendor.id		usb 0x04b4
+&device.id		usb 0x4717
++device.name		West Bridge
+
+ vendor.id		usb 0x04b4
 &device.id		usb 0x5201
 +device.name		Combi Keyboard-Hub (Hub)
 
@@ -17166,6 +17652,14 @@
  vendor.id		usb 0x04b4
 &device.id		usb 0x6560
 +device.name		CY7C65640 USB-2.0 "TetraHub"
+
+ vendor.id		usb 0x04b4
+&device.id		usb 0x6570
++device.name		Unprogrammed CY7C65632/34 hub HX2VL
+
+ vendor.id		usb 0x04b4
+&device.id		usb 0x6572
++device.name		Unprogrammed CY7C65642 hub
 
  vendor.id		usb 0x04b4
 &device.id		usb 0x6830
@@ -17497,7 +17991,7 @@
 
  vendor.id		usb 0x04b8
 &device.id		usb 0x0202
-+device.name		Receipt Printer M129C/TM-T70
++device.name		Interface Card UB-U05 for Thermal Receipt Printers [M129C/TM-T70/TM-T88IV]
 
  vendor.id		usb 0x04b8
 &device.id		usb 0x0401
@@ -17809,7 +18303,7 @@
 
  vendor.id		usb 0x04b8
 &device.id		usb 0x084f
-+device.name		ME OFFICE 510
++device.name		Multifunctional Printer Scanner [ME Office 510 / Epson Stylus SX215]
 
  vendor.id		usb 0x04b8
 &device.id		usb 0x0850
@@ -17970,6 +18464,10 @@
  vendor.id		usb 0x04b8
 &device.id		usb 0x0893
 +device.name		EP-774A
+
+ vendor.id		usb 0x04b8
+&device.id		usb 0x0e03
++device.name		Thermal Receipt Printer [TM-T20]
 
  vendor.id		usb 0x04b8
 &device.id		usb 0x1114
@@ -18493,12 +18991,20 @@
 +vendor.name		Lite-On Technology Corp.
 
  vendor.id		usb 0x04ca
+&device.id		usb 0x0020
++device.name		USB Keyboard
+
+ vendor.id		usb 0x04ca
 &device.id		usb 0x004b
 +device.name		Keyboard
 
  vendor.id		usb 0x04ca
 &device.id		usb 0x004f
 +device.name		SK-9020 keyboard
+
+ vendor.id		usb 0x04ca
+&device.id		usb 0x008a
++device.name		Acer Wired Mouse Model SM-9023
 
  vendor.id		usb 0x04ca
 &device.id		usb 0x1766
@@ -18535,6 +19041,10 @@
  vendor.id		usb 0x04ca
 &device.id		usb 0x3014
 +device.name		Qualcomm Atheros Bluetooth
+
+ vendor.id		usb 0x04ca
+&device.id		usb 0x3015
++device.name		Qualcomm Atheros QCA9377 Bluetooth
 
  vendor.id		usb 0x04ca
 &device.id		usb 0x7022
@@ -19159,6 +19669,18 @@
 +device.name		TL866CS EEPROM Programmer [MiniPRO]
 
  vendor.id		usb 0x04d8
+&device.id		usb 0xed16
++device.name		BeamiRC 2.0 CNC remote controller analoge
+
+ vendor.id		usb 0x04d8
+&device.id		usb 0xedb4
++device.name		micro PLC (ATSAMD51G19A) [Black Brix ECU II]
+
+ vendor.id		usb 0x04d8
+&device.id		usb 0xedb5
++device.name		ATMEGA32U4 [Black Brix ECU]
+
+ vendor.id		usb 0x04d8
 &device.id		usb 0xf2c4
 +device.name		Macareux-labs Hygrometry Temperature Sensor
 
@@ -19236,6 +19758,10 @@
  vendor.id		usb 0x04d9
 &device.id		usb 0x0022
 +device.name		Portable Keyboard
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0x0348
++device.name		Keyboard
 
  vendor.id		usb 0x04d9
 &device.id		usb 0x048e
@@ -19340,6 +19866,14 @@
  vendor.id		usb 0x04d9
 &device.id		usb 0xa11b
 +device.name		Mouse [MX-3200]
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0xa29f
++device.name		Microarray fingerprint reader
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0xb534
++device.name		LGT8F328P Microprocessor
 
  vendor.id		usb 0x04d9
 &device.id		usb 0xe002
@@ -20372,6 +20906,10 @@
 +device.name		SCX-3400 Series
 
  vendor.id		usb 0x04e8
+&device.id		usb 0x347e
++device.name		C48x Series Color Laser Multifunction Printer
+
+ vendor.id		usb 0x04e8
 &device.id		usb 0x3605
 +device.name		InkJet Color Printer
 
@@ -20688,6 +21226,10 @@
 +device.name		M3 Portable Hard Drive 1TB
 
  vendor.id		usb 0x04e8
+&device.id		usb 0x61b7
++device.name		M3 Portable Hard Drive 4TB
+
+ vendor.id		usb 0x04e8
 &device.id		usb 0x61f3
 +device.name		Portable SSD T3 (MU-PT250B, MU-PT500B)
 
@@ -20936,8 +21478,20 @@
 +device.name		Human Interface Device
 
  vendor.id		usb 0x04e8
+&device.id		usb 0x7301
++device.name		Fingerprint Device
+
+ vendor.id		usb 0x04e8
 &device.id		usb 0x8001
 +device.name		Handheld
+
+ vendor.id		usb 0x04e8
+&device.id		usb 0x8002
++device.name		Portable SSD 500GB Model Number: MU - P8500B
+
+ vendor.id		usb 0x04e8
+&device.id		usb 0x8003
++device.name		Portable SSD T1
 
  vendor.id		usb 0x04e8
 &device.id		usb 0xd003
@@ -21101,6 +21655,10 @@
  vendor.id		usb 0x04f2
 &device.id		usb 0x0860
 +device.name		2.4G Multimedia Wireless Kit
+
+ vendor.id		usb 0x04f2
+&device.id		usb 0x0939
++device.name		Amazon Basics mouse
 
  vendor.id		usb 0x04f2
 &device.id		usb 0x1061
@@ -21347,6 +21905,10 @@
 +device.name		Integrated HP HD Webcam
 
  vendor.id		usb 0x04f2
+&device.id		usb 0xb249
++device.name		HP Integrated Webcam
+
+ vendor.id		usb 0x04f2
 &device.id		usb 0xb257
 +device.name		Lenovo Integrated Camera
 
@@ -21415,6 +21977,10 @@
 +device.name		Lenovo Integrated Webcam
 
  vendor.id		usb 0x04f2
+&device.id		usb 0xb49f
++device.name		Bluetooth (RTL8723BE)
+
+ vendor.id		usb 0x04f2
 &device.id		usb 0xb563
 +device.name		Integrated Camera
 
@@ -21429,6 +21995,14 @@
  vendor.id		usb 0x04f2
 &device.id		usb 0xb5db
 +device.name		HP Webcam
+
+ vendor.id		usb 0x04f2
+&device.id		usb 0xb604
++device.name		Integrated Camera (1280x720@30)
+
+ vendor.id		usb 0x04f2
+&device.id		usb 0xb681
++device.name		ThinkPad T490 Webcam
 
  vendor.id		usb 0x04f3
 +vendor.name		Elan Microelectronics Corp.
@@ -21492,6 +22066,10 @@
  vendor.id		usb 0x04f3
 &device.id		usb 0x04a0
 +device.name		Dream Cheeky Stress/Panic Button
+
+ vendor.id		usb 0x04f3
+&device.id		usb 0x2234
++device.name		Touchscreen
 
  vendor.id		usb 0x04f4
 +vendor.name		Harting Elektronik, Inc.
@@ -21670,6 +22248,14 @@
  vendor.id		usb 0x04f9
 &device.id		usb 0x0042
 +device.name		HL-2270DW Laser Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x004d
++device.name		HL-6180DW series
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0080
++device.name		HL-L6250DN series
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x0100
@@ -22510,6 +23096,10 @@
  vendor.id		usb 0x04f9
 &device.id		usb 0x0240
 +device.name		MFC-J950DN
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0245
++device.name		MFC-9560CDW
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x0248
@@ -23476,6 +24066,10 @@
 +device.name		DCP-J762N
 
  vendor.id		usb 0x04f9
+&device.id		usb 0x03fd
++device.name		ADS-2700W
+
+ vendor.id		usb 0x04f9
 &device.id		usb 0x1000
 +device.name		Printer
 
@@ -23524,8 +24118,20 @@
 +device.name		PT-7600 P-touch Label Printer
 
  vendor.id		usb 0x04f9
+&device.id		usb 0x202c
++device.name		PT-1230PC P-touch Label Printer E mode
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x2030
++device.name		PT-1230PC P-touch Label Printer EL mode
+
+ vendor.id		usb 0x04f9
 &device.id		usb 0x2041
 +device.name		PT-2730 P-touch Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x2042
++device.name		QL-700 P-touch Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2061
@@ -23534,6 +24140,18 @@
  vendor.id		usb 0x04f9
 &device.id		usb 0x2064
 +device.name		PT-P700 P-touch Label Printer RemovableDisk
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x209b
++device.name		QL-800 P-touch Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x209c
++device.name		QL-810W P-touch Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x209d
++device.name		QL-820NWB P-touch Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2100
@@ -24948,6 +25566,10 @@
 +device.name		ICSI Bluetooth Device
 
  vendor.id		usb 0x0547
+&device.id		usb 0x0080
++device.name		I3SYSTEM HYUNY
+
+ vendor.id		usb 0x0547
 &device.id		usb 0x1002
 +device.name		Python2 WDM Encoder
 
@@ -25117,6 +25739,10 @@
  vendor.id		usb 0x054c
 &device.id		usb 0x0046
 +device.name		Network Walkman
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x0049
++device.name		UP-D895
 
  vendor.id		usb 0x054c
 &device.id		usb 0x004a
@@ -25455,6 +26081,10 @@
 +device.name		VRD-VC10 [Video Capture]
 
  vendor.id		usb 0x054c
+&device.id		usb 0x01e7
++device.name		UP-D897
+
+ vendor.id		usb 0x054c
 &device.id		usb 0x01e8
 +device.name		UP-DR150 Photo Printer
 
@@ -25631,6 +26261,10 @@
 +device.name		PSP Slim
 
  vendor.id		usb 0x054c
+&device.id		usb 0x02d4
++device.name		UP-CX1
+
+ vendor.id		usb 0x054c
 &device.id		usb 0x02d8
 +device.name		SBAC-US10 SxS PRO memory card reader/writer
 
@@ -25701,6 +26335,18 @@
  vendor.id		usb 0x054c
 &device.id		usb 0x03bc
 +device.name		Webbie HD - MHS-CM1
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x03c3
++device.name		UP-DR80MD
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x03c4
++device.name		Stryker SDP1000
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x03c5
++device.name		UP-DR80
 
  vendor.id		usb 0x054c
 &device.id		usb 0x03cc
@@ -25817,6 +26463,10 @@
  vendor.id		usb 0x054c
 &device.id		usb 0x0c34
 +device.name		ILCE-7M3 [A7III] in PC Remote mode
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x0cd3
++device.name		WH-1000XM3 [Wireless Noise-Canceling Headphones]
 
  vendor.id		usb 0x054c
 &device.id		usb 0x0cda
@@ -26421,6 +27071,14 @@
 +device.name		Genius KB-29E
 
  vendor.id		usb 0x0566
+&device.id		usb 0x3013
++device.name		BakkerElkhuizen Wired Keyboard S-board 840 Design
+
+ vendor.id		usb 0x0566
+&device.id		usb 0x3020
++device.name		BakkerElkhuizen Wired Keyboard S-board 840 Design USB-Hub
+
+ vendor.id		usb 0x0566
 &device.id		usb 0x3027
 +device.name		Sun-Flex ProTouch
 
@@ -26581,6 +27239,14 @@
 +device.name		DTU-710
 
  vendor.id		usb 0x056a
+&device.id		usb 0x003a
++device.name		DTI-520
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x003b
++device.name		Integrated Hub
+
+ vendor.id		usb 0x056a
 &device.id		usb 0x003f
 +device.name		DTZ-2100 [Cintiq 21UX]
 
@@ -26670,7 +27336,7 @@
 
  vendor.id		usb 0x056a
 &device.id		usb 0x0084
-+device.name		Wireless adapter for Bamboo tablets
++device.name		ACK-40401 [Wireless Accessory Kit]
 
  vendor.id		usb 0x056a
 &device.id		usb 0x0090
@@ -26687,6 +27353,10 @@
  vendor.id		usb 0x056a
 &device.id		usb 0x009a
 +device.name		TPC9A
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x00a2
++device.name		STU-300B [LCD signature pad]
 
  vendor.id		usb 0x056a
 &device.id		usb 0x00b0
@@ -26853,6 +27523,10 @@
 +device.name		TPCEF
 
  vendor.id		usb 0x056a
+&device.id		usb 0x00f0
++device.name		DTU-1631
+
+ vendor.id		usb 0x056a
 &device.id		usb 0x00f4
 +device.name		DTK-2400 [Cintiq 24HD] tablet
 
@@ -26863,6 +27537,10 @@
  vendor.id		usb 0x056a
 &device.id		usb 0x00f8
 +device.name		DTH-2400 [Cintiq 24HD touch] tablet
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x00f9
++device.name		DTK-2200 [Cintiq 22HD] hub
 
  vendor.id		usb 0x056a
 &device.id		usb 0x00fa
@@ -26953,16 +27631,72 @@
 +device.name		CTH-301 [Bamboo]
 
  vendor.id		usb 0x056a
+&device.id		usb 0x0319
++device.name		CTH-300 [Bamboo Pad wireless]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0323
++device.name		CTL-680 [Intuos Pen (M)]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x032a
++device.name		DTK-2700 [Cintiq 27QHD]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x032b
++device.name		DTH-2700 [Cintiq 27QHD touch] tablet
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x032c
++device.name		DTH-2700 [Cintiq 27QHD touch] touchscreen
+
+ vendor.id		usb 0x056a
 &device.id		usb 0x032f
 +device.name		DTU-1031X
 
  vendor.id		usb 0x056a
+&device.id		usb 0x0331
++device.name		ACK-411050 [ExpressKey Remote]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0333
++device.name		DTH-1300 [Cintiq 13HD Touch] tablet
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0335
++device.name		DTH-1300 [Cintiq 13HD Touch] touchscreen
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0336
++device.name		DTU-1141
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x033b
++device.name		CTL-490 [Intuos Draw (S)]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x033c
++device.name		CTH-490 [Intuos Art/Photo/Comic (S)]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x033d
++device.name		CTL-690 [Intuos Draw (M)]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x033e
++device.name		CTH-690 [Intuos Art (M)]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0343
++device.name		DTK-1651
+
+ vendor.id		usb 0x056a
 &device.id		usb 0x0347
-+device.name		Integrated Hub
++device.name		DTH-W1620 [MobileStudio Pro 16] internal hub
 
  vendor.id		usb 0x056a
 &device.id		usb 0x0348
-+device.name		Integrated Hub
++device.name		DTH-W1620 [MobileStudio Pro 16] external hub
 
  vendor.id		usb 0x056a
 &device.id		usb 0x034a
@@ -27019,6 +27753,10 @@
  vendor.id		usb 0x056a
 &device.id		usb 0x0358
 +device.name		PTH-860 [Intuos Pro (L)]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0359
++device.name		DTU-1141B
 
  vendor.id		usb 0x056a
 &device.id		usb 0x035a
@@ -27089,6 +27827,46 @@
 +device.name		DTK-1660 [Cintiq 16]
 
  vendor.id		usb 0x056a
+&device.id		usb 0x0392
++device.name		PTH-460 [Intuos Pro (S)]
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0396
++device.name		DTK-1660E
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0398
++device.name		DTH-W1320 [MobileStudio Pro 13] tablet
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x0399
++device.name		DTH-W1620 [MobileStudio Pro 16] tablet
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x039a
++device.name		DTH-W1320 [MobileStudio Pro 13] touchscreen
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x039b
++device.name		DTH-W1620 [MobileStudio Pro 16] touchscreen
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x039c
++device.name		DTH-W1320 [MobileStudio Pro 16] external hub
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x039d
++device.name		DTH-W1320 [MobileStudio Pro 16] internal hub
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x03aa
++device.name		DTH-W1620 [MobileStudio Pro 16] tablet
+
+ vendor.id		usb 0x056a
+&device.id		usb 0x03ac
++device.name		DTH-W1620 [MobileStudio Pro 16] touchscreen
+
+ vendor.id		usb 0x056a
 &device.id		usb 0x0400
 +device.name		PenPartner 4x5
 
@@ -27157,6 +27935,10 @@
 &device.id		usb 0x0003
 +device.name		Device Bay Controller
 
+ vendor.id		usb 0x056d
+&device.id		usb 0x4001
++device.name		Monitor
+
  vendor.id		usb 0x056e
 +vendor.name		Elecom Co., Ltd
 
@@ -27217,6 +27999,94 @@
 +device.name		Laser mouse M-LY2UL
 
  vendor.id		usb 0x056e
+&device.id		usb 0x0079
++device.name		Laser mouse M-D21DL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x007b
++device.name		Laser mouse M-D20DR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x007c
++device.name		Laser Bluetooth mouse M-BT5BL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x007e
++device.name		Option mouse M-M8UR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x007f
++device.name		Option mouse M-M9UR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0081
++device.name		Option mouse M-DY6DR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0082
++device.name		Laser mouse M-D22DR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0088
++device.name		Micro Grast2 Bit M-BG3DL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0089
++device.name		Micro Grast2 Pop M-PG3DL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x008c
++device.name		M-NE3DL Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x008d
++device.name		ORIME M-NE4DR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x008f
++device.name		M-BT8BL Bluetooth Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0092
++device.name		Wireless BlueLED Mouse (M-BL2DB)
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x009c
++device.name		IR Mouse M-IR02DR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x009d
++device.name		IR Mouse M-IR03DR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x009f
++device.name		BlueLED Mouse M-HS1DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00a1
++device.name		IR Mouse M-IR05DR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00a4
++device.name		Blue LED Mouse M-BL06DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00a5
++device.name		M-NV1BR Bluetooth Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00a7
++device.name		Blue LED Mouse M-BL08DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00a8
++device.name		M-BL09DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00a9
++device.name		M-BL10UB Mouse
+
+ vendor.id		usb 0x056e
 &device.id		usb 0x2003
 +device.name		JC-U3613M
 
@@ -27227,6 +28097,10 @@
  vendor.id		usb 0x056e
 &device.id		usb 0x200c
 +device.name		LD-USB/TX
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x2012
++device.name		JC-U4013S Gamepad
 
  vendor.id		usb 0x056e
 &device.id		usb 0x4002
@@ -29759,6 +30633,22 @@
  vendor.id		usb 0x05a6
 &device.id		usb 0x0004
 +device.name		CVA122E Cable Voice Adapter (WDM)
+
+ vendor.id		usb 0x05a6
+&device.id		usb 0x0a00
++device.name		Integrated Management Controller Hub
+
+ vendor.id		usb 0x05a6
+&device.id		usb 0x0a01
++device.name		Virtual Keyboard/Mouse
+
+ vendor.id		usb 0x05a6
+&device.id		usb 0x0a02
++device.name		Virtual Mass Storage
+
+ vendor.id		usb 0x05a6
+&device.id		usb 0x0a03
++device.name		Virtual Ethernet/RNDIS
 
  vendor.id		usb 0x05a7
 +vendor.name		Bose Corp.
@@ -36612,6 +37502,10 @@
  vendor.id		usb 0x06f8
 &device.id		usb 0xb000
 +device.name		Hercules DJ Console
+
+ vendor.id		usb 0x06f8
+&device.id		usb 0xb121
++device.name		Hercules P32 DJ
 
  vendor.id		usb 0x06f8
 &device.id		usb 0xc000
@@ -45026,7 +45920,7 @@
 +vendor.name		Nisca Corp.
 
  vendor.id		usb 0x09c3
-+vendor.name		ActivCard, Inc.
++vendor.name		HID Global
 
  vendor.id		usb 0x09c3
 &device.id		usb 0x0007
@@ -45039,6 +45933,30 @@
  vendor.id		usb 0x09c3
 &device.id		usb 0x0014
 +device.name		ActivIdentity ActivKey SIM USB Token
+
+ vendor.id		usb 0x09c3
+&device.id		usb 0x0028
++device.name		Crescendo Key
+
+ vendor.id		usb 0x09c3
+&device.id		usb 0x0029
++device.name		Crescendo Key
+
+ vendor.id		usb 0x09c3
+&device.id		usb 0x002a
++device.name		Crescendo Key
+
+ vendor.id		usb 0x09c3
+&device.id		usb 0x002b
++device.name		Crescendo Key
+
+ vendor.id		usb 0x09c3
+&device.id		usb 0x002c
++device.name		Crescendo Key
+
+ vendor.id		usb 0x09c3
+&device.id		usb 0x002e
++device.name		Crescendo Key
 
  vendor.id		usb 0x09c4
 +vendor.name		ACTiSYS Corp.
@@ -46920,6 +47838,18 @@
  vendor.id		usb 0x0aad
 &device.id		usb 0x0095
 +device.name		NRP-Z86
+
+ vendor.id		usb 0x0aad
+&device.id		usb 0x0117
++device.name		HMF / HMP / HMS-X / HMO series Oscilloscopes
+
+ vendor.id		usb 0x0aad
+&device.id		usb 0x0118
++device.name		HMF / HMP / HMS-X / HMO series Oscilloscopes
+
+ vendor.id		usb 0x0aad
+&device.id		usb 0x0119
++device.name		HMF / HMP / HMS-X / HMO series Oscilloscopes
 
  vendor.id		usb 0x0aae
 +vendor.name		NEC infrontia Corp. (Nitsuko)
@@ -58217,7 +59147,7 @@
 +device.name		ULS Print Support
 
  vendor.id		usb 0x10c4
-+vendor.name		Cygnal Integrated Products, Inc.
++vendor.name		Silicon Labs
 
  vendor.id		usb 0x10c4
 &device.id		usb 0x0002
@@ -58372,20 +59302,84 @@
 +device.name		C8051F38x HDMI Extender [UHBX-SW3-WP]
 
  vendor.id		usb 0x10c4
+&device.id		usb 0x89fb
++device.name		Qivicon ZigBee Stick
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0x8a3c
++device.name		C8051F38x HDBaseT Receiver [UHBX-R-XT]
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0x8a6c
++device.name		C8051F38x 4K HDMI Audio Extractor [EMX-AMP]
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0x8acb
++device.name		C8051F38x HDBaseT Wall Plate Receiver with IR, RS-232, and PoH [UHBX-R-WP]
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0x8af8
++device.name		C8051F38x 4K HDMI Audio Extractor w/Audio Amplifier, HDBT Input, Line Audio Input RS-232 Ports and IP Control [VSA-X21]
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0x8b8c
++device.name		C8051F38x 4K HDMI Audio Extractor w/Audio Amplifier, HDBT Input, Line Audio Input RS-232 Ports and IP Control [SC-3H]
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0x8db5
++device.name		C8051F38x CATx HDMI Receiver with USB [EX-HDU-R]
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0x8db6
++device.name		C8051F38x CATx HDMI Receiver
+
+ vendor.id		usb 0x10c4
 &device.id		usb 0xea60
-+device.name		CP2102/CP2109 UART Bridge Controller [CP210x family]
++device.name		CP210x UART Bridge
 
  vendor.id		usb 0x10c4
 &device.id		usb 0xea61
 +device.name		CP210x UART Bridge
 
  vendor.id		usb 0x10c4
-&device.id		usb 0xea70
+&device.id		usb 0xea63
 +device.name		CP210x UART Bridge
 
  vendor.id		usb 0x10c4
+&device.id		usb 0xea70
++device.name		CP2105 Dual UART Bridge
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xea71
++device.name		CP2108 Quad UART Bridge
+
+ vendor.id		usb 0x10c4
 &device.id		usb 0xea80
-+device.name		CP210x UART Bridge
++device.name		CP2110 HID UART Bridge
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xea90
++device.name		CP2112 HID I2C Bridge
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xea91
++device.name		CP2112 HID SMBus/I2C Bridge for CP2614 Evaluation Kit
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xea93
++device.name		CP2112 HID SMBus/I2C Bridge for CP2615 Evaluation Kit
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xeab0
++device.name		CP2114 I2S Audio Bridge
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xeac0
++device.name		CP2614 MFi Accessory Digital Audio Bridge
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xeac1
++device.name		CP2615 I2S Audio Bridge
 
  vendor.id		usb 0x10c4
 &device.id		usb 0xeac9
@@ -58394,6 +59388,10 @@
  vendor.id		usb 0x10c4
 &device.id		usb 0xeaca
 +device.name		EFM8UB2 Bootloader
+
+ vendor.id		usb 0x10c4
+&device.id		usb 0xeacb
++device.name		EFM8UB3 Bootloader
 
  vendor.id		usb 0x10c5
 +vendor.name		Sanei Electric, Inc.
@@ -63494,6 +64492,10 @@
 &device.id		usb 0x001d
 +device.name		Greentit [Ambit2 R]
 
+ vendor.id		usb 0x1493
+&device.id		usb 0x001e
++device.name		Ibisbill [Ambit3 Run]
+
  vendor.id		usb 0x1497
 +vendor.name		Panstrong Company Ltd.
 
@@ -64850,6 +65852,10 @@
  vendor.id		usb 0x15d9
 &device.id		usb 0x0a4d
 +device.name		Optical Mouse
+
+ vendor.id		usb 0x15d9
+&device.id		usb 0x0a4e
++device.name		AM-5400 [Optical Mouse]
 
  vendor.id		usb 0x15d9
 &device.id		usb 0x0a4f
@@ -71426,11 +72432,15 @@
 +device.name		instadose dosimeter
 
  vendor.id		usb 0x1e1d
-+vendor.name		Lumension Security
++vendor.name		Kanguru Solutions
 
  vendor.id		usb 0x1e1d
 &device.id		usb 0x0165
 +device.name		Secure Pen drive
+
+ vendor.id		usb 0x1e1d
+&device.id		usb 0x1101
++device.name		FlashBlu Flash Drive
 
  vendor.id		usb 0x1e1f
 +vendor.name		INVIA
@@ -71617,6 +72627,10 @@
  vendor.id		usb 0x1e7d
 &device.id		usb 0x2d51
 +device.name		Kone+ Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2e22
++device.name		Kone XTD Mouse
 
  vendor.id		usb 0x1e7d
 &device.id		usb 0x30d4
@@ -72860,6 +73874,37 @@
 &device.id		usb 0x4161
 +device.name		eReader White
 
+ vendor.id		usb 0x224f
++vendor.name		APDM
+
+ vendor.id		usb 0x224f
+&device.id		usb 0x0001
++device.name		Access Point
+
+ vendor.id		usb 0x224f
+&device.id		usb 0x0002
++device.name		Docking Station
+
+ vendor.id		usb 0x224f
+&device.id		usb 0x0004
++device.name		V2 Opal ACM
+
+ vendor.id		usb 0x224f
+&device.id		usb 0x0005
++device.name		V2 Opal
+
+ vendor.id		usb 0x224f
+&device.id		usb 0x0006
++device.name		V2 Docking Station
+
+ vendor.id		usb 0x224f
+&device.id		usb 0x0007
++device.name		V2 Access Point ACM
+
+ vendor.id		usb 0x224f
+&device.id		usb 0x0008
++device.name		V2 Access Point
+
  vendor.id		usb 0x225d
 +vendor.name		Morpho
 
@@ -73270,6 +74315,52 @@
  vendor.id		usb 0x22ba
 +vendor.name		Technology Innovation Holdings, Ltd
 
+ vendor.id		usb 0x22c9
++vendor.name		StepOver GmbH
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0601
++device.name		naturaSign Pad Colour
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0701
++device.name		naturaSign Pad Mobile
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0801
++device.name		naturaSign Pad Comfort
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0881
++device.name		naturaSign Pad Flawless
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0901
++device.name		naturaSign Pad Classic
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x09e1
++device.name		naturaSign Pad Biometric
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0ce1
++device.name		duraSign Pad Brilliance
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0cf1
++device.name		duraSign Pad Biometric 5.0
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0d01
++device.name		duraSign 10.0
+
+ vendor.id		usb 0x22c9
+&device.id		usb 0x0df1
++device.name		duraSign Pad Biometric 10.0
+
+ vendor.id		usb 0x22cd
++vendor.name		Kinova Robotics Inc.
+
  vendor.id		usb 0x22e0
 +vendor.name		secunet Security Networks AG
 
@@ -73530,6 +74621,10 @@
 +device.name		Archer T1U 802.11a/n/ac Wireless Adapter [MediaTek MT7610U]
 
  vendor.id		usb 0x2357
+&device.id		usb 0x0106
++device.name		Archer T9UH v1 [Realtek RTL8814AU]
+
+ vendor.id		usb 0x2357
 &device.id		usb 0x0107
 +device.name		TL-WN821N Version 5 RTL8192EU
 
@@ -73674,6 +74769,13 @@
  vendor.id		usb 0x2548
 &device.id		usb 0x1002
 +device.name		CEC Adapter
+
+ vendor.id		usb 0x25b5
++vendor.name		FlatFrog
+
+ vendor.id		usb 0x25b5
+&device.id		usb 0x0002
++device.name		Multitouch 3200
 
  vendor.id		usb 0x2632
 +vendor.name		TwinMOS
@@ -74088,6 +75190,49 @@
 &device.id		usb 0x01ed
 +device.name		blink(1)
 
+ vendor.id		usb 0x27c6
++vendor.name		Shenzhen Goodix Technology Co.,Ltd.
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5117
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5201
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5301
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x530c
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5385
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x538c
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5395
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5584
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x55b4
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5740
++device.name		Fingerprint Reader
+
  vendor.id		usb 0x2821
 +vendor.name		ASUSTek Computer Inc.
 
@@ -74419,6 +75564,13 @@
 &device.id		usb 0x0000
 +device.name		Wireless Optical Mouse
 
+ vendor.id		usb 0x2c23
++vendor.name		Supermicro Computer Incorporated
+
+ vendor.id		usb 0x2c23
+&device.id		usb 0x1b83
++device.name		NIC
+
  vendor.id		usb 0x2c7c
 +vendor.name		Quectel Wireless Solutions Co., Ltd.
 
@@ -74450,6 +75602,13 @@
 &device.id		usb 0x0435
 +device.name		AG35 LTE modem
 
+ vendor.id		usb 0x2cdc
++vendor.name		Sea & Sun Technology GmbH
+
+ vendor.id		usb 0x2cdc
+&device.id		usb 0xf232
++device.name		CTD48Mc CTD Probe
+
  vendor.id		usb 0x2dcf
 +vendor.name		Dialog Semiconductor
 
@@ -74466,6 +75625,23 @@
  vendor.id		usb 0x3016
 &device.id		usb 0x0001
 +device.name		Nitrogen Bootloader
+
+ vendor.id		usb 0x30a4
++vendor.name		Blues Wireless
+
+ vendor.id		usb 0x30a4
+&device.id		usb 0x0001
++device.name		Notecard
+
+ vendor.id		usb 0x30c2
++vendor.name		UNPARALLEL Innovation, Lda
+
+ vendor.id		usb 0x30c2
+&device.id		usb 0x1388
++device.name		SPL Meter
+
+ vendor.id		usb 0x30c9
++vendor.name		Luxvisions Innotech Limited
 
  vendor.id		usb 0x30ee
 +vendor.name		Fujitsu Connected Technologies Limited

--- a/src/isdn/cdb/cdb_read.c
+++ b/src/isdn/cdb/cdb_read.c
@@ -119,7 +119,7 @@ static char *add_sortedname_list(const char *str, const char *list, const char *
 	char	*t,*p;
 	if (!list || !list[0])
 		return(add_name(str, 1));
-	strncpy(stmp, list, 4096);
+	strncpy(stmp, list, 4096 - 1);
 	sscanf(str, fmt, &v);
 	p = sstmp;
 	t = strtok(stmp, ",");


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1169682

Update PCI and USB device database.

## Solution

Do this:

- https://github.com/openSUSE/hwinfo/blob/master/src/ids/README.md

## Bonus

Fix compiler warnings.