### PR TITLE
rework network device detection on aarch64 (bsc#1177600, bsc#1177261)

### DIFF
--- a/src/hd/hd_int.h
+++ b/src/hd/hd_int.h
@@ -120,7 +120,10 @@ str_list_t *free_str_list(str_list_t *list);
 str_list_t *reverse_str_list(str_list_t *list);
 str_list_t *read_file(char *file_name, unsigned start_line, unsigned lines);
 str_list_t *read_dir(char *dir_name, int type);
+str_list_t *read_dir_canonical(char *dir_name, int type);
 char *hd_read_sysfs_link(char *base_dir, char *link_name);
+str_list_t *subcomponent_list(str_list_t *list, char *comp, int max);
+int has_subcomponent(str_list_t *list, char *comp);
 void progress(hd_data_t *hd_data, unsigned pos, unsigned count, char *msg);
 
 void remove_hd_entries(hd_data_t *hd_data);


### PR DESCRIPTION
## Issue

- https://trello.com/c/HageBaxh
- https://bugzilla.suse.com/show_bug.cgi?id=1177600
- https://bugzilla.suse.com/show_bug.cgi?id=1177261

## Solution

The new code takes into account that:
  - a platform device may have the network interface link hidden several levels deep in its sysfs entry
  - there might be more than one interface per platform device