### PR TITLE
Fixed serial port conflicts

### DIFF
--- a/src/hd/mouse.c
+++ b/src/hd/mouse.c
@@ -407,7 +407,7 @@ void get_serial_mouse(hd_data_t *hd_data)
         /*
          * PnP COM spec black magic...
          */
-        setspeed(fd, 1200, 1, CS7);
+        setspeed(fd, 1200, 0, CS7);
         modem_info = TIOCM_DTR | TIOCM_RTS;
         ioctl(fd, TIOCMBIC, &modem_info);
       }


### PR DESCRIPTION
 In the function of setspeed(fd, 1200, 0, CS7);
 If the third parameter is set to 1, data will be written to the device. This is unreasonable

Log: wu