### PR TITLE
update pci and usb ids

### DIFF
--- a/src/ids/src/pci
+++ b/src/ids/src/pci
@@ -60,6 +60,10 @@
 +device.name		DMA (Direct Memory Access) Controller
 
  vendor.id		pci 0x0014
+&device.id		pci 0x7a10
++device.name		Hyper Transport Bridge Controller
+
+ vendor.id		pci 0x0014
 &device.id		pci 0x7a14
 +device.name		EHCI USB Controller
 
@@ -143,6 +147,9 @@
  vendor.id		pci 0x01de
 +vendor.name		Oxide Computer Company
 
+ vendor.id		pci 0x0200
++vendor.name		Dell (wrong ID)
+
  vendor.id		pci 0x021b
 +vendor.name		Compaq Computer Corporation
 
@@ -213,6 +220,13 @@
 
  vendor.id		pci 0x0721
 +vendor.name		Sapphire, Inc.
+
+ vendor.id		pci 0x0731
++vendor.name		Jingjia Microelectronics Co Ltd
+
+ vendor.id		pci 0x0731
+&device.id		pci 0x7200
++device.name		JM7200 Series GPU
 
  vendor.id		pci 0x0777
 +vendor.name		Ubiquiti Networks, Inc.
@@ -1010,6 +1024,24 @@
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0014
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9460
++subdevice.name		MegaRAID 9460-16i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0014
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9480
++subdevice.name		MegaRAID 9480-8i8e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0014
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9481
++subdevice.name		MegaRAID 9480-8e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0014
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1f3a
 +subdevice.name		PERC H745 Adapter
@@ -1074,6 +1106,12 @@
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0015
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9441
++subdevice.name		MegaRAID 9440-16i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0015
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1f3c
 +subdevice.name		PERC H345 Adapter
@@ -1093,6 +1131,30 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x0016
 +device.name		MegaRAID Tri-Mode SAS3508
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0016
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9461
++subdevice.name		MegaRAID 9460-8i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0016
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9462
++subdevice.name		MegaRAID 9460-4i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0016
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9463
++subdevice.name		MegaRAID 9365-28i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0016
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9464
++subdevice.name		MegaRAID 9365-24i
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0016
@@ -1151,6 +1213,18 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x0017
 +device.name		MegaRAID Tri-Mode SAS3408
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0017
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9440
++subdevice.name		MegaRAID 9440-8i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0017
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9442
++subdevice.name		MegaRAID 9440-4i
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0017
@@ -1874,6 +1948,12 @@
 
  vendor.id		pci 0x1000
 &device.id		pci 0x005d
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x9380
++subdevice.name		MegaRAID SAS 9380-8e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x005d
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1f41
 +subdevice.name		PERC H830 Adapter
@@ -2337,6 +2417,12 @@
 &subvendor.id		pci 0x1000
 &subdevice.id		pci 0x30b0
 +subdevice.name		9200-8e [LSI SAS 6Gb/s SAS/SATA PCIe x8 External HBA]
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x0072
+&subvendor.id		pci 0x1014
+&subdevice.id		pci 0x03ca
++subdevice.name		IBM 6Gb SAS HBA [9212-4i4e]
 
  vendor.id		pci 0x1000
 &device.id		pci 0x0072
@@ -3349,6 +3435,16 @@
 +subdevice.name		ThinkSystem 430-8i SAS/SATA 12Gb Dense HBA
 
  vendor.id		pci 0x1000
+&device.id		pci 0x00b2
++device.name		PCIe Switch management endpoint
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00b2
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0003
++subdevice.name		ThinkSystem 1611-8P PCIe Gen4 NVMe Switch Adapter
+
+ vendor.id		pci 0x1000
 &device.id		pci 0x00be
 +device.name		SAS3504 Fusion-MPT Tri-Mode RAID On Chip (ROC)
 
@@ -3375,6 +3471,12 @@
  vendor.id		pci 0x1000
 &device.id		pci 0x00c4
 +device.name		SAS3224 PCI-Express Fusion-MPT SAS-3
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00c4
+&subvendor.id		pci 0x1170
+&subdevice.id		pci 0x0002
++subdevice.name		SAS3224 PCI Express to 12Gb HBA MEZZ CARD
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00c5
@@ -3548,6 +3650,30 @@
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00e6
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x4050
++subdevice.name		9500-16i Tri-Mode HBA
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x4060
++subdevice.name		9500-8i Tri-Mode HBA
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x4070
++subdevice.name		9500-16e Tri-Mode HBA
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x4080
++subdevice.name		9500-8e Tri-Mode HBA
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x00e6
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x200b
 +subdevice.name		HBA355i Adapter
@@ -3568,7 +3694,7 @@
 &device.id		pci 0x00e6
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x200e
-+subdevice.name		HBA355i MX
++subdevice.name		HBA350i MX
 
  vendor.id		pci 0x1000
 &device.id		pci 0x00e6
@@ -4104,6 +4230,30 @@
 
  vendor.id		pci 0x1000
 &device.id		pci 0x10e2
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x4000
++subdevice.name		MegaRAID 9560-16i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x4010
++subdevice.name		MegaRAID 9560-8i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x4020
++subdevice.name		MegaRAID 9580-8i8e
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
+&subvendor.id		pci 0x1000
+&subdevice.id		pci 0x40b0
++subdevice.name		MegaRAID 9562-16i
+
+ vendor.id		pci 0x1000
+&device.id		pci 0x10e2
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1ae0
 +subdevice.name		PERC H755 Adapter
@@ -4290,6 +4440,20 @@
 &device.id		pci 0x6001
 +device.name		DX1 Multiformat Broadcast HD/SD Encoder/Decoder
 
+ vendor.id		pci 0x1000
+&device.id		pci 0xc010
++device.name		PEX88048 50 lane, 50 port, PCI Express Gen 4.0 ExpressFabric Platform
+
+ vendor.id		pci 0x1000
+&device.id		pci 0xc012
++device.name		PEX880xx PCIe Gen 4 Switch
+
+ vendor.id		pci 0x1000
+&device.id		pci 0xc012
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0003
++subdevice.name		ThinkSystem 1611-8P PCIe Gen4 NVMe Switch Adapter
+
  vendor.id		pci 0x1001
 +vendor.name		Kolter Electronic
 
@@ -4460,7 +4624,13 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x154c
-+device.name		Kryptos
++device.name		Kryptos [Radeon RX 350]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x154c
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7c28
++subdevice.name		MS-7C28 Motherboard
 
  vendor.id		pci 0x1002
 &device.id		pci 0x154e
@@ -4491,8 +4661,20 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x15d8
 &subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3181
++subdevice.name		ThinkCentre M75n IoT
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15d8
+&subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x5124
 +subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15d8
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xcc10
++subdevice.name		RXi2-BP
 
  vendor.id		pci 0x1002
 &device.id		pci 0x15dd
@@ -4506,9 +4688,21 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x15dd
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15dd
 &subvendor.id		pci 0x1458
 &subdevice.id		pci 0xd000
 +subdevice.name		Radeon RX Vega 11
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15dd
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xcc10
++subdevice.name		RXi2-BP
 
  vendor.id		pci 0x1002
 &device.id		pci 0x15de
@@ -4522,9 +4716,21 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x15de
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME B450M-A Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15de
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x5124
 +subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x15de
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xcc10
++subdevice.name		RXi2-BP
 
  vendor.id		pci 0x1002
 &device.id		pci 0x15df
@@ -4537,6 +4743,12 @@
 +subdevice.name		Pavilion Laptop 15-cw1xxx
 
  vendor.id		pci 0x1002
+&device.id		pci 0x15df
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x15ff
 +device.name		Fenghuang [Zhongshan Subor Z+]
 
@@ -4547,6 +4759,22 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x1636
 +device.name		Renoir
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x1638
++device.name		Cezanne
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x163f
++device.name		VanGogh
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x164c
++device.name		Lucienne
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x164d
++device.name		Rembrandt
 
  vendor.id		pci 0x1002
 &device.id		pci 0x1714
@@ -4590,7 +4818,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x3e50
-+device.name		RV380 [Radeon X600]
++device.name		RV380 [Radeon X550/X600]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x3e54
@@ -4598,7 +4826,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x3e70
-+device.name		RV380 [Radeon X600] (Secondary)
++device.name		RV380 [Radeon X550/X600] (Secondary)
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4136
@@ -5494,6 +5722,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4383
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4383
 &subvendor.id		pci 0x17f2
 &subdevice.id		pci 0x5000
 +subdevice.name		KI690-AM2 Motherboard
@@ -5559,6 +5793,12 @@
 &subvendor.id		pci 0x1462
 &subdevice.id		pci 0x7368
 +subdevice.name		K9AG Neo2
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4385
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4385
@@ -5842,6 +6082,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4390
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4390
 &subvendor.id		pci 0x1849
 &subdevice.id		pci 0x4390
 +subdevice.name		Motherboard (one of many)
@@ -5968,6 +6214,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4396
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4396
 &subvendor.id		pci 0x15d9
 &subdevice.id		pci 0xa811
 +subdevice.name		H8DGU
@@ -6026,6 +6278,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4397
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4397
 &subvendor.id		pci 0x15d9
 &subdevice.id		pci 0xa811
 +subdevice.name		H8DGU
@@ -6057,6 +6315,12 @@
 &subvendor.id		pci 0x105b
 &subdevice.id		pci 0x0e13
 +subdevice.name		N15235/A74MX mainboard / AMD SB700
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4398
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4398
@@ -6100,6 +6364,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x4399
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x4399
 &subvendor.id		pci 0x174b
 &subdevice.id		pci 0x1001
 +subdevice.name		PURE Fusion Mini
@@ -6137,6 +6407,12 @@
 &subvendor.id		pci 0x105b
 &subdevice.id		pci 0x0e13
 +subdevice.name		N15235/A74MX mainboard / AMD SB700
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x439c
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
 
  vendor.id		pci 0x1002
 &device.id		pci 0x439d
@@ -6177,6 +6453,12 @@
 &subvendor.id		pci 0x105b
 &subdevice.id		pci 0x0e13
 +subdevice.name		N15235/A74MX mainboard / AMD SB700
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x439d
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
 
  vendor.id		pci 0x1002
 &device.id		pci 0x439d
@@ -7532,7 +7814,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5046
-+device.name		Rage 4 [Rage 128 PRO AGP 4X TMDS]
++device.name		Rage 4 [Rage 128 PRO AGP 4X]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5046
@@ -7590,7 +7872,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5050
-+device.name		Rage128 [Xpert 128 PCI]
++device.name		Rage 4 [Rage 128 PRO PCI / Xpert 128 PCI]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5050
@@ -7600,7 +7882,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5052
-+device.name		Rage 128 PRO AGP 4X TMDS
++device.name		Rage 4 [Rage 128 PRO AGP 4X]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5144
@@ -8163,16 +8445,6 @@
 +subdevice.name		Xpert 99
 
  vendor.id		pci 0x1002
-&device.id		pci 0x5346
-+device.name		Rage 128 SF/4x AGP 2x
-
- vendor.id		pci 0x1002
-&device.id		pci 0x5346
-&subvendor.id		pci 0x1002
-&subdevice.id		pci 0x0048
-+subdevice.name		RAGE 128 16MB VGA TVOUT AMC PAL
-
- vendor.id		pci 0x1002
 &device.id		pci 0x534d
 +device.name		Rage 128 4X AGP 4x
 
@@ -8308,7 +8580,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x554d
-+device.name		R430 [Radeon X800 XL]
++device.name		R480 [Radeon X800 GTO2/XL]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x554d
@@ -8348,7 +8620,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x556d
-+device.name		R430 [Radeon X800 XL] (Secondary)
++device.name		R480 [Radeon X800 GTO2/XL] (Secondary)
 
  vendor.id		pci 0x1002
 &device.id		pci 0x556d
@@ -8592,7 +8864,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5960
-+device.name		RV280 [Radeon 9200 PRO]
++device.name		RV280 [Radeon 9200 PRO / 9250]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5960
@@ -8682,7 +8954,7 @@
 &device.id		pci 0x5964
 &subvendor.id		pci 0x1458
 &subdevice.id		pci 0x4018
-+subdevice.name		Radeon 9200 SE
++subdevice.name		R92S128T (Radeon 9200 SE 128MB)
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5964
@@ -9094,7 +9366,7 @@
 &device.id		pci 0x5d44
 &subvendor.id		pci 0x1458
 &subdevice.id		pci 0x4019
-+subdevice.name		Radeon 9200 SE (Secondary)
++subdevice.name		R92S128T (Radeon 9200 SE 128MB Secondary)
 
  vendor.id		pci 0x1002
 &device.id		pci 0x5d44
@@ -9266,7 +9538,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6600
-+device.name		Mars [Radeon HD 8670A/8670M/8750M]
++device.name		Mars [Radeon HD 8670A/8670M/8750M / R7 M370]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6600
@@ -9353,14 +9625,30 @@
 +subdevice.name		MXRT-2600
 
  vendor.id		pci 0x1002
+&device.id		pci 0x6609
++device.name		Oland GL [FirePro W2100 / Barco MXRT 2600]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x6610
-+device.name		Oland XT [Radeon HD 8670 / R7 250/350]
++device.name		Oland XT [Radeon HD 8670 / R5 340X OEM / R7 250/350/350X OEM]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6610
 &subvendor.id		pci 0x1019
 &subdevice.id		pci 0x0030
 +subdevice.name		Radeon HD 8670
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6610
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0081
++subdevice.name		Radeon R7 350X OEM
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6610
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0083
++subdevice.name		Radeon R5 340X OEM
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6610
@@ -9412,13 +9700,43 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6611
-+device.name		Oland [Radeon HD 8570 / R7 240/340 / Radeon 520 OEM]
++device.name		Oland [Radeon HD 8570 / R5 430 OEM / R7 240/340 / Radeon 520 OEM]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6611
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1001
++subdevice.name		Radeon R5 430 OEM (1024 MByte)
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6611
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1002
++subdevice.name		Radeon R5 430 OEM (2048 MByte)
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6611
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x1711
++subdevice.name		R5 430 OEM (2048 MByte)
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6611
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x210b
 +subdevice.name		Radeon R5 240 OEM
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6611
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2121
++subdevice.name		Radeon HD 8570 OEM
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6611
+&subvendor.id		pci 0x10cf
+&subdevice.id		pci 0x1889
++subdevice.name		Radeon HD 8570 OEM
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6611
@@ -9525,6 +9843,10 @@
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x3d2a
 +subdevice.name		MXRT-5600
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x664d
++device.name		Bonaire [FirePro W5100 / Barco MXRT-5600]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6650
@@ -9796,7 +10118,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x66a1
-+device.name		Vega 20
++device.name		Vega 20 WKS GL-XE [Radeon Pro VII]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x66a2
@@ -9804,7 +10126,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x66a3
-+device.name		Vega 20
++device.name		Vega 20 [Radeon Pro Vega II/Radeon Pro Vega II Duo]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x66a7
@@ -10926,7 +11248,7 @@
 &device.id		pci 0x6749
 &subvendor.id		pci 0x15c3
 &subdevice.id		pci 0x2b06
-+subdevice.name		MED-X4900
++subdevice.name		MED-X4900 (EIZO)
 
  vendor.id		pci 0x1002
 &device.id		pci 0x674a
@@ -11090,7 +11412,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6759
-+device.name		Turks PRO [Radeon HD 6570/7570/8550]
++device.name		Turks PRO [Radeon HD 6570/7570/8550 / R5 230]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6759
@@ -11142,9 +11464,33 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6759
+&subvendor.id		pci 0x1682
+&subdevice.id		pci 0x5230
++subdevice.name		Radeon R5 230 series
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6759
+&subvendor.id		pci 0x1682
+&subdevice.id		pci 0x6450
++subdevice.name		Radeon HD 6450 series
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6759
 &subvendor.id		pci 0x174b
 &subdevice.id		pci 0x7570
 +subdevice.name		Radeon HD 7570
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6759
+&subvendor.id		pci 0x174b
+&subdevice.id		pci 0x8550
++subdevice.name		Radeon HD8550 OEM
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6759
+&subvendor.id		pci 0x174b
+&subdevice.id		pci 0x8570
++subdevice.name		Radeon HD8550 OEM
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6759
@@ -11157,6 +11503,18 @@
 &subvendor.id		pci 0x174b
 &subdevice.id		pci 0xe181
 +subdevice.name		Radeon HD 6570
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6759
+&subvendor.id		pci 0x1787
+&subdevice.id		pci 0xa230
++subdevice.name		Radeon R5 230 series
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6759
+&subvendor.id		pci 0x1787
+&subdevice.id		pci 0xa450
++subdevice.name		Radeon HD 6450 series
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6759
@@ -13215,6 +13573,10 @@
 +subdevice.name		Sapphire Nitro R9 390
 
  vendor.id		pci 0x1002
+&device.id		pci 0x67b8
++device.name		Hawaii XT [Radeon R9 290X Engineering Sample]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x67b9
 +device.name		Vesuvius [Radeon R9 295X2]
 
@@ -13265,6 +13627,10 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x67d0
 +device.name		Ellesmere [Radeon Pro V7300X / V7350x2]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67d7
++device.name		Ellesmere [Radeon Pro WX 5100 / Barco MXRT-6700]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
@@ -13381,8 +13747,20 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
 &subvendor.id		pci 0x1462
+&subdevice.id		pci 0x341b
++subdevice.name		Radeon RX 570 Armor 8G OC
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x1462
 &subdevice.id		pci 0x341e
 +subdevice.name		Radeon RX 570 Armor 4G OC
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x809e
++subdevice.name		Radeon RX 480 4GB
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
@@ -13404,6 +13782,30 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
+&subvendor.id		pci 0x148c
+&subdevice.id		pci 0x2377
++subdevice.name		Red Devil RX 580 8G Golden
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x148c
+&subdevice.id		pci 0x2378
++subdevice.name		Radeon RX 580
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x148c
+&subdevice.id		pci 0x2379
++subdevice.name		Radeon RX 570 4G [Red Dragon]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x148c
+&subdevice.id		pci 0x2391
++subdevice.name		Radeon RX 590 [Red Devil]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
 &subvendor.id		pci 0x1682
 &subdevice.id		pci 0x9470
 +subdevice.name		Radeon RX 470
@@ -13417,6 +13819,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
 &subvendor.id		pci 0x1682
+&subdevice.id		pci 0x9587
++subdevice.name		Radeon RX 590 FATBOY 8GB
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x1682
 &subdevice.id		pci 0x9588
 +subdevice.name		Radeon RX 580 XTR
 
@@ -13425,6 +13833,12 @@
 &subvendor.id		pci 0x1682
 &subdevice.id		pci 0xc570
 +subdevice.name		Radeon RX 570
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x1682
+&subdevice.id		pci 0xc580
++subdevice.name		Radeon RX 580
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67df
@@ -13473,6 +13887,12 @@
 &subvendor.id		pci 0x1da2
 &subdevice.id		pci 0xe366
 +subdevice.name		Nitro+ Radeon RX 570/580/590
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67df
+&subvendor.id		pci 0x1da2
+&subdevice.id		pci 0xe387
++subdevice.name		Radeon RX 570 Pulse 4GB
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67e0
@@ -13564,6 +13984,12 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67ef
+&subvendor.id		pci 0x1025
+&subdevice.id		pci 0x1367
++subdevice.name		RX560X 4GB
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67ef
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1703
 +subdevice.name		RX 560D OEM OC 2 GB
@@ -13573,6 +13999,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x3421
 +subdevice.name		Radeon RX 460
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x67ef
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x0561
++subdevice.name		AREZ Radeon RX 560
 
  vendor.id		pci 0x1002
 &device.id		pci 0x67ef
@@ -13989,6 +14421,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3824
 +subdevice.name		Radeon R9 M375
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x6820
+&subvendor.id		pci 0x1da2
+&subdevice.id		pci 0xe26a
++subdevice.name		Radeon R7 250
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6821
@@ -14913,8 +15351,28 @@
 +device.name		Vega 10 [Radeon PRO WX 8100/8200]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x6869
++device.name		Vega 10 XGA [Radeon Pro Vega 48]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x686a
++device.name		Vega 10 LEA
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x686b
++device.name		Vega 10 XTXA [Radeon Pro Vega 64X]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x686c
 +device.name		Vega 10 [Radeon Instinct MI25 MxGPU]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x686d
++device.name		Vega 10 GLXTA
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x686e
++device.name		Vega 10 GLXLA
 
  vendor.id		pci 0x1002
 &device.id		pci 0x687f
@@ -14930,7 +15388,19 @@
 &device.id		pci 0x687f
 &subvendor.id		pci 0x1002
 &subdevice.id		pci 0x6b76
-+subdevice.name		RX Vega56
++subdevice.name		RX Vega64
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x687f
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x230c
++subdevice.name		Radeon RX VEGA 56 GAMING OC 8G
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x687f
+&subvendor.id		pci 0x1da2
+&subdevice.id		pci 0xe376
++subdevice.name		Radeon RX VEGA 56 Pulse 8GB OC HBM2
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6880
@@ -16331,6 +16801,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x68da
 +device.name		Redwood LE [Radeon HD 5550/5570/5630/6390/6490/7570]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x68da
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x8071
++subdevice.name		VR5550-MD1G (Radeon HD 5550)
 
  vendor.id		pci 0x1002
 &device.id		pci 0x68da
@@ -17819,8 +18295,12 @@
 +device.name		Meso XT [Radeon R5 M315]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x6920
++device.name		Amethyst [Radeon R9 M395/ M395X Mac Edition]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x6921
-+device.name		Amethyst XT [Radeon R9 M295X]
++device.name		Amethyst XT [Radeon R9 M295X / M390X]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6929
@@ -17909,6 +18389,16 @@
 +subdevice.name		Radeon R9 380 Nitro 4G D5
 
  vendor.id		pci 0x1002
+&device.id		pci 0x6939
+&subvendor.id		pci 0x174b
+&subdevice.id		pci 0xe315
++subdevice.name		Radeon R9 285
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x693b
++device.name		Tonga PRO GL [FirePro W7100 / Barco MXRT-7600]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x694c
 +device.name		Polaris 22 XT [Radeon RX Vega M GH]
 
@@ -17939,6 +18429,10 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x6987
 +device.name		Lexa [Radeon 540X/550X/630 / RX 640 / E9171 MCM]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x698f
++device.name		Lexa XT [Radeon PRO WX 3100 / Barco MXRT 4700]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x6995
@@ -18012,7 +18506,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x7104
-+device.name		R520 GL [FireGL V7200]
++device.name		R520 GL [FireGL V7200 / Barco MXTR-5100]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x7104
@@ -18375,6 +18869,10 @@
 +device.name		RV530 [Radeon X1600 PRO]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x71c3
++device.name		RV530 [Radeon X1600 PRO]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x71c4
 +device.name		RV530/M56 GL [Mobility FireGL V5200]
 
@@ -18664,15 +19162,43 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x7310
-+device.name		Navi 10
++device.name		Navi 10 [Radeon Pro W5700X]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x7312
 +device.name		Navi 10 [Radeon Pro W5700]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x7314
++device.name		Navi 10 USB
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x731f
 +device.name		Navi 10 [Radeon RX 5600 OEM/5600 XT / 5700/5700 XT]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x731f
+&subvendor.id		pci 0x1458
+&subdevice.id		pci 0x2313
++subdevice.name		Radeon RX 5700 XT Gaming OC
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x731f
+&subvendor.id		pci 0x1682
+&subdevice.id		pci 0x5701
++subdevice.name		RX 5700 XT RAW II
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x731f
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x5120
++subdevice.name		Radeon RX 5600 XT
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x731f
+&subvendor.id		pci 0x1da2
+&subdevice.id		pci 0xe411
++subdevice.name		Radeon RX 5600 XT
 
  vendor.id		pci 0x1002
 &device.id		pci 0x7340
@@ -18689,6 +19215,88 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x734f
 +device.name		Navi 14 [Radeon Pro W5300M]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x7360
++device.name		Navi 12 [Radeon Pro 5600M / V520]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x7362
++device.name		Navi 12 [Radeon Pro V520]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x7388
++device.name		Arcturus GL-XL
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x738c
++device.name		Arcturus GL-XL [AMD Instinct MI100]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x738e
++device.name		Arcturus GL-XL
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73a3
++device.name		Navi 21 [Radeon PRO W6800]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73a4
++device.name		Navi 21 USB
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73af
++device.name		Navi 21 [Radeon RX 6900 XT]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73bf
++device.name		Navi 21 [Radeon RX 6800/6800 XT / 6900 XT]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73bf
+&subvendor.id		pci 0x1eae
+&subdevice.id		pci 0x6701
++subdevice.name		XFX Speedster MERC 319 AMD Radeon RX 6800 XT Black
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73c3
++device.name		Navi 22
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73c4
++device.name		Navi 22 USB
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73df
++device.name		Navi 22 [Radeon RX 6700/6700 XT / 6800M]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73e0
++device.name		Navi 23
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73e1
++device.name		Navi 23
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73e4
++device.name		Navi 23 USB
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x73ff
++device.name		Navi 23 [Radeon RX 6600/6600 XT/6600M]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x7408
++device.name		Aldebaran
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x740c
++device.name		Aldebaran
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x740f
++device.name		Aldebaran
 
  vendor.id		pci 0x1002
 &device.id		pci 0x7833
@@ -19607,6 +20215,12 @@
 +subdevice.name		Mobility Radeon HD 3470
 
  vendor.id		pci 0x1002
+&device.id		pci 0x95c0
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x3243
++subdevice.name		C120D
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x95c2
 +device.name		RV620/M82 [Mobility Radeon HD 3410/3430]
 
@@ -19655,6 +20269,12 @@
 +device.name		RS780 HDMI Audio [Radeon 3000/3100 / HD 3200/3300]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x960f
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7596
++subdevice.name		760GM-E51(MS-7596) Motherboard
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x9610
 +device.name		RS780 [Radeon HD 3200]
 
@@ -19681,8 +20301,18 @@
 +device.name		RS780D [Radeon HD 3300]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x9615
++device.name		RS780E [Radeon HD 3200]
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x9616
 +device.name		RS780L [Radeon 3000]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x9616
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7501
++subdevice.name		760GM-E51(MS-7596) Motherboard
 
  vendor.id		pci 0x1002
 &device.id		pci 0x9640
@@ -19853,6 +20483,12 @@
 +device.name		Kabini [Radeon HD 8400 / R3 Series]
 
  vendor.id		pci 0x1002
+&device.id		pci 0x9830
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
+
+ vendor.id		pci 0x1002
 &device.id		pci 0x9831
 +device.name		Kabini [Radeon HD 8400E]
 
@@ -19901,6 +20537,12 @@
  vendor.id		pci 0x1002
 &device.id		pci 0x9840
 +device.name		Kabini HDMI/DP Audio
+
+ vendor.id		pci 0x1002
+&device.id		pci 0x9840
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
 
  vendor.id		pci 0x1002
 &device.id		pci 0x9840
@@ -20182,7 +20824,7 @@
 
  vendor.id		pci 0x1002
 &device.id		pci 0x991e
-+device.name		Bishop
++device.name		Bishop [Xbox One S APU]
 
  vendor.id		pci 0x1002
 &device.id		pci 0x9920
@@ -20473,6 +21115,10 @@
  vendor.id		pci 0x1002
 &device.id		pci 0xab20
 +device.name		Vega 20 HDMI Audio [Radeon VII]
+
+ vendor.id		pci 0x1002
+&device.id		pci 0xab28
++device.name		Navi 21 HDMI Audio [Radeon RX 6800/6800 XT / 6900 XT]
 
  vendor.id		pci 0x1002
 &device.id		pci 0xab38
@@ -21145,19 +21791,19 @@
 
  vendor.id		pci 0x1011
 &device.id		pci 0x000f
-+device.name		DEFPA FDDI PCI-to-PDQ Interface Chip [PFI]
++device.name		PCI-to-PDQ Interface Chip [PFI] FDDI (DEFPA)
 
  vendor.id		pci 0x1011
 &device.id		pci 0x000f
 &subvendor.id		pci 0x1011
 &subdevice.id		pci 0xdef1
-+subdevice.name		FDDI controller (DEFPA)
++subdevice.name		FDDIcontroller/PCI (DEFPA)
 
  vendor.id		pci 0x1011
 &device.id		pci 0x000f
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0xdef1
-+subdevice.name		FDDI controller (3X-DEFPA)
++subdevice.name		FDDIcontroller/PCI (3X-DEFPA)
 
  vendor.id		pci 0x1011
 &device.id		pci 0x0014
@@ -21171,7 +21817,7 @@
 
  vendor.id		pci 0x1011
 &device.id		pci 0x0016
-+device.name		DGLPB [OPPO]
++device.name		ATMworks 350 Adapter [OPPO] (DGLPB)
 
  vendor.id		pci 0x1011
 &device.id		pci 0x0017
@@ -23343,6 +23989,12 @@
 +device.name		Family 17h (Models 00h-1fh) PCIe Dummy Host Bridge
 
  vendor.id		pci 0x1022
+&device.id		pci 0x1452
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x1453
 +device.name		Family 17h (Models 00h-0fh) PCIe GPP Bridge
 
@@ -23421,6 +24073,14 @@
  vendor.id		pci 0x1022
 &device.id		pci 0x1468
 +device.name		Zeppelin Cryptographic Coprocessor NTBCCP
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x1470
++device.name		Vega 10 PCIe Bridge
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x1471
++device.name		Vega 10 PCIe Bridge
 
  vendor.id		pci 0x1022
 &device.id		pci 0x1480
@@ -23557,6 +24217,10 @@
 +subdevice.name		X570-A PRO motherboard
 
  vendor.id		pci 0x1022
+&device.id		pci 0x149d
++device.name		Vangogh CVIP
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x1510
 +device.name		Family 14h Processor Root Complex
 
@@ -23613,6 +24277,12 @@
  vendor.id		pci 0x1022
 &device.id		pci 0x1536
 +device.name		Family 16h Processor Root Complex
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x1536
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
 
  vendor.id		pci 0x1022
 &device.id		pci 0x1536
@@ -23899,6 +24569,12 @@
 +subdevice.name		Pavilion Laptop 15-cw1xxx
 
  vendor.id		pci 0x1022
+&device.id		pci 0x15d0
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME B450M-A Motherboard
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x15d1
 +device.name		Raven/Raven2 IOMMU
 
@@ -23907,6 +24583,18 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x8615
 +subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15d1
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME B450M-A Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15d1
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15d2
@@ -23933,8 +24621,20 @@
 +device.name		Raven/Raven2 Internal PCIe GPP Bridge 0 to Bus A
 
  vendor.id		pci 0x1022
+&device.id		pci 0x15db
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x15dc
 +device.name		Raven/Raven2 Internal PCIe GPP Bridge 0 to Bus B
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15dc
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15de
@@ -23946,9 +24646,21 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15df
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15df
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x5124
 +subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15df
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e0
@@ -23962,9 +24674,21 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e0
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e0
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x5124
 +subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e0
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e1
@@ -23978,9 +24702,21 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e1
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e1
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x5124
 +subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e1
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e2
@@ -24001,6 +24737,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x8615
 +subdevice.name		Pavilion Laptop 15-cw1xxx
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x15e3
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x86c7
++subdevice.name		PRIME B450M-A Motherboard
 
  vendor.id		pci 0x1022
 &device.id		pci 0x15e3
@@ -24279,6 +25021,14 @@
 +device.name		Renoir I2S
 
  vendor.id		pci 0x1022
+&device.id		pci 0x1648
++device.name		VanGogh Root Complex
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x1649
++device.name		VanGogh PSP/CCP
+
+ vendor.id		pci 0x1022
 &device.id		pci 0x1700
 +device.name		Family 12h/14h Processor Function 0
 
@@ -24484,7 +25234,7 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x2001
-+device.name		79c978 [HomePNA]
++device.name		Am79C978 PCnet Home (HomePNA) 1/10 PCI Ethernet Adapter [Am79C971 PHY]
 
  vendor.id		pci 0x1022
 &device.id		pci 0x2001
@@ -24563,6 +25313,14 @@
  vendor.id		pci 0x1022
 &device.id		pci 0x209a
 +device.name		CS5536 [Geode companion] IDE
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x2625
++device.name		Am79C973 [Lance/PCI PCNet/32]
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x2627
++device.name		Am79C975 [Lance/PCI PCNet/32]
 
  vendor.id		pci 0x1022
 &device.id		pci 0x3000
@@ -24922,6 +25680,12 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7801
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7801
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3988
 +subdevice.name		Z50-75
@@ -24976,6 +25740,12 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7807
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7807
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3988
 +subdevice.name		Z50-75
@@ -25001,6 +25771,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1985
 +subdevice.name		Pavilion 17-e163sg Notebook PC
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7808
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7808
@@ -25052,6 +25828,12 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x780b
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780b
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3988
 +subdevice.name		Z50-75
@@ -25090,6 +25872,12 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x780d
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8576
++subdevice.name		AM1I-A Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780d
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3988
 +subdevice.name		Z50-75
@@ -25115,6 +25903,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1985
 +subdevice.name		Pavilion 17-e163sg Notebook PC
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x780e
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
 
  vendor.id		pci 0x1022
 &device.id		pci 0x780e
@@ -25158,6 +25952,12 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7814
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8623
++subdevice.name		AM1I-A Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7814
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3988
 +subdevice.name		Z50-75
@@ -25184,9 +25984,21 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7901
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7901
 &subvendor.id		pci 0x1462
 &subdevice.id		pci 0x7c37
 +subdevice.name		X570-A PRO motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x7901
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x7902
@@ -25220,6 +26032,12 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x790b
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790b
 &subvendor.id		pci 0x1462
 &subdevice.id		pci 0x7c37
 +subdevice.name		X570-A PRO motherboard
@@ -25229,6 +26047,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x5124
 +subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790b
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x790e
@@ -25242,6 +26066,12 @@
 
  vendor.id		pci 0x1022
 &device.id		pci 0x790e
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x876b
++subdevice.name		PRIME B450M-A Motherboard
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790e
 &subvendor.id		pci 0x1462
 &subdevice.id		pci 0x7c37
 +subdevice.name		X570-A PRO motherboard
@@ -25251,6 +26081,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x5124
 +subdevice.name		ThinkPad E595
+
+ vendor.id		pci 0x1022
+&device.id		pci 0x790e
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x1022
 &device.id		pci 0x790f
@@ -26138,6 +26974,12 @@
 &subvendor.id		pci 0x102b
 &subdevice.id		pci 0x0100
 +subdevice.name		MGA-1064SG Mystique
+
+ vendor.id		pci 0x102b
+&device.id		pci 0x051a
+&subvendor.id		pci 0x102b
+&subdevice.id		pci 0x051a
++subdevice.name		MGA-1164SG Mystique 220
 
  vendor.id		pci 0x102b
 &device.id		pci 0x051a
@@ -28202,6 +29044,12 @@
 +subdevice.name		PCI-USB2 (OHCI subsystem)
 
  vendor.id		pci 0x1033
+&device.id		pci 0x0035
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4d44
++subdevice.name		D850EMV2 motherboard
+
+ vendor.id		pci 0x1033
 &device.id		pci 0x003b
 +device.name		PCI to C-bus Bridge
 
@@ -28350,6 +29198,12 @@
 &subvendor.id		pci 0x807d
 &subdevice.id		pci 0x1043
 +subdevice.name		PCI-USB2 (EHCI subsystem)
+
+ vendor.id		pci 0x1033
+&device.id		pci 0x00e0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4d44
++subdevice.name		D850EMV2 motherboard
 
  vendor.id		pci 0x1033
 &device.id		pci 0x00e7
@@ -33606,55 +34460,55 @@
 &device.id		pci 0x2339
 &subvendor.id		pci 0x11a4
 &subdevice.id		pci 0x000a
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0000
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0004
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0005
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0006
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0008
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0009
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x000a
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x2339
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x000c
-+subdevice.name		Barco Metheus 5 Megapixel
++subdevice.name		Metheus 5 Megapixel
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
@@ -33664,49 +34518,49 @@
 &device.id		pci 0x493d
 &subvendor.id		pci 0x11a4
 &subdevice.id		pci 0x000a
-+subdevice.name		Barco Metheus 5 Megapixel, Dual Head
++subdevice.name		Metheus 5 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
 &subvendor.id		pci 0x11a4
 &subdevice.id		pci 0x000b
-+subdevice.name		Barco Metheus 5 Megapixel, Dual Head
++subdevice.name		Metheus 5 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0002
-+subdevice.name		Barco Metheus 4 Megapixel, Dual Head
++subdevice.name		Metheus 4 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0003
-+subdevice.name		Barco Metheus 5 Megapixel, Dual Head
++subdevice.name		Metheus 5 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0007
-+subdevice.name		Barco Metheus 5 Megapixel, Dual Head
++subdevice.name		Metheus 5 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0008
-+subdevice.name		Barco Metheus 5 Megapixel, Dual Head
++subdevice.name		Metheus 5 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x0009
-+subdevice.name		Barco Metheus 5 Megapixel, Dual Head
++subdevice.name		Metheus 5 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x493d
 &subvendor.id		pci 0x13cc
 &subdevice.id		pci 0x000a
-+subdevice.name		Barco Metheus 5 Megapixel, Dual Head
++subdevice.name		Metheus 5 Megapixel, Dual Head
 
  vendor.id		pci 0x105d
 &device.id		pci 0x5348
@@ -34061,6 +34915,10 @@
  vendor.id		pci 0x106b
 &device.id		pci 0x0007
 +device.name		O'Hare I/O
+
+ vendor.id		pci 0x106b
+&device.id		pci 0x000b
++device.name		Apple Camera
 
  vendor.id		pci 0x106b
 &device.id		pci 0x000c
@@ -34825,6 +35683,12 @@
 +subdevice.name		3830C 16G Fibre Channel Host Bus Adapter
 
  vendor.id		pci 0x1077
+&device.id		pci 0x2031
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0241
++subdevice.name		QLE2670 16Gb Single Port Fibre Channel Adapter
+
+ vendor.id		pci 0x1077
 &device.id		pci 0x2071
 +device.name		ISP2714-based 16/32Gb Fibre Channel to PCIe Adapter
 
@@ -34867,6 +35731,22 @@
 &subvendor.id		pci 0x1077
 &subdevice.id		pci 0x02e3
 +subdevice.name		QLE2774 Quad Port 32GFC PCIe Gen4 x16 Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2089
++device.name		ISP2854-based 64/32G Fibre Channel to PCIe Controller with StorCryption
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2089
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02e8
++subdevice.name		QLE2884 Quad Port 64GFC PCIe Gen4 x16 Adapter with StorCryption
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2089
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02ea
++subdevice.name		QLE2784 Quad Port 32GFC PCIe Gen4 x16 Adapter with StorCryption
 
  vendor.id		pci 0x1077
 &device.id		pci 0x2100
@@ -34983,6 +35863,12 @@
 +subdevice.name		5830C 32Gb Dual Port Fibre Channel Adapter
 
  vendor.id		pci 0x1077
+&device.id		pci 0x2261
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x100d
++subdevice.name		NIC-FC680i-Mb-2x16G
+
+ vendor.id		pci 0x1077
 &device.id		pci 0x2281
 +device.name		ISP2812-based 64/32G Fibre Channel to PCIe Controller
 
@@ -35033,6 +35919,34 @@
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x02d4
 +subdevice.name		SN1610Q – 2P Enhanced 32GFC Dual Port Fibre Channel Host Bus Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2289
++device.name		ISP2852-based 64/32G Fibre Channel to PCIe Controller with StorCryption
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2289
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02e9
++subdevice.name		QLE2882 Dual Port 64GFC PCIe Gen4 x8 Adapter with StorCryption
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2289
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02eb
++subdevice.name		QLE2782 Dual Port 32GFC PCIe Gen4 x8 Adapter with StorCryption
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2289
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02ef
++subdevice.name		QLE2880 Single Port 64GFC PCIe Gen4 x8 Adapter with StorCryption
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2289
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x02f1
++subdevice.name		QLE2780 Single Port 32GFC PCIe Gen4 x8 Adapter with StorCryption
 
  vendor.id		pci 0x1077
 &device.id		pci 0x2300
@@ -35088,7 +36002,13 @@
 &device.id		pci 0x2432
 &subvendor.id		pci 0x1077
 &subdevice.id		pci 0x0137
-+subdevice.name		QLE2460 4 GB PCI-X Host-Bus-Adapter
++subdevice.name		QLE2460 Single-Port 4Gbps FC-to-PCI-X/PCIe Host Bus Adapter
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x2432
+&subvendor.id		pci 0x1077
+&subdevice.id		pci 0x0138
++subdevice.name		QLE2462 Dual-Port 4Gbps FC-to-PCI-X/PCIe Host Bus Adapter
 
  vendor.id		pci 0x1077
 &device.id		pci 0x2532
@@ -35533,6 +36453,18 @@
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x02bd
 +subdevice.name		10Gb 2P 524SFP+ NIC
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1030
++subdevice.name		NIC-ETH681i-Mb-2x25G
+
+ vendor.id		pci 0x1077
+&device.id		pci 0x8070
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1032
++subdevice.name		NIC-ETH682i-Mb-2x25G
 
  vendor.id		pci 0x1077
 &device.id		pci 0x8080
@@ -42032,6 +42964,12 @@
 
  vendor.id		pci 0x10b5
 &device.id		pci 0x9050
+&subvendor.id		pci 0x12fe
+&subdevice.id		pci 0x0001
++subdevice.name		CAN-PCI/331 CAN bus controller
+
+ vendor.id		pci 0x10b5
+&device.id		pci 0x9050
 &subvendor.id		pci 0x1369
 &subdevice.id		pci 0x8901
 +subdevice.name		PCX11+ PCI
@@ -46608,7 +47546,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x00f5
-+device.name		G71 [GeForce 7800 GS]
++device.name		G70/G71 [GeForce 7800 GS AGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x00f6
@@ -48558,7 +49496,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e0
-+device.name		G73 [GeForce 7600 GT]
++device.name		G73 [GeForce 7600 GT AGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e0
@@ -48568,7 +49506,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e1
-+device.name		G73 [GeForce 7600 GS]
++device.name		G73 [GeForce 7600 GS AGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e1
@@ -48584,21 +49522,25 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e2
-+device.name		G73 [GeForce 7300 GT]
++device.name		G73 [GeForce 7300 GT AGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e3
-+device.name		G71 [GeForce 7900 GS]
++device.name		G71 [GeForce 7900 GS AGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e4
-+device.name		G71 [GeForce 7950 GT]
++device.name		G71 [GeForce 7950 GT AGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02e4
 &subvendor.id		pci 0x1682
 &subdevice.id		pci 0x2271
 +subdevice.name		PV-T71A-YDF7 (512MB)
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x02e5
++device.name		G71 [GeForce 7600 GS AGP]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x02f0
@@ -49082,7 +50024,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0333
-+device.name		NV38 [GeForce FX 5950 Ultra]
++device.name		NV38 [GeForce FX 5950 Ultra / PCX 5950]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0334
@@ -51488,7 +52430,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x06ee
-+device.name		G98 [GeForce 9600 GT / 9800 GT]
++device.name		G98 [GeForce 9600 GT / 9800 GT / GT 240]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x06ef
@@ -52733,6 +53675,10 @@
  vendor.id		pci 0x10de
 &device.id		pci 0x0a23
 +device.name		GT216 [GeForce 210]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x0a24
++device.name		GT216 [GeForce 405]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0a26
@@ -54311,6 +55257,10 @@
 +device.name		GK107M [GeForce GT 650M Mac Edition]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x0fd6
++device.name		GK107M
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x0fd8
 +device.name		GK107M [GeForce GT 640M Mac Edition]
 
@@ -54375,6 +55325,10 @@
 &subvendor.id		pci 0x10de
 &subdevice.id		pci 0x101e
 +subdevice.name		GRID K100
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x0fe8
++device.name		GK107M
 
  vendor.id		pci 0x10de
 &device.id		pci 0x0fe9
@@ -57107,6 +58061,10 @@
 +subdevice.name		GK104 [GeForce GTX 760 OEM]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1186
++device.name		GK104 [GeForce GTX 660 Ti]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1187
 +device.name		GK104 [GeForce GTX 760]
 
@@ -57219,6 +58177,10 @@
  vendor.id		pci 0x10de
 &device.id		pci 0x11a7
 +device.name		GK104M [GeForce GTX 675MX]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x11a9
++device.name		GK104M [GeForce GTX 870M]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x11af
@@ -57651,6 +58613,10 @@
 +device.name		GK208 [GeForce GT 710]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x128a
++device.name		GK208B
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x128b
 +device.name		GK208B [GeForce GT 710]
 
@@ -57659,6 +58625,16 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x85f7
 +subdevice.name		GT710-SL-1GD5
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x128b
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8770
++subdevice.name		GT710-4H-SL-2GD5
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x128c
++device.name		GK208B
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1290
@@ -58215,6 +59191,10 @@
 +device.name		GM206 [GeForce GTX 950]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1404
++device.name		GM206 [GeForce GTX 960 FAKE]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1406
 +device.name		GM206 [GeForce GTX 960 OEM]
 
@@ -58393,6 +59373,10 @@
 +device.name		TU116 USB Type-C UCSI Controller
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1aef
++device.name		GA102 High Definition Audio Controller
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1b00
 +device.name		GP102 [TITAN X]
 
@@ -58423,6 +59407,10 @@
  vendor.id		pci 0x10de
 &device.id		pci 0x1b38
 +device.name		GP102GL [Tesla P40]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1b39
++device.name		GP102GL [Tesla P10]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1b70
@@ -58666,7 +59654,11 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1c35
-+device.name		GP106
++device.name		GP106M [Quadro P2000 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1c36
++device.name		GP106 [P106M]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1c60
@@ -58895,6 +59887,10 @@
 +device.name		GP108BM [GeForce MX250]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1d56
++device.name		GP108BM [GeForce MX330]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1d81
 +device.name		GV100 [TITAN V]
 
@@ -58981,12 +59977,16 @@
 +subdevice.name		RTX 2080 Ti GAMING X TRIO
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1e09
++device.name		TU102 [CMP 50HX]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1e2d
-+device.name		TU102B
++device.name		TU102 [GeForce RTX 2080 Ti Engineering Sample]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1e2e
-+device.name		TU102B
++device.name		TU102 [GeForce RTX 2080 Ti 12GB Engineering Sample]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1e30
@@ -59006,7 +60006,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1e36
-+device.name		TU102GL
++device.name		TU102GL [Quadro RTX 6000]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1e37
@@ -59151,6 +60151,10 @@
 +device.name		TU104BM [GeForce RTX 2080 SUPER Mobile / Max-Q]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1ef5
++device.name		TU104GLM [Quadro RTX 5000 Mobile Refresh]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1f02
 +device.name		TU106 [GeForce RTX 2070]
 
@@ -59181,6 +60185,14 @@
 +device.name		TU106 [GeForce GTX 1660 SUPER]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1f0a
++device.name		TU106 [GeForce GTX 1650]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f0b
++device.name		TU106 [CMP 40HX]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1f10
 +device.name		TU106M [GeForce RTX 2070 Mobile]
 
@@ -59191,6 +60203,10 @@
  vendor.id		pci 0x10de
 &device.id		pci 0x1f12
 +device.name		TU106M [GeForce RTX 2060 Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f14
++device.name		TU106M [GeForce RTX 2070 Mobile / Max-Q Refresh]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f15
@@ -59221,6 +60237,18 @@
 +device.name		TU106BM [GeForce RTX 2060 Mobile]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1f54
++device.name		TU106BM [GeForce RTX 2070 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f55
++device.name		TU106BM [GeForce RTX 2060 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f76
++device.name		TU106GLM [Quadro RTX 3000 Mobile Refresh]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1f81
 +device.name		TU117
 
@@ -59238,7 +60266,7 @@
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f94
-+device.name		TU117M
++device.name		TU117M [GeForce GTX 1650 Mobile]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1f95
@@ -59249,12 +60277,40 @@
 +device.name		TU117M [GeForce GTX 1650 Mobile / Max-Q]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1f97
++device.name		TU117M [GeForce MX450]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f98
++device.name		TU117M [GeForce MX450]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1f99
 +device.name		TU117M
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1f9c
++device.name		TU117M [GeForce MX450]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1f9d
++device.name		TU117M [GeForce GTX 1650 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1fae
 +device.name		TU117GL
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fb0
++device.name		TU117GLM [Quadro T1000 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fb1
++device.name		TU117GLM [Quadro T600 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fb2
++device.name		TU117GLM [Quadro T400 Mobile]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x1fb8
@@ -59265,8 +60321,56 @@
 +device.name		TU117GLM [Quadro T1000 Mobile]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x1fbb
++device.name		TU117GLM [Quadro T500 Mobile]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x1fbf
 +device.name		TU117GL
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fd9
++device.name		TU117BM [GeForce GTX 1650 Mobile Refresh]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1fdd
++device.name		TU117BM [GeForce GTX 1650 Mobile Refresh]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x1ff9
++device.name		TU117GLM [Quadro T1000 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20b0
++device.name		GA100 [A100 SXM4 40GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20b1
++device.name		GA100 [A100 PCIe 40GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20b2
++device.name		GA100 [A100 SXM4 80GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20b6
++device.name		GA100GL [PG506-232]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20b7
++device.name		GA100GL [A30 PCIe]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20be
++device.name		GA100 [GRID A100A]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20bf
++device.name		GA100 [GRID A100B]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x20f1
++device.name		GA100 [A100 PCIe 40GB]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x2182
@@ -59285,6 +60389,14 @@
 +device.name		TU116 [GeForce GTX 1650 SUPER]
 
  vendor.id		pci 0x10de
+&device.id		pci 0x2188
++device.name		TU116 [GeForce GTX 1650]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2189
++device.name		TU116 [CMP 30HX]
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x2191
 +device.name		TU116M [GeForce GTX 1660 Ti Mobile]
 
@@ -59301,12 +60413,262 @@
 +device.name		TU116GL
 
  vendor.id		pci 0x10de
+&device.id		pci 0x21c2
++device.name		TU116
+
+ vendor.id		pci 0x10de
 &device.id		pci 0x21c4
 +device.name		TU116 [GeForce GTX 1660 SUPER]
 
  vendor.id		pci 0x10de
 &device.id		pci 0x21d1
 +device.name		TU116BM [GeForce GTX 1660 Ti Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2200
++device.name		GA102
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2204
++device.name		GA102 [GeForce RTX 3090]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2205
++device.name		GA102 [GeForce RTX 3080 20GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2206
++device.name		GA102 [GeForce RTX 3080]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2206
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x1467
++subdevice.name		GA102 [GeForce RTX 3080]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2206
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x146d
++subdevice.name		GA102 [GeForce RTX 3080 20GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2206
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x3892
++subdevice.name		RTX 3080 10GB GAMING X TRIO
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2208
++device.name		GA102 [GeForce RTX 3080 Ti]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x220d
++device.name		GA102 [GeForce RTX 3080 Lite Hash Rate]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x222b
++device.name		GA102 [GeForce RTX 3090 Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x222f
++device.name		GA102 [GeForce RTX 3080 11GB / 12GB Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2230
++device.name		GA102GL [RTX A6000]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2231
++device.name		GA102GL [RTX A5000]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2235
++device.name		GA102GL [A40]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2236
++device.name		GA102GL [A10]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2237
++device.name		GA102GL [A10G]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x223f
++device.name		GA102GL
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x228b
++device.name		GA104 High Definition Audio Controller
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2302
++device.name		GA103
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2321
++device.name		GA103
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2482
++device.name		GA104 [GeForce RTX 3070 Ti]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2483
++device.name		GA104
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2484
++device.name		GA104 [GeForce RTX 3070]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2484
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x146b
++subdevice.name		GA104 [GeForce RTX 3070]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2484
+&subvendor.id		pci 0x10de
+&subdevice.id		pci 0x14ae
++subdevice.name		GA104 [GeForce RTX 3070 16GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2486
++device.name		GA104 [GeForce RTX 3060 Ti]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x249c
++device.name		GA104M [GeForce RTX 3080 Mobile / Max-Q 8GB/16GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x249d
++device.name		GA104M [GeForce RTX 3070 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x249f
++device.name		GA104M
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24ac
++device.name		GA104 [GeForce RTX 30x0 Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24ad
++device.name		GA104 [GeForce RTX 3060 Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24af
++device.name		GA104 [GeForce RTX 3070 Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24b0
++device.name		GA104GL [RTX A4000]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24b6
++device.name		GA104GLM [RTX A5000 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24b7
++device.name		GA104GLM [RTX A4000 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24b8
++device.name		GA104GLM [RTX A3000 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24bf
++device.name		GA104 [GeForce RTX 3070 Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24dc
++device.name		GA104M [GeForce RTX 3080 Mobile / Max-Q 8GB/16GB]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x24dd
++device.name		GA104M [GeForce RTX 3070 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2501
++device.name		GA106 [GeForce RTX 3060]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2503
++device.name		GA106 [GeForce RTX 3060]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2504
++device.name		GA106 [GeForce RTX 3060 Lite Hash Rate]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2505
++device.name		GA106
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2520
++device.name		GA106M [GeForce RTX 3060 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2523
++device.name		GA106M [GeForce RTX 3050 Ti Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x252f
++device.name		GA106 [GeForce RTX 3060 Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2560
++device.name		GA106M [GeForce RTX 3060 Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2563
++device.name		GA106M [GeForce RTX 3050 Ti Mobile / Max-Q]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x2583
++device.name		GA107 [GeForce RTX 3050]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25a0
++device.name		GA107M [GeForce RTX 3050 Ti Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25a2
++device.name		GA107M [GeForce RTX 3050 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25a4
++device.name		GA107
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25a5
++device.name		GA107M [GeForce RTX 3050 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25af
++device.name		GA107 [GeForce RTX 3050 Engineering Sample]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25b5
++device.name		GA107GLM [RTX A4 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25b8
++device.name		GA107GLM [RTX A2000 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25e0
++device.name		GA107BM [GeForce RTX 3050 Ti Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25e2
++device.name		GA107BM [GeForce RTX 3050 Mobile]
+
+ vendor.id		pci 0x10de
+&device.id		pci 0x25e5
++device.name		GA107BM [GeForce RTX 3050 Mobile]
 
  vendor.id		pci 0x10df
 +vendor.name		Emulex Corporation
@@ -59628,6 +60990,12 @@
 +subdevice.name		Synergy 5330C 2-Port 32Gb Fibre Channel Mezz Card
 
  vendor.id		pci 0x10df
+&device.id		pci 0xe300
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1060
++subdevice.name		NIC-FC730i-Mb-2P
+
+ vendor.id		pci 0x10df
 &device.id		pci 0xf011
 +device.name		Saturn: LightPulse Fibre Channel Host Adapter
 
@@ -59794,6 +61162,10 @@
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x02d6
 +subdevice.name		StoreFabric SN1610E 2-Port 32Gb Fibre Channel Adapter
+
+ vendor.id		pci 0x10df
+&device.id		pci 0xf500
++device.name		LPe37000/LPe38000 Series 32Gb/64Gb Fibre Channel Adapter
 
  vendor.id		pci 0x10df
 &device.id		pci 0xf700
@@ -60211,6 +61583,10 @@
 +device.name		RTL-8139/8139C/8139C+ Ethernet Controller
 
  vendor.id		pci 0x10ec
+&device.id		pci 0x3000
++device.name		Killer E3000 2.5GbE Controller
+
+ vendor.id		pci 0x10ec
 &device.id		pci 0x5208
 +device.name		RTS5208 PCI Express Card Reader
 
@@ -60326,6 +61702,12 @@
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x525a
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x525a
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x224f
 +subdevice.name		ThinkPad X1 Carbon 5th Gen
@@ -60361,6 +61743,10 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x1457
 +subdevice.name		K55A Laptop
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x5762
++device.name		RTS5763DL NVMe SSD Controller
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8029
@@ -60781,6 +62167,16 @@
 +subdevice.name		ALN-325C
 
  vendor.id		pci 0x10ec
+&device.id		pci 0x8161
++device.name		RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8161
+&subvendor.id		pci 0x10ec
+&subdevice.id		pci 0x8168
++subdevice.name		TP-Link TG-3468 v4.0 Gigabit PCI Express Network Adapter
+
+ vendor.id		pci 0x10ec
 &device.id		pci 0x8167
 +device.name		RTL-8110SC/8169SC Gigabit Ethernet
 
@@ -60841,6 +62237,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x04da
 +subdevice.name		Vostro 3750
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
@@ -60934,6 +62336,24 @@
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8554
++subdevice.name		H81M-C Motherboard
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x859e
++subdevice.name		AM1I-A Motherboard
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8677
++subdevice.name		PRIME B450M-A Motherboard
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
 &subvendor.id		pci 0x105b
 &subdevice.id		pci 0x0d7c
 +subdevice.name		D270S/D250S Motherboard
@@ -61001,6 +62421,12 @@
  vendor.id		pci 0x10ec
 &device.id		pci 0x8168
 &subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x3814
 +subdevice.name		Z50-75
 
@@ -61039,6 +62465,12 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0xd615
 +subdevice.name		Desktop Board D510MO/D525MW
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x8168
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8169
@@ -61133,6 +62565,46 @@
 &subvendor.id		pci 0xa0a0
 &subdevice.id		pci 0x0449
 +subdevice.name		AK86-L motherboard
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816a
++device.name		RTL8111xP UART #1
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816a
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816b
++device.name		RTL8111xP UART #2
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816b
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816c
++device.name		RTL8111xP IPMI interface
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816c
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816d
++device.name		RTL811x EHCI host controller
+
+ vendor.id		pci 0x10ec
+&device.id		pci 0x816d
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xce19
++subdevice.name		mCOM10-L1900
 
  vendor.id		pci 0x10ec
 &device.id		pci 0x8171
@@ -61305,6 +62777,10 @@
 +device.name		RTL8822CE 802.11ac PCIe Wireless Network Adapter
 
  vendor.id		pci 0x10ec
+&device.id		pci 0xc82f
++device.name		RTL8822CE 802.11ac PCIe Wireless Network Adapter
+
+ vendor.id		pci 0x10ec
 &device.id		pci 0xd723
 +device.name		RTL8723DE 802.11b/g/n PCIe Adapter
 
@@ -61387,6 +62863,10 @@
 +device.name		RME Hammerfall DSP MADI
 
  vendor.id		pci 0x10ee
+&device.id		pci 0x5005
++device.name		Alveo U250
+
+ vendor.id		pci 0x10ee
 &device.id		pci 0x7038
 +device.name		FPGA Card XC7VX690T
 
@@ -61395,6 +62875,10 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x402f
 +subdevice.name		FPGA XC7VX690T-3FFG1157E
+
+ vendor.id		pci 0x10ee
+&device.id		pci 0x8019
++device.name		Memory controller
 
  vendor.id		pci 0x10ee
 &device.id		pci 0x8380
@@ -62555,6 +64039,10 @@
 &device.id		pci 0x4310
 +device.name		RocketRaid 4310
 
+ vendor.id		pci 0x1103
+&device.id		pci 0x7505
++device.name		SSD7505 PCIe Gen4 x16 4-Port M.2 NVMe RAID Controller
+
  vendor.id		pci 0x1104
 +vendor.name		RasterOps Corp.
 
@@ -62758,7 +64246,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x0353
-+device.name		VX800 Host Bridge
++device.name		VX800/820-Series Chipset Host-Bridge Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x0364
@@ -62780,7 +64268,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x0410
-+device.name		VX900 Host Bridge: Host Control
++device.name		VX900 Series Host Bridge: Host Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x0415
@@ -62916,7 +64404,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x0581
-+device.name		CX700/VX700 RAID Controller
++device.name		CX700/VX700/VX800/820-Series Serial ATA RAID-Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x0581
@@ -63184,7 +64672,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x1324
-+device.name		CX700/VX700 Host Bridge
++device.name		CX700/VX700-Series Error Reporting
 
  vendor.id		pci 0x1106
 &device.id		pci 0x1327
@@ -63216,7 +64704,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x1410
-+device.name		VX900 Error Reporting
++device.name		VX900 Series Error Reporting
 
  vendor.id		pci 0x1106
 &device.id		pci 0x1571
@@ -63284,7 +64772,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x2324
-+device.name		CX700/VX700 Host Bridge
++device.name		CX700/VX700-Series Host Interface Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x2327
@@ -63316,7 +64804,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x2410
-+device.name		VX900 CPU Bus Controller
++device.name		VX900 Series CPU Bus Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x287a
@@ -63344,7 +64832,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3038
-+device.name		VT82xx/62xx UHCI USB 1.1 Controller
++device.name		VT82xx/62xx/VX700/8x0/900 UHCI USB 1.1 Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3038
@@ -63374,7 +64862,7 @@
 &device.id		pci 0x3038
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x808c
-+subdevice.name		VT6202 USB2.0 4 port controller
++subdevice.name		VT62xx USB1.1 4 port controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3038
@@ -63393,6 +64881,12 @@
 &subvendor.id		pci 0x1179
 &subdevice.id		pci 0x0001
 +subdevice.name		Magnia Z310
+
+ vendor.id		pci 0x1106
+&device.id		pci 0x3038
+&subvendor.id		pci 0x1234
+&subdevice.id		pci 0x0925
++subdevice.name		MVP3 USB Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3038
@@ -64040,7 +65534,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3104
-+device.name		USB 2.0
++device.name		USB 2.0 EHCI-Compliant Host-Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3104
@@ -64596,7 +66090,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3288
-+device.name		VT8237A/VT8251 HDA Controller
++device.name		VX900/VT8xxx High Definition Audio Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3288
@@ -64614,7 +66108,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3324
-+device.name		CX700/VX700 Host Bridge
++device.name		CX700/VX700-Series DRAM Bus Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3327
@@ -64650,11 +66144,15 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3353
-+device.name		VX800 PCI to PCI Bridge
++device.name		VX800/820 PCI to PCI Bridge
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3364
 +device.name		CN896/VN896/P4M900 Host Bridge
+
+ vendor.id		pci 0x1106
+&device.id		pci 0x3365
++device.name		VT630x IEEE 1394 Host Controller [Fire II/M]
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3371
@@ -64694,7 +66192,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3410
-+device.name		VX900 DRAM Bus Control
++device.name		VX900 Series DRAM Bus Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3410
@@ -64704,7 +66202,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3432
-+device.name		VL80x xHCI USB 3.0 Controller
++device.name		VL800/801 xHCI USB 3.0 Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3456
@@ -64716,7 +66214,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3483
-+device.name		VL805 USB 3.0 Host Controller
++device.name		VL805/806 xHCI USB 3.0 Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x3a01
@@ -64776,7 +66274,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x4324
-+device.name		CX700/VX700 Host Bridge
++device.name		CX700/VX700-Series Power Management and Testing Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x4327
@@ -64808,7 +66306,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x4410
-+device.name		VX900 Power Management and Chip Testing Control
++device.name		VX900 Series Power Management and Chip Testing Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x4410
@@ -64846,7 +66344,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x5324
-+device.name		VX800 Serial ATA and EIDE Controller
++device.name		CX700M2/VX700/VX800/820-Series Serial ATA & EIDE-Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x5327
@@ -64882,7 +66380,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x5410
-+device.name		VX900 APIC and Central Traffic Control
++device.name		VX900 Series APIC and Central Traffic Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x6100
@@ -64914,7 +66412,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x6410
-+device.name		VX900 Scratch Registers
++device.name		VX900 Series Scratch Registers
 
  vendor.id		pci 0x1106
 &device.id		pci 0x6410
@@ -64992,7 +66490,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x7324
-+device.name		CX700/VX700 Host Bridge
++device.name		CX700/VX700-Series North-South Module Interface Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x7327
@@ -65024,7 +66522,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x7410
-+device.name		VX900 North-South Module Interface Control
++device.name		VX900 Series North-South Module Interface Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0x7410
@@ -65046,7 +66544,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x8324
-+device.name		CX700/VX700 PCI to ISA Bridge
++device.name		CX700/VX700-Series Bus Control and Power Management
 
  vendor.id		pci 0x1106
 &device.id		pci 0x8353
@@ -65066,7 +66564,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x8410
-+device.name		VX900 Bus Control and Power Management
++device.name		VX900 Series Bus Control and Power Management
 
  vendor.id		pci 0x1106
 &device.id		pci 0x8410
@@ -65134,7 +66632,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x9001
-+device.name		VX900 Serial ATA Controller
++device.name		VX900 Series Serial-ATA Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x9082
@@ -65150,11 +66648,11 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0x9530
-+device.name		Secure Digital Memory Card Controller
++device.name		VX800/820/900 Series Secure Digital Memory Card Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0x95d0
-+device.name		SDIO Host Controller
++device.name		VX800/820/900 Series SDIO Host Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0xa208
@@ -65170,7 +66668,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xa353
-+device.name		VX8xx South-North Module Interface Control
++device.name		VX8xx/900 Series South-North Module Interface Control
 
  vendor.id		pci 0x1106
 &device.id		pci 0xa364
@@ -65178,11 +66676,11 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xa409
-+device.name		VX855/VX875 USB Device Controller
++device.name		VX855/VX875/VX900 Series USB Device Controller
 
  vendor.id		pci 0x1106
 &device.id		pci 0xa410
-+device.name		VX900 PCI Express Root Port 0
++device.name		VX900 Series PCI Express Root Port 0
 
  vendor.id		pci 0x1106
 &device.id		pci 0xb091
@@ -65232,7 +66730,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xb198
-+device.name		VT8237/VX700 PCI Bridge
++device.name		VT8237/CX700/VX700-Series PCI to PCI Bridge
 
  vendor.id		pci 0x1106
 &device.id		pci 0xb213
@@ -65244,7 +66742,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xb410
-+device.name		VX900 PCI Express Root Port 1
++device.name		VX900 Series PCI Express Root Port 1
 
  vendor.id		pci 0x1106
 &device.id		pci 0xb999
@@ -65268,7 +66766,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xc353
-+device.name		VX800/VX820 PCI Express Root Port
++device.name		VX800/820-Series PCI-Express Root (PCI-to-PCI Virtual Bridge)
 
  vendor.id		pci 0x1106
 &device.id		pci 0xc364
@@ -65280,7 +66778,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xc410
-+device.name		VX900 PCI Express Root Port 2
++device.name		VX900 Series PCI Express Root Port 2
 
  vendor.id		pci 0x1106
 &device.id		pci 0xd104
@@ -65304,7 +66802,7 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xd410
-+device.name		VX900 PCI Express Root Port 3
++device.name		VX900 Series PCI Express Root Port 3
 
  vendor.id		pci 0x1106
 &device.id		pci 0xe208
@@ -65320,11 +66818,11 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xe353
-+device.name		VX800/VX820 PCI Express Root Port
++device.name		VX800/820-Series PCI-Express Root Port 0
 
  vendor.id		pci 0x1106
 &device.id		pci 0xe410
-+device.name		VX900 PCI Express Physical Layer Electrical Sub-block
++device.name		VX900 Series PCI Express Physical Layer Electrical Sub-block
 
  vendor.id		pci 0x1106
 &device.id		pci 0xf208
@@ -65340,7 +66838,11 @@
 
  vendor.id		pci 0x1106
 &device.id		pci 0xf353
-+device.name		VX800/VX820 PCI Express Root Port
++device.name		VX800/820-Series PCI-Express Root Port 1
+
+ vendor.id		pci 0x1106
+&device.id		pci 0xf410
++device.name		VX900 Series PCI UART Port 0-3
 
  vendor.id		pci 0x1107
 +vendor.name		Stratus Computers
@@ -68372,7 +69874,7 @@
 +device.name		POET PSDMS Device
 
  vendor.id		pci 0x1135
-+vendor.name		Fuji Xerox Co Ltd
++vendor.name		FUJIFILM Business Innovation Corp.
 
  vendor.id		pci 0x1135
 &device.id		pci 0x0001
@@ -68499,6 +70001,18 @@
 &subvendor.id		pci 0x1137
 &subdevice.id		pci 0x014d
 +subdevice.name		VIC 1385 PCIe Management Controller
+
+ vendor.id		pci 0x1137
+&device.id		pci 0x0042
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0217
++subdevice.name		VIC 1455 PCIe Management Controller
+
+ vendor.id		pci 0x1137
+&device.id		pci 0x0042
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x0218
++subdevice.name		VIC 1457 PCIe Management Controller
 
  vendor.id		pci 0x1137
 &device.id		pci 0x0043
@@ -70593,6 +72107,10 @@
 &device.id		pci 0x0530
 +device.name		Stratix IV
 
+ vendor.id		pci 0x1172
+&device.id		pci 0x646c
++device.name		KT-500/KT-521 board
+
  vendor.id		pci 0x1173
 +vendor.name		Adobe Systems, Inc
 
@@ -70625,6 +72143,10 @@
  vendor.id		pci 0x1179
 &device.id		pci 0x0103
 +device.name		EX-IDE Type-B
+
+ vendor.id		pci 0x1179
+&device.id		pci 0x010e
++device.name		PXP04 NVMe SSD
 
  vendor.id		pci 0x1179
 &device.id		pci 0x010f
@@ -70687,8 +72209,18 @@
 +device.name		BG3 NVMe SSD Controller
 
  vendor.id		pci 0x1179
+&device.id		pci 0x0113
+&subvendor.id		pci 0x1179
+&subdevice.id		pci 0x0001
++subdevice.name		Toshiba KBG30ZMS128G 128GB NVMe SSD
+
+ vendor.id		pci 0x1179
 &device.id		pci 0x0115
 +device.name		XG4 NVMe SSD Controller
+
+ vendor.id		pci 0x1179
+&device.id		pci 0x011a
++device.name		XG6 NVMe SSD Controller
 
  vendor.id		pci 0x1179
 &device.id		pci 0x0404
@@ -71002,6 +72534,62 @@
 &subvendor.id		pci 0x117c
 &subdevice.id		pci 0x00ac
 +subdevice.name		Celerity FC-324E
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00bb
++device.name		Celerity FC 32/64Gb/s Gen 7 Fibre Channel HBA
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00bb
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00bc
++subdevice.name		Celerity FC-321P
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00bb
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00bd
++subdevice.name		Celerity FC-322P
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00bb
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00be
++subdevice.name		Celerity FC-324P
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00e6
++device.name		ExpressSAS GT 12Gb/s SAS/SATA HBA
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00c0
++subdevice.name		ExpressSAS H1280 GT
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00c1
++subdevice.name		ExpressSAS H1208 GT
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00c2
++subdevice.name		ExpressSAS H1244 GT
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00c3
++subdevice.name		ExpressSAS H12F0 GT
+
+ vendor.id		pci 0x117c
+&device.id		pci 0x00e6
+&subvendor.id		pci 0x117c
+&subdevice.id		pci 0x00c4
++subdevice.name		ExpressSAS H120F GT
 
  vendor.id		pci 0x117c
 &device.id		pci 0x8013
@@ -72123,6 +73711,10 @@
 &device.id		pci 0x0344
 +device.name		Model 44 Road Runner Frame Grabber
 
+ vendor.id		pci 0x118d
+&device.id		pci 0xb04e
++device.name		Claxon CXP4 CoaXPress frame grabber
+
  vendor.id		pci 0x118e
 +vendor.name		Hermstedt GmbH
 
@@ -72344,6 +73936,10 @@
 
  vendor.id		pci 0x11ab
 +vendor.name		Marvell Technology Group Ltd.
+
+ vendor.id		pci 0x11ab
+&device.id		pci 0x0100
++device.name		88F3700 [Armada 3700 Family] ARM SoC
 
  vendor.id		pci 0x11ab
 &device.id		pci 0x0146
@@ -73450,6 +75046,14 @@
 +device.name		MV64460/64461/64462 System Controller, Revision B
 
  vendor.id		pci 0x11ab
+&device.id		pci 0x6820
++device.name		88F6820 [Armada 385] ARM SoC
+
+ vendor.id		pci 0x11ab
+&device.id		pci 0x6828
++device.name		88F6828 [Armada 388] ARM SoC
+
+ vendor.id		pci 0x11ab
 &device.id		pci 0x7042
 +device.name		88SX7042 PCI-e 4-port SATA-II
 
@@ -73521,7 +75125,7 @@
 &device.id		pci 0x0002
 &subvendor.id		pci 0x1385
 &subdevice.id		pci 0xf004
-+subdevice.name		FA310TX
++subdevice.name		FA310/TX LAN 10/100 PCI Ethernet Adapter
 
  vendor.id		pci 0x11ad
 &device.id		pci 0x0002
@@ -74923,6 +76527,10 @@
  vendor.id		pci 0x11f8
 &device.id		pci 0x8546
 +device.name		PM8546 B-FEIP PSX 96xG3 PCIe Storage Switch
+
+ vendor.id		pci 0x11f8
+&device.id		pci 0x8562
++device.name		PM8562 Switchtec PFX-L 32xG3 Fanout-Lite PCIe Gen3 Switch
 
  vendor.id		pci 0x11f9
 +vendor.name		I-Cube Inc
@@ -76500,6 +78108,40 @@
 &subdevice.id		pci 0x1100
 +subdevice.name		AX8814X Based PCI Fast Ethernet Adapter
 
+ vendor.id		pci 0x125b
+&device.id		pci 0x9100
++device.name		AX99100 PCIe to Multi I/O Controller
+
+ vendor.id		pci 0x125b
+&device.id		pci 0x9100
+&subvendor.id		pci 0xa000
+&subdevice.id		pci 0x1000
++subdevice.name		Serial Port
+
+ vendor.id		pci 0x125b
+&device.id		pci 0x9100
+&subvendor.id		pci 0xa000
+&subdevice.id		pci 0x2000
++subdevice.name		Parallel Port
+
+ vendor.id		pci 0x125b
+&device.id		pci 0x9100
+&subvendor.id		pci 0xa000
+&subdevice.id		pci 0x6000
++subdevice.name		SPI
+
+ vendor.id		pci 0x125b
+&device.id		pci 0x9100
+&subvendor.id		pci 0xa000
+&subdevice.id		pci 0x7000
++subdevice.name		Local Bus
+
+ vendor.id		pci 0x125b
+&device.id		pci 0x9100
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0x1c10
++subdevice.name		RXi2-BP
+
  vendor.id		pci 0x125c
 +vendor.name		Aurora Technologies, Inc.
 
@@ -77105,6 +78747,14 @@
  vendor.id		pci 0x126f
 &device.id		pci 0x0910
 +device.name		SM910
+
+ vendor.id		pci 0x126f
+&device.id		pci 0x2262
++device.name		SM2262/SM2262EN SSD Controller
+
+ vendor.id		pci 0x126f
+&device.id		pci 0x2263
++device.name		SM2263EN/SM2263XT SSD Controller
 
  vendor.id		pci 0x1270
 +vendor.name		Olympus Optical Co., Ltd.
@@ -78263,7 +79913,7 @@
 
  vendor.id		pci 0x1282
 &device.id		pci 0x9009
-+device.name		Ethernet 100/10 MBit
++device.name		DM9009 Ethernet Controller
 
  vendor.id		pci 0x1282
 &device.id		pci 0x9100
@@ -78271,7 +79921,7 @@
 
  vendor.id		pci 0x1282
 &device.id		pci 0x9102
-+device.name		21x4x DEC-Tulip compatible 10/100 Ethernet
++device.name		DM9102 Fast Ethernet Controller
 
  vendor.id		pci 0x1282
 &device.id		pci 0x9102
@@ -78343,6 +79993,12 @@
  vendor.id		pci 0x1283
 &device.id		pci 0x8892
 +device.name		IT8892E PCIe to PCI Bridge
+
+ vendor.id		pci 0x1283
+&device.id		pci 0x8892
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
 
  vendor.id		pci 0x1283
 &device.id		pci 0x8893
@@ -79230,6 +80886,12 @@
 +device.name		PI7C9X2G608GP PCIe2 6-Port/8-Lane Packet Switch
 
  vendor.id		pci 0x12d8
+&device.id		pci 0x2608
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xcc10
++subdevice.name		RXi2-BP
+
+ vendor.id		pci 0x12d8
 &device.id		pci 0x400a
 +device.name		PI7C9X442SL PCI Express Bridge Port
 
@@ -79268,6 +80930,10 @@
  vendor.id		pci 0x12d8
 &device.id		pci 0x8154
 +device.name		PI7C8154A/PI7C8154B/PI7C8154BI PCI-to-PCI Bridge
+
+ vendor.id		pci 0x12d8
+&device.id		pci 0x8619
++device.name		PI7C9X2G1616PR PCIe2 16-Port/16-Lane Packet Switch
 
  vendor.id		pci 0x12d8
 &device.id		pci 0xe110
@@ -79394,6 +81060,12 @@
 
  vendor.id		pci 0x12eb
 &device.id		pci 0x0001
+&subvendor.id		pci 0x0000
+&subdevice.id		pci 0x0300
++subdevice.name		Terasound A3D PCI
+
+ vendor.id		pci 0x12eb
+&device.id		pci 0x0001
 &subvendor.id		pci 0x104d
 &subdevice.id		pci 0x8036
 +subdevice.name		AU8820 Vortex Digital Audio Processor
@@ -79426,7 +81098,7 @@
 &device.id		pci 0x0001
 &subvendor.id		pci 0x122d
 &subdevice.id		pci 0x1002
-+subdevice.name		AU8820 Vortex Digital Audio Processor
++subdevice.name		SC 338-A3D
 
  vendor.id		pci 0x12eb
 &device.id		pci 0x0001
@@ -80548,7 +82220,7 @@
 +vendor.name		Sonix Inc
 
  vendor.id		pci 0x1353
-+vendor.name		Vierling Communication SAS
++vendor.name		dbeeSet Technology
 
  vendor.id		pci 0x1353
 &device.id		pci 0x0002
@@ -80565,6 +82237,14 @@
  vendor.id		pci 0x1353
 &device.id		pci 0x0005
 +device.name		PCI-FUT-S0
+
+ vendor.id		pci 0x1353
+&device.id		pci 0x0006
++device.name		OTDU-1U (FPGA Zynq-7000)
+
+ vendor.id		pci 0x1353
+&device.id		pci 0x0007
++device.name		OTDU-EX
 
  vendor.id		pci 0x1354
 +vendor.name		Dwave System Inc
@@ -82097,7 +83777,7 @@
 +vendor.name		Yano Electric Co Ltd
 
  vendor.id		pci 0x13cc
-+vendor.name		Metheus Corporation
++vendor.name		BARCO
 
  vendor.id		pci 0x13cd
 +vendor.name		Compatible Systems Corporation
@@ -83499,6 +85179,10 @@
 +device.name		MN-130 (ADMtek Centaur-P based)
 
  vendor.id		pci 0x1414
+&device.id		pci 0x008c
++device.name		Basic Render Driver
+
+ vendor.id		pci 0x1414
 &device.id		pci 0x5353
 +device.name		Hyper-V virtual VGA
 
@@ -83674,8 +85358,160 @@
 +device.name		OX16PCI952 Integrated Parallel Port
 
  vendor.id		pci 0x1415
+&device.id		pci 0xc100
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc101
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc104
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc105
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc106
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc108
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc109
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc10c
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc10d
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc10e
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc110
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc114
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc118
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc11b
++device.name		OXPCIe952 Native 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc11c
++device.name		OXPCIe952 Parallel Port
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc11e
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc11f
++device.name		OXPCIe952 Native 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc120
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc124
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc126
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc128
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc12c
++device.name		OXPCIe952 Legacy 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc12e
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc134
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc138
++device.name		OXPCIe952 Native 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc13c
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc13d
++device.name		OXPCIe952 Native 950 UART
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc140
++device.name		OXPCIe952 Legacy 950 UART #1
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc141
++device.name		OXPCIe952 Legacy 950 UART #2
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc144
++device.name		OXPCIe952 Legacy 950 UART #1
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc145
++device.name		OXPCIe952 Legacy 950 UART #2
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc146
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc148
++device.name		OXPCIe952 Legacy 950 UART #1
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc149
++device.name		OXPCIe952 Legacy 950 UART #2
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc14c
++device.name		OXPCIe952 Legacy 950 UART #1
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc14d
++device.name		OXPCIe952 Legacy 950 UART #2
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc14e
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc154
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
 &device.id		pci 0xc158
-+device.name		OXPCIe952 Dual 16C950 UART
++device.name		OXPCIe952 Dual Native 950 UART
 
  vendor.id		pci 0x1415
 &device.id		pci 0xc158
@@ -83688,6 +85524,14 @@
 &subvendor.id		pci 0xe4bf
 &subdevice.id		pci 0xd551
 +subdevice.name		DU1-MUSTANG Dual-Port RS-485 Interface
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc15c
++device.name		OXPCIe952 GPIO
+
+ vendor.id		pci 0x1415
+&device.id		pci 0xc15d
++device.name		OXPCIe952 Dual Native 950 UART
 
  vendor.id		pci 0x1415
 &device.id		pci 0xc308
@@ -86644,6 +88488,10 @@
 +device.name		Apple PCIe SSD
 
  vendor.id		pci 0x144d
+&device.id		pci 0xa544
++device.name		Exynos 8890 PCIe Root Complex
+
+ vendor.id		pci 0x144d
 &device.id		pci 0xa800
 +device.name		XP941 PCIe SSD
 
@@ -86652,8 +88500,20 @@
 +device.name		NVMe SSD Controller SM951/PM951
 
  vendor.id		pci 0x144d
+&device.id		pci 0xa802
+&subvendor.id		pci 0x144d
+&subdevice.id		pci 0xa801
++subdevice.name		PM963 2.5" NVMe PCIe SSD
+
+ vendor.id		pci 0x144d
 &device.id		pci 0xa804
-+device.name		NVMe SSD Controller SM961/PM961
++device.name		NVMe SSD Controller SM961/PM961/SM963
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa804
+&subvendor.id		pci 0x144d
+&subdevice.id		pci 0xa801
++subdevice.name		SM963 2.5" NVMe PCIe SSD
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa808
@@ -86664,6 +88524,10 @@
 &subvendor.id		pci 0x1d49
 &subdevice.id		pci 0x403b
 +subdevice.name		Thinksystem U.2 PM983 NVMe SSD
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa80a
++device.name		NVMe SSD Controller PM9A1/PM9A3/980PRO
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa820
@@ -86895,61 +88759,245 @@
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2040
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 1.6TB / AGN MU U.2 Gen4 1.6TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN MU U.2 Gen4 1.6TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2041
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 3.2TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN MU U.2 Gen4 3.2TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2042
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 6.4TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN MU U.2 Gen4 6.4TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2043
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 12.8TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN MU U.2 Gen4 12.8TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2044
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 1.6TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN MU AIC Gen4 1.6TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2045
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 3.2TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN MU AIC Gen4 3.2TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2046
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 6.4TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN MU AIC Gen4 6.4TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2070
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 1.92TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN RI U.2 Gen4 1.92TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2071
-+subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 3.84TB
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN RI U.2 Gen4 3.84TB
 
  vendor.id		pci 0x144d
 &device.id		pci 0xa824
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x2072
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN RI U.2 Gen4 7.68TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2073
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN RI U.2 Gen4 15.36TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2074
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN RI AIC Gen4 1.92TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2075
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN RI AIC Gen4 3.84TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2076
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN RI AIC Gen4 7.68TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2090
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 1.6TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2091
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 3.2TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2092
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 6.4TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2093
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU U.2 Gen4 12.8TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2094
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 1.6TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2095
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 3.2TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2096
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED MU AIC Gen4 6.4TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2097
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 1.92TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2098
++subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 3.84TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2099
 +subdevice.name		EMC PowerEdge Express Flash Ent NVMe AGN SED RI U.2 Gen4 7.68TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2118
++subdevice.name		Ent NVMe v2 AGN FIPS MU U.2 1.6TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2119
++subdevice.name		Ent NVMe v2 AGN MU U.2 1.6TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2120
++subdevice.name		Ent NVMe v2 AGN FIPS MU U.2 3.2T
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2121
++subdevice.name		Ent NVMe v2 AGN MU U.2 3.2TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2122
++subdevice.name		Ent NVMe v2 AGN FIPS MU U.2 6.4TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2123
++subdevice.name		Ent NVMe v2 AGN MU U.2 6.4TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2124
++subdevice.name		Ent NVMe v2 AGN FIPS MU U.2 6.4TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2125
++subdevice.name		Ent NVMe v2 AGN MU U.2 12.8TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2126
++subdevice.name		Ent NVMe v2 AGN FIPS RI U.2 1.92TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2127
++subdevice.name		Ent NVMe v2 AGN RI U.2 1.92TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2128
++subdevice.name		Ent NVMe v2 AGN FIPS RI U.2 3.84TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2129
++subdevice.name		Ent NVMe v2 AGN RI U.2 3.84TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2130
++subdevice.name		Ent NVMe v2 AGN FIPS RI U.2 7.68TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2131
++subdevice.name		Ent NVMe v2 AGN RI U.2 7.68TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2132
++subdevice.name		Ent NVMe v2 AGN FIPS RI U.2 15.36TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xa824
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2133
++subdevice.name		Ent NVMe v2 AGN RI U.2 15.36TB
+
+ vendor.id		pci 0x144d
+&device.id		pci 0xecec
++device.name		Exynos 8895 PCIe Root Complex
 
  vendor.id		pci 0x144e
 +vendor.name		OLITEC
@@ -86980,6 +89028,10 @@
 
  vendor.id		pci 0x1458
 +vendor.name		Gigabyte Technology Co., Ltd
+
+ vendor.id		pci 0x1458
+&device.id		pci 0x3483
++device.name		USB 3.0 Controller (VIA VL80x-based xHCI Controller)
 
  vendor.id		pci 0x1459
 +vendor.name		DOOIN Electronics
@@ -87034,6 +89086,10 @@
 
  vendor.id		pci 0x1462
 +vendor.name		Micro-Star International Co., Ltd. [MSI]
+
+ vendor.id		pci 0x1462
+&device.id		pci 0x3483
++device.name		MSI USB 3.0 (VIA VL80x-based xHCI USB Controller)
 
  vendor.id		pci 0x1462
 &device.id		pci 0xaaf0
@@ -87181,6 +89237,10 @@
 
  vendor.id		pci 0x148c
 +vendor.name		Tul Corporation / PowerColor
+
+ vendor.id		pci 0x148c
+&device.id		pci 0x2391
++device.name		Radeon RX 590 [Red Devil]
 
  vendor.id		pci 0x148d
 +vendor.name		DIGICOM Systems, Inc.
@@ -87528,12 +89588,20 @@
 +vendor.name		MEDIATEK Corp.
 
  vendor.id		pci 0x14c3
+&device.id		pci 0x7612
++device.name		MT7612E 802.11acbgn PCI Express Wireless Network Adapter
+
+ vendor.id		pci 0x14c3
 &device.id		pci 0x7630
 +device.name		MT7630e 802.11bgn Wireless Network Adapter
 
  vendor.id		pci 0x14c3
 &device.id		pci 0x7662
 +device.name		MT7662E 802.11ac PCI Express Wireless Network Adapter
+
+ vendor.id		pci 0x14c3
+&device.id		pci 0x7915
++device.name		MT7915E 802.11ax PCI Express Wireless Network Adapter
 
  vendor.id		pci 0x14c4
 +vendor.name		IWASAKI Information Systems Co Ltd
@@ -88839,7 +90907,7 @@
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x165f
-+device.name		NetXtreme BCM5720 2-port Gigabit Ethernet PCIe
++device.name		NetXtreme BCM5720 Gigabit Ethernet PCIe
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x165f
@@ -88864,6 +90932,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x0900
 +subdevice.name		PowerEdge C6525 LOM
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x165f
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x0917
++subdevice.name		PowerEdge C6520 LOM
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x165f
@@ -89306,6 +91380,12 @@
 +subdevice.name		530F-L
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x168e
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x100f
++subdevice.name		NIC-ETH522i-Mb-2x10G
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x1690
 +device.name		NetXtreme BCM57760 Gigabit Ethernet PCIe
 
@@ -89432,6 +91512,12 @@
 &subvendor.id		pci 0x1043
 &subdevice.id		pci 0x866e
 +subdevice.name		PEB-10G/57840-2T 10GBase-T Network Adapter
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16a1
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x100b
++subdevice.name		NIC-ETH521i-Mb-4x10G
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x16a2
@@ -90054,8 +92140,20 @@
  vendor.id		pci 0x14e4
 &device.id		pci 0x16d6
 &subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x1202
++subdevice.name		BCM957412M4122C OCP 1x25G Type1 wRoCE
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16d6
+&subvendor.id		pci 0x14e4
 &subdevice.id		pci 0x4120
 +subdevice.name		NetXtreme E-Series Advanced Dual-port 10Gb SFP+ Ethernet Network Daughter Card
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16d6
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x4126
++subdevice.name		NetXtreme-E Dual-port 10G SFP+ Ethernet OCP 3.0 Adapter (BCM957412N4120C)
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x16d6
@@ -90076,12 +92174,6 @@
  vendor.id		pci 0x14e4
 &device.id		pci 0x16d7
 &subvendor.id		pci 0x14e4
-&subdevice.id		pci 0x1202
-+subdevice.name		BCM957412M4122C OCP 1x25G Type1 wRoCE
-
- vendor.id		pci 0x14e4
-&device.id		pci 0x16d7
-&subvendor.id		pci 0x14e4
 &subdevice.id		pci 0x1402
 +subdevice.name		BCM957414A4142CC 10Gb/25Gb Ethernet PCIe
 
@@ -90096,6 +92188,12 @@
 &subvendor.id		pci 0x14e4
 &subdevice.id		pci 0x4140
 +subdevice.name		NetXtreme E-Series Advanced Dual-port 25Gb SFP28 Network Daughter Card
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16d7
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x4146
++subdevice.name		NetXtreme-E Dual-port 25G SFP28 Ethernet OCP 3.0 Adapter (BCM957414N4140C)
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x16d7
@@ -90123,7 +92221,13 @@
 &device.id		pci 0x16d8
 &subvendor.id		pci 0x14e4
 &subdevice.id		pci 0x4163
-+subdevice.name		BCM957416M4163C OCP 2x10GBT Type1 wRoCE
++subdevice.name		NetXtreme-E Dual-port 10GBASE-T Ethernet OCP 2.0 Adapter (BCM957416M4163C)
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16d8
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x4166
++subdevice.name		NetXtreme-E Dual-port 10GBASE-T Ethernet OCP 3.0 Adapter (BCM957416N4160C)
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x16d8
@@ -90196,6 +92300,10 @@
  vendor.id		pci 0x14e4
 &device.id		pci 0x16e9
 +device.name		BCM57407 NetXtreme-E 25Gb Ethernet Controller
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x16eb
++device.name		BCM57412 NetXtreme-E RDMA Partition
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x16ec
@@ -90360,20 +92468,134 @@
 +device.name		BCM57508 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x1750
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x2100
++subdevice.name		NetXtreme-E Dual-port 100G QSFP56 Ethernet PCIe4.0 x16 Adapter (BCM957508-P2100G)
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1750
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x5208
++subdevice.name		NetXtreme-E Dual-port 100G QSFP56 Ethernet OCP 3.0 Adapter (BCM957508-N2100G)
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1750
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xd124
++subdevice.name		NetXtreme-E P2100D BCM57508 2x100G QSFP PCIE
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1750
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xdf24
++subdevice.name		BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz Ethernet
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x1751
 +device.name		BCM57504 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1751
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x5045
++subdevice.name		NetXtreme-E BCM57504 4x25G OCP3.0
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1751
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0x5250
++subdevice.name		NetXtreme-E BCM57504 4x25G KR Mezz
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1751
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xd142
++subdevice.name		NetXtreme-E P425D BCM57504 4x25G SFP28 PCIE
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x1752
 +device.name		BCM57502 NetXtreme-E 10Gb/25Gb/40Gb/50Gb Ethernet
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x1800
++device.name		BCM57502 NetXtreme-E Ethernet Partition
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1801
++device.name		BCM57504 NetXtreme-E Ethernet Partition
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1802
++device.name		BCM57508 NetXtreme-E Ethernet Partition
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1802
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xdf24
++subdevice.name		BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz Ethernet Partition
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1803
++device.name		BCM57502 NetXtreme-E RDMA Partition
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1804
++device.name		BCM57504 NetXtreme-E RDMA Partition
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1805
++device.name		BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz RDMA Partition
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1805
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xdf24
++subdevice.name		NetXtreme-E NGM2100D BCM57508 2x100G KR Mezz RDMA Partition
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x1806
 +device.name		BCM5750X NetXtreme-E Ethernet Virtual Function
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x1806
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xdf24
++subdevice.name		BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz Ethernet Virtual Function
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x1807
 +device.name		BCM5750X NetXtreme-E RDMA Virtual Function
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1807
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xdf24
++subdevice.name		BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz RDMA Virtual Function
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1808
++device.name		BCM5750X NetXtreme-E Ethernet Virtual Function
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1808
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xdf24
++subdevice.name		BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz Ethernet Virtual Function
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1809
++device.name		BCM5750X NetXtreme-E RDMA Virtual Function
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x1809
+&subvendor.id		pci 0x14e4
+&subdevice.id		pci 0xdf24
++subdevice.name		BCM57508 NetXtreme-E NGM2100D 2x100G KR Mezz RDMA Virtual Function
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x2711
++device.name		BCM2711 PCIe Bridge
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x3352
@@ -91336,6 +93558,12 @@
 +device.name		BCM4350 802.11ac Wireless Network Adapter
 
  vendor.id		pci 0x14e4
+&device.id		pci 0x43a3
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x075a
++subdevice.name		00JT494
+
+ vendor.id		pci 0x14e4
 &device.id		pci 0x43a9
 +device.name		BCM43217 802.11b/g/n
 
@@ -91440,6 +93668,22 @@
  vendor.id		pci 0x14e4
 &device.id		pci 0x4412
 +device.name		BCM4412 10/100BaseT
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x4415
++device.name		BCM4359 802.11ac Dual-Band Wireless Network Controller
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x441f
++device.name		BCM4361 802.11ac Dual-Band Wireless Network Controller
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x4420
++device.name		BCM4361 802.11ac 2.4 GHz Wireless Network Controller
+
+ vendor.id		pci 0x14e4
+&device.id		pci 0x4421
++device.name		BCM4361 802.11ac 5 GHz Wireless Network Controller
 
  vendor.id		pci 0x14e4
 &device.id		pci 0x4430
@@ -92615,6 +94859,12 @@
 &subvendor.id		pci 0x0070
 &subdevice.id		pci 0x9001
 +subdevice.name		Nova-T DVB-T
+
+ vendor.id		pci 0x14f1
+&device.id		pci 0x8800
+&subvendor.id		pci 0x0070
+&subdevice.id		pci 0x9002
++subdevice.name		Nova-T DVB-T Model 909
 
  vendor.id		pci 0x14f1
 &device.id		pci 0x8800
@@ -93836,7 +96086,7 @@
 +vendor.name		ACKSYS
 
  vendor.id		pci 0x1529
-+vendor.name		AMERICAN MICROSystems Inc
++vendor.name		ON Semiconductor
 
  vendor.id		pci 0x152a
 +vendor.name		QUICKTURN DESIGN Systems
@@ -93950,6 +96200,10 @@
 +device.name		Pulse Width Modulator Card
 
  vendor.id		pci 0x1542
+&device.id		pci 0x9273
++device.name		RCIM-IV Real-Time Clock & Interrupt Module (PCIe)
+
+ vendor.id		pci 0x1542
 &device.id		pci 0x9277
 +device.name		5 Volt Delta Sigma Converter Card
 
@@ -94058,8 +96312,28 @@
 +device.name		XpressRich Reference Design
 
  vendor.id		pci 0x1556
+&device.id		pci 0x1111
++device.name		XpressRich-AXI Ref Design
+
+ vendor.id		pci 0x1556
+&device.id		pci 0x1112
++device.name		QuickPCIe
+
+ vendor.id		pci 0x1556
 &device.id		pci 0x1113
 +device.name		XpressSwitch
+
+ vendor.id		pci 0x1556
+&device.id		pci 0x1114
++device.name		Inspector
+
+ vendor.id		pci 0x1556
+&device.id		pci 0x1115
++device.name		XpressLINK Ref Design
+
+ vendor.id		pci 0x1556
+&device.id		pci 0x1116
++device.name		XpressLINK-SOC Ref Design
 
  vendor.id		pci 0x1556
 &device.id		pci 0xbe00
@@ -94626,6 +96900,30 @@
 +device.name		MT2894 Family [ConnectX-6 Lx Secure Flash Recovery]
 
  vendor.id		pci 0x15b3
+&device.id		pci 0x0218
++device.name		MT2910 Family [ConnectX-7 Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0219
++device.name		MT2910 Family [ConnectX-7 Secure Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x021a
++device.name		MT43162 Family [BlueField-3 Lx SoC Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x021b
++device.name		MT43162 Family [BlueField-3 Lx Secure Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x021c
++device.name		MT43244 Family [BlueField-3 SoC Flash Recovery]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x021d
++device.name		MT43244 Family [BlueField-3 Secure Flash Recovery]
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0x024e
 +device.name		MT53100 [Spectrum-2, Flash recovery mode]
 
@@ -94644,6 +96942,10 @@
  vendor.id		pci 0x15b3
 &device.id		pci 0x0252
 +device.name		Amos chiplet
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x0253
++device.name		Amos GearBox Manager
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x0254
@@ -94676,14 +96978,6 @@
  vendor.id		pci 0x15b3
 &device.id		pci 0x0281
 +device.name		NPS-600 Flash Recovery
-
- vendor.id		pci 0x15b3
-&device.id		pci 0x0538
-+device.name		MT2910 Family [ConnectX-7 Flash Recovery]
-
- vendor.id		pci 0x15b3
-&device.id		pci 0x0539
-+device.name		MT2910 Family [ConnectX-7 Secure Flash Recovery]
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x1002
@@ -95050,6 +97344,30 @@
 +subdevice.name		620F-B
 
  vendor.id		pci 0x15b3
+&device.id		pci 0x1015
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1023
++subdevice.name		NIC-ETH540F-LP-2P
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1015
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1031
++subdevice.name		NIC-ETH640i-Mb-2x25G
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1015
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1083
++subdevice.name		NIC-ETH640F-3S-2P
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1015
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1084
++subdevice.name		NIC-ETH540F-3S-2P
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0x1016
 +device.name		MT27710 Family [ConnectX-4 Lx Virtual Function]
 
@@ -95066,6 +97384,12 @@
  vendor.id		pci 0x15b3
 &device.id		pci 0x1017
 &subvendor.id		pci 0x15b3
+&subdevice.id		pci 0x0007
++subdevice.name		Mellanox ConnectX®-5 MCX516A-CCAT
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1017
+&subvendor.id		pci 0x15b3
 &subdevice.id		pci 0x0020
 +subdevice.name		ConnectX®-5 EN network interface card, 10/25GbE dual-port SFP28, PCIe3.0 x8, tall bracket ; MCX512A-ACAT
 
@@ -95074,6 +97398,12 @@
 &subvendor.id		pci 0x15b3
 &subdevice.id		pci 0x0068
 +subdevice.name		ConnectX®-5 EN network interface card for OCP2.0, Type 1, with host management, 25GbE dual-port SFP28, PCIe3.0 x8, no bracket Halogen free ; MCX542B-ACAN
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1017
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1051
++subdevice.name		NIC-IB1040i-Mb-2P
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x1018
@@ -95088,6 +97418,12 @@
 &subvendor.id		pci 0x15b3
 &subdevice.id		pci 0x0008
 +subdevice.name		ConnectX-5 Ex EN network interface card, 100GbE dual-port QSFP28, PCIe4.0 x16, tall bracket; MCX516A-CDAT
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x1019
+&subvendor.id		pci 0x15b3
+&subdevice.id		pci 0x0125
++subdevice.name		Tencent ConnectX-5 EN Ex network interface card for OCP 3.0, with host management, 50GbE Dual-port QSFP28, PCIe4.0 x16, Thumbscrew (pull-tab) bracket
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x101a
@@ -95144,6 +97480,30 @@
  vendor.id		pci 0x15b3
 &device.id		pci 0x1979
 +device.name		MT2910 Family [ConnectX-7 PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x197a
++device.name		MT43162 Family [BlueField-3 Lx SoC PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x197b
++device.name		MT43244 Family [BlueField-3 SoC PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x2020
++device.name		MT2892 Family [ConnectX-6 Dx Emulated PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x2021
++device.name		MT42822 Family [BlueField-2 SoC Emulated PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x2023
++device.name		MT2910 Family [ConnectX-7 Emulated PCIe Bridge]
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0x2024
++device.name		MT43244 Family [BlueField-3 SoC Emulated PCIe Bridge]
 
  vendor.id		pci 0x15b3
 &device.id		pci 0x4117
@@ -95388,12 +97748,44 @@
 +device.name		MT42822 BlueField-2 integrated ConnectX-6 Dx network controller
 
  vendor.id		pci 0x15b3
+&device.id		pci 0xa2d7
++device.name		MT43162 BlueField-3 Lx SoC Crypto enabled
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xa2d8
++device.name		MT43162 BlueField-3 Lx SoC Crypto disabled
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xa2d9
++device.name		MT43162 BlueField-3 Lx integrated ConnectX-7 network controller
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xa2da
++device.name		MT43244 BlueField-3 SoC Crypto enabled
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xa2db
++device.name		MT43244 BlueField-3 SoC Crypto disabled
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xa2dc
++device.name		MT43244 BlueField-3 integrated ConnectX-7 network controller
+
+ vendor.id		pci 0x15b3
 &device.id		pci 0xc2d2
 +device.name		MT416842 BlueField SoC management interfac
 
  vendor.id		pci 0x15b3
 &device.id		pci 0xc2d3
 +device.name		MT42822 BlueField-2 SoC Management Interface
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xc2d4
++device.name		MT43162 BlueField-3 Lx SoC Management Interface
+
+ vendor.id		pci 0x15b3
+&device.id		pci 0xc2d5
++device.name		MT43244 BlueField-3 SoC Management Interface
 
  vendor.id		pci 0x15b3
 &device.id		pci 0xc738
@@ -95529,11 +97921,51 @@
 
  vendor.id		pci 0x15b7
 &device.id		pci 0x5002
-+device.name		WD Black 2018/PC SN720 NVMe SSD
++device.name		WD Black 2018/SN750 / PC SN720 NVMe SSD
 
  vendor.id		pci 0x15b7
 &device.id		pci 0x5003
-+device.name		WD Black 2018/PC SN520 NVMe SSD
++device.name		WD Blue SN500 / PC SN520 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x5004
++device.name		PC SN520 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x5005
++device.name		PC SN520 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x5006
++device.name		WD Black SN750 / PC SN730 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x5009
++device.name		WD Blue SN550 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x5009
+&subvendor.id		pci 0x15b7
+&subdevice.id		pci 0x5009
++subdevice.name		WD Blue SN550 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x500b
++device.name		PC SN530 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x500b
+&subvendor.id		pci 0x1414
+&subdevice.id		pci 0x500b
++subdevice.name		Xbox Series X
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x500d
++device.name		WD Ultrastar DC SN340 NVMe SSD
+
+ vendor.id		pci 0x15b7
+&device.id		pci 0x5011
++device.name		WD Black SN850
 
  vendor.id		pci 0x15b8
 +vendor.name		ADDI-DATA GmbH
@@ -96627,6 +99059,10 @@
 +vendor.name		XFX Pine Group Inc.
 
  vendor.id		pci 0x1682
+&device.id		pci 0x5701
++device.name		Radeon 5700 XT Thicc III Ultra
+
+ vendor.id		pci 0x1682
 &device.id		pci 0xc580
 +device.name		Radeon RX 580
 
@@ -96636,6 +99072,33 @@
  vendor.id		pci 0x1688
 &device.id		pci 0x1170
 +device.name		WLAN 802.11b card
+
+ vendor.id		pci 0x168a
++vendor.name		Utimaco IS GmbH
+
+ vendor.id		pci 0x168a
+&device.id		pci 0x2086
++device.name		CryptoServer Se-Series Hardware Security Module
+
+ vendor.id		pci 0x168a
+&device.id		pci 0xc040
++device.name		CryptoServer CSe-Series Hardware Security Module
+
+ vendor.id		pci 0x168a
+&device.id		pci 0xc051
++device.name		CryptoServer Se-Series Gen2 Hardware Security Module
+
+ vendor.id		pci 0x168a
+&device.id		pci 0xc070
++device.name		u.trust Anchor Hardware Security Module cs7.2 Series
+
+ vendor.id		pci 0x168a
+&device.id		pci 0xc071
++device.name		u.trust Anchor Hardware Security Module cs7.3 Series
+
+ vendor.id		pci 0x168a
+&device.id		pci 0xc072
++device.name		u.trust Anchor Hardware Security Module cs7.3 Series Virtual Function
 
  vendor.id		pci 0x168c
 +vendor.name		Qualcomm Atheros
@@ -97975,6 +100438,12 @@
 +subdevice.name		Qualcomm Atheros QCA9377 802.11ac Wireless Network Adapter
 
  vendor.id		pci 0x168c
+&device.id		pci 0x0042
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x0901
++subdevice.name		Qualcomm Atheros QCA9377 Wireless Network Adapter
+
+ vendor.id		pci 0x168c
 &device.id		pci 0x0046
 +device.name		QCA9984 802.11ac Wave 2 Wireless Network Adapter
 
@@ -98749,6 +101218,10 @@
 +vendor.name		Altima (nee Broadcom)
 
  vendor.id		pci 0x173b
+&device.id		pci 0x0001
++device.name		AC1002 PCI Gigabit Ethernet controller
+
+ vendor.id		pci 0x173b
 &device.id		pci 0x03e8
 +device.name		AC1000 Gigabit Ethernet
 
@@ -98827,6 +101300,62 @@
 +device.name		PCT-7424 PCI card with standard counters
 
  vendor.id		pci 0x1760
+&device.id		pci 0x0141
++device.name		PCA7208AL - Analog Inputs/Outputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0142
++device.name		PCA7208AS - Analog inputs/Outputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0143
++device.name		PCA7408AL - Analog Inputs/Outputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0144
++device.name		PCA7408AS - Analog Inputs/Outputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0145
++device.name		PCA-7228AL Multifunction PCI IO card
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0146
++device.name		PCA-7228AS Multifunction PCI IO card
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0147
++device.name		PCA7428AL Multifunction PCI IO card
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0148
++device.name		PCA7428AS Multifunction PCI IO card
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0149
++device.name		PCA7228EL Multifunction PCI IO card with isolated analog inputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0150
++device.name		PCA7428EL Multifunction PCI IO card with isolated analog inputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0151
++device.name		PCA7628AL - PCI card with analog inputs, counters and DIO
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0152
++device.name		PCA7628AS PCI card with analog inputs, outputs, counters and DIO
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0161
++device.name		PCA7288A PCI card with analog outputs, counters and DIO
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0180
++device.name		PCI1052 Communication card for MicroUnit network
+
+ vendor.id		pci 0x1760
 &device.id		pci 0x0214
 +device.name		PCT-7424C (F0) PC card with standard counters
 
@@ -98843,8 +101372,52 @@
 +device.name		PCT-7424E (F1) PC card with standard counters
 
  vendor.id		pci 0x1760
+&device.id		pci 0x0240
++device.name		PCA7428CL_F0 - analog Inputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0241
++device.name		PCA7428CL_F1 - analog Inputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0242
++device.name		PCA7428CS_F0 - Analog Inputs/Outputs non isolated
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0243
++device.name		PCA7428CS_F1 - Analog Inputs/Outputs non isolated
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0244
++device.name		PCA7428CE_F0 - Analog Inputs isolated
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0245
++device.name		PCA7428CE_F1 - Analog Inputs isolated
+
+ vendor.id		pci 0x1760
 &device.id		pci 0x0303
 +device.name		PCD-7006C Digital Input & Output PCI Card
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0800
++device.name		PCD8006 - PCIe digital Inputs/Outputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0840
++device.name		PCA-8428 General-purpose multifunctional PCIe card with 8 analog inputs and 2 analog outputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0841
++device.name		PCA-8429 General-purpose multifunctional PCIe card with 8 analog inputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0842
++device.name		PCA-8438 General-purpose multifunctional PCIe card with 16 analog inputs and 2 analog outputs
+
+ vendor.id		pci 0x1760
+&device.id		pci 0x0843
++device.name		PCA-8439 General-purpose multifunctional PCIe card with 16 analog inputs
 
  vendor.id		pci 0x1760
 &device.id		pci 0xff00
@@ -98884,7 +101457,15 @@
 
  vendor.id		pci 0x177d
 &device.id		pci 0x0010
-+device.name		Nitrox XL NPX
++device.name		CN15XX/CN16XX [Nitrox PX]
+
+ vendor.id		pci 0x177d
+&device.id		pci 0x0011
++device.name		CNN35XX [Nitrox III]
+
+ vendor.id		pci 0x177d
+&device.id		pci 0x0012
++device.name		CNN55XX [Nitrox V]
 
  vendor.id		pci 0x177d
 &device.id		pci 0x0020
@@ -99540,8 +102121,20 @@
 &device.id		pci 0x9750
 +device.name		GL9750 SD Host Controller
 
+ vendor.id		pci 0x17a0
+&device.id		pci 0x9755
++device.name		GL9755 SD Host Controller
+
+ vendor.id		pci 0x17a0
+&device.id		pci 0xe763
++device.name		GL9763E eMMC Controller
+
  vendor.id		pci 0x17aa
 +vendor.name		Lenovo
+
+ vendor.id		pci 0x17aa
+&device.id		pci 0x3181
++device.name		ThinkCentre M75n IoT
 
  vendor.id		pci 0x17aa
 &device.id		pci 0x402b
@@ -99625,12 +102218,44 @@
 +subdevice.name		WPC54GX4 v1 802.11g Wireless-G Notebook Adapter with SRX400
 
  vendor.id		pci 0x17cb
+&device.id		pci 0x0105
++device.name		MSM8998 PCIe Root Complex
+
+ vendor.id		pci 0x17cb
+&device.id		pci 0x0108
++device.name		SM8150 PCIe Root Complex
+
+ vendor.id		pci 0x17cb
+&device.id		pci 0x0109
++device.name		SA8195P PCIe Root Complex
+
+ vendor.id		pci 0x17cb
+&device.id		pci 0x0300
++device.name		MDM9x35 LTE Modem [Snapdragon X7]
+
+ vendor.id		pci 0x17cb
+&device.id		pci 0x0301
++device.name		MDM9x45 LTE Modem [Snapdragon X12]
+
+ vendor.id		pci 0x17cb
+&device.id		pci 0x0302
++device.name		MDM9x55 LTE Modem [Snapdragon X16]
+
+ vendor.id		pci 0x17cb
 &device.id		pci 0x0400
 +device.name		Datacenter Technologies QDF2432 PCI Express Root Port
 
  vendor.id		pci 0x17cb
 &device.id		pci 0x0401
 +device.name		Datacenter Technologies QDF2400 PCI Express Root Port
+
+ vendor.id		pci 0x17cb
+&device.id		pci 0x1000
++device.name		QCS405 PCIe Root Complex
+
+ vendor.id		pci 0x17cb
+&device.id		pci 0x1101
++device.name		QCA6390 Wireless Network Adapter [AX500-DBS (2x2)]
 
  vendor.id		pci 0x17cc
 +vendor.name		NetChip Technology, Inc
@@ -101664,6 +104289,14 @@
 &device.id		pci 0x01c5
 +device.name		NT200A02 Network Adapter
 
+ vendor.id		pci 0x18f4
+&device.id		pci 0x01d5
++device.name		NT50B01 Network Adapter
+
+ vendor.id		pci 0x18f4
+&device.id		pci 0x01e5
++device.name		NT100A01 Network Adapter
+
  vendor.id		pci 0x18f6
 +vendor.name		NextIO
 
@@ -102934,7 +105567,7 @@
 &device.id		pci 0x00b6
 &subvendor.id		pci 0x1a56
 &subdevice.id		pci 0x1101
-+subdevice.name		Killer Xeno Pro Gigabit Ethernet Controller
++subdevice.name		Bigfoot Killer Xeno Pro Gigabit Ethernet Controller
 
  vendor.id		pci 0x1957
 &device.id		pci 0x00c2
@@ -103094,7 +105727,7 @@
 &device.id		pci 0xc006
 &subvendor.id		pci 0x1a56
 &subdevice.id		pci 0x1201
-+subdevice.name		Killer E2100 Gigabit Ethernet Controller
++subdevice.name		Bigfoot Killer E2100 Gigabit Ethernet Controller
 
  vendor.id		pci 0x1957
 &device.id		pci 0xfc02
@@ -103176,6 +105809,32 @@
  vendor.id		pci 0x1966
 &device.id		pci 0x1977
 +device.name		DVG128 family
+
+ vendor.id		pci 0x1966
+&device.id		pci 0x1979
++device.name		3DVG/UHD3
+
+ vendor.id		pci 0x1966
+&device.id		pci 0x1980
++device.name		HDV2/UHD2
+
+ vendor.id		pci 0x1966
+&device.id		pci 0x1980
+&subvendor.id		pci 0x1234
+&subdevice.id		pci 0x3160
++subdevice.name		UHD2LC
+
+ vendor.id		pci 0x1966
+&device.id		pci 0x1980
+&subvendor.id		pci 0x1234
+&subdevice.id		pci 0x3300
++subdevice.name		Legacy UHD2
+
+ vendor.id		pci 0x1966
+&device.id		pci 0x1980
+&subvendor.id		pci 0x1234
+&subdevice.id		pci 0x3410
++subdevice.name		UHD2
 
  vendor.id		pci 0x1969
 +vendor.name		Qualcomm Atheros
@@ -103339,6 +105998,14 @@
 &device.id		pci 0x0011
 +device.name		FlexCard PMC-II Ethernet
 
+ vendor.id		pci 0x1974
+&device.id		pci 0x0018
++device.name		FlexCard PXIe3
+
+ vendor.id		pci 0x1974
+&device.id		pci 0x0019
++device.name		FlexCard PCIe3
+
  vendor.id		pci 0x1976
 +vendor.name		TRENDnet
 
@@ -103359,6 +106026,10 @@
  vendor.id		pci 0x197b
 &device.id		pci 0x0368
 +device.name		JMB368 IDE controller
+
+ vendor.id		pci 0x197b
+&device.id		pci 0x0585
++device.name		JMB58x AHCI SATA controller
 
  vendor.id		pci 0x197b
 &device.id		pci 0x2360
@@ -103499,6 +106170,10 @@
  vendor.id		pci 0x1987
 &device.id		pci 0x5012
 +device.name		E12 NVMe Controller
+
+ vendor.id		pci 0x1987
+&device.id		pci 0x5013
++device.name		PS5013 E13 NVMe Controller
 
  vendor.id		pci 0x1987
 &device.id		pci 0x5016
@@ -103859,8 +106534,20 @@
 +subdevice.name		Hi1822 SC371 (2*100GE)
 
  vendor.id		pci 0x19e5
+&device.id		pci 0x0200
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd147
++subdevice.name		Hi1822 SP573 (2*100GE)
+
+ vendor.id		pci 0x19e5
 &device.id		pci 0x0202
 +device.name		Hi1822 Family (2*32G FC)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0202
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd149
++subdevice.name		Hi1822 SP528 (2*32G FC)
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x0202
@@ -103877,6 +106564,12 @@
  vendor.id		pci 0x19e5
 &device.id		pci 0x0203
 +device.name		Hi1822 Family (2*16G FC)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0203
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd148
++subdevice.name		Hi1822 SP527 (2*16G FC)
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x0203
@@ -103915,6 +106608,12 @@
 &subvendor.id		pci 0x19e5
 &subdevice.id		pci 0xd13a
 +subdevice.name		Hi1822 SC381 (2*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x0206
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd145
++subdevice.name		Hi1822 SP586 (2*25GE)
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x0210
@@ -103970,7 +106669,7 @@
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x1711
-+device.name		Hi1710 [iBMC Intelligent Management system chip w/VGA support]
++device.name		Hi171x Series [iBMC Intelligent Management system chip w/VGA support]
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x1822
@@ -103995,8 +106694,82 @@
 +subdevice.name		Hi1822 SP583 (4*25GE)
 
  vendor.id		pci 0x19e5
+&device.id		pci 0x1822
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0xd146
++subdevice.name		Hi1822 SP585 (4*25GE)
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3714
++device.name		ES3000 V5 NVMe PCIe SSD
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3714
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x5312
++subdevice.name		NVMe SSD ES3500P V5 2000GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
 &device.id		pci 0x371e
 +device.name		Hi1822 Family Virtual Bridge
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
++device.name		ES3000 V6 NVMe PCIe SSD
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6122
++subdevice.name		NVMe SSD ES3600P V6 1600GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6123
++subdevice.name		NVMe SSD ES3600P V6 3200GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6124
++subdevice.name		NVMe SSD ES3600P V6 6400GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6141
++subdevice.name		NVMe SSD ES3800P V6 800GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6142
++subdevice.name		NVMe SSD ES3800P V6 1600GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6212
++subdevice.name		NVMe SSD ES3500P V6 1920GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6213
++subdevice.name		NVMe SSD ES3500P V6 3840GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6214
++subdevice.name		NVMe SSD ES3500P V6 7680GB 2.5" U.2
+
+ vendor.id		pci 0x19e5
+&device.id		pci 0x3754
+&subvendor.id		pci 0x19e5
+&subdevice.id		pci 0x6215
++subdevice.name		NVMe SSD ES3500P V6 15360GB 2.5" U.2
 
  vendor.id		pci 0x19e5
 &device.id		pci 0x375e
@@ -104228,6 +107001,9 @@
 &device.id		pci 0x0000
 +device.name		SC15064
 
+ vendor.id		pci 0x1a0d
++vendor.name		SEAKR Engineering
+
  vendor.id		pci 0x1a0e
 +vendor.name		DekTec Digital Video B.V.
 
@@ -104358,7 +107134,11 @@
 
  vendor.id		pci 0x1a4a
 &device.id		pci 0x1020
-+device.name		Cluster On Board (COB) Ethernet Switch
++device.name		PGPCard - Gen3 Cameralink Interface
+
+ vendor.id		pci 0x1a4a
+&device.id		pci 0x1030
++device.name		PGPCard - Gen3 GIGe Interface
 
  vendor.id		pci 0x1a4a
 &device.id		pci 0x2000
@@ -104373,12 +107153,28 @@
 +device.name		PCI-Express EVR
 
  vendor.id		pci 0x1a4a
+&device.id		pci 0x2011
++device.name		PCI-Express EVR - TPR Version
+
+ vendor.id		pci 0x1a4a
 &device.id		pci 0x2020
-+device.name		PGP-GEN3 PCIe
++device.name		PGP-GEN3 PCIe - 8 Lane Plus EVR
 
  vendor.id		pci 0x1a4a
 &device.id		pci 0x2030
 +device.name		AXI Stream DAQ PCIe card
+
+ vendor.id		pci 0x1a4a
+&device.id		pci 0x2040
++device.name		EXO PCIe TEM
+
+ vendor.id		pci 0x1a4a
+&device.id		pci 0x3000
++device.name		COB DTM V1
+
+ vendor.id		pci 0x1a4a
+&device.id		pci 0x3001
++device.name		COB DTM V2
 
  vendor.id		pci 0x1a51
 +vendor.name		Hectronic AB
@@ -104451,7 +107247,7 @@
 +device.name		CinePlay
 
  vendor.id		pci 0x1a56
-+vendor.name		Bigfoot Networks, Inc.
++vendor.name		Rivet Networks
 
  vendor.id		pci 0x1a57
 +vendor.name		Highly Reliable Systems
@@ -104661,6 +107457,10 @@
 &device.id		pci 0x0042
 +device.name		Compute Engine Virtual Ethernet [gVNIC]
 
+ vendor.id		pci 0x1ae0
+&device.id		pci 0xabcd
++device.name		Airbrush Combined Paintbox IPU/Oscar Edge TPU [Pixel Neural Core]
+
  vendor.id		pci 0x1ae3
 +vendor.name		SANBlaze Technology, Inc.
 
@@ -104675,20 +107475,108 @@
 +vendor.name		Silicon Software GmbH
 
  vendor.id		pci 0x1ae8
+&device.id		pci 0x0751
++device.name		mE5 marathon VCL
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0752
++device.name		mE5 marathon AF2
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0753
++device.name		mE5 marathon ACX QP
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0754
++device.name		mE5 marathon ACL
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0755
++device.name		mE5 marathon ACX SP
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0756
++device.name		mE5 marathon ACX DP
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0757
++device.name		mE5 marathon VCX QP
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0758
++device.name		mE5 marathon VF2
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0759
++device.name		mE5 marathon VCLx
+
+ vendor.id		pci 0x1ae8
 &device.id		pci 0x0a40
-+device.name		microEnable IV-BASE x1
++device.name		microEnable IV AD1-CL
 
  vendor.id		pci 0x1ae8
 &device.id		pci 0x0a41
-+device.name		microEnable IV-FULL x1
++device.name		microEnable IV VD1-CL
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a42
++device.name		microEnable IV AD4-CL
 
  vendor.id		pci 0x1ae8
 &device.id		pci 0x0a44
-+device.name		microEnable IV-FULL x4
++device.name		microEnable IV VD4-CL
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a45
++device.name		microEnable IV AS1-CL
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a53
++device.name		microEnable 5 AQ8-CXP6B
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a54
++device.name		microEnable 5 VQ8-CXP6B
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a56
++device.name		microEnable 5 VQ8-CXP6D
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a57
++device.name		microEnable 5 AQ8-CXP6D
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a58
++device.name		microEnable 5 VD8-CL
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0a5a
++device.name		microEnable 5 AD8-CL
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0b52
++device.name		mE5 Abacus 4G Base
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0b53
++device.name		mE5 Abacus 4G Base II
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0b61
++device.name		mE6 Abacus 4TG
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0b63
++device.name		CXP-12 Interface Card 1C
+
+ vendor.id		pci 0x1ae8
+&device.id		pci 0x0e42
++device.name		microEnable IV AQ4-GE
 
  vendor.id		pci 0x1ae8
 &device.id		pci 0x0e44
-+device.name		microEnable IV-GigE x4
++device.name		microEnable IV VQ4-GE
 
  vendor.id		pci 0x1ae9
 +vendor.name		Wilocity Ltd.
@@ -104887,6 +107775,14 @@
 +device.name		Virtio input
 
  vendor.id		pci 0x1af4
+&device.id		pci 0x1053
++device.name		Virtio socket
+
+ vendor.id		pci 0x1af4
+&device.id		pci 0x105a
++device.name		Virtio file system
+
+ vendor.id		pci 0x1af4
 &device.id		pci 0x1110
 +device.name		Inter-VM shared memory
 
@@ -104929,6 +107825,9 @@
 &device.id		pci 0x0e70
 +device.name		GRAPE
 
+ vendor.id		pci 0x1b1c
++vendor.name		Corsair
+
  vendor.id		pci 0x1b21
 +vendor.name		ASMedia Technology Inc.
 
@@ -104947,8 +107846,18 @@
 +subdevice.name		Motherboard
 
  vendor.id		pci 0x1b21
+&device.id		pci 0x1040
++device.name		ASM1040 XHCI Controller
+
+ vendor.id		pci 0x1b21
 &device.id		pci 0x1042
 +device.name		ASM1042 SuperSpeed USB Host Controller
+
+ vendor.id		pci 0x1b21
+&device.id		pci 0x1042
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x1059
++subdevice.name		K53SM motherboard
 
  vendor.id		pci 0x1b21
 &device.id		pci 0x1042
@@ -104977,14 +107886,24 @@
 +device.name		ASM1042A USB 3.0 Host Controller
 
  vendor.id		pci 0x1b21
+&device.id		pci 0x1182
++device.name		ASM1182e 2-Port PCIe x1 Gen2 Packet Switch
+
+ vendor.id		pci 0x1b21
+&device.id		pci 0x1182
+&subvendor.id		pci 0x1b21
+&subdevice.id		pci 0x118f
++subdevice.name		ASM1182e 2-Port PCIe x1 Gen2 Packet Switch
+
+ vendor.id		pci 0x1b21
 &device.id		pci 0x1184
-+device.name		ASM1184e PCIe Switch Port
++device.name		ASM1184e 4-Port PCIe x1 Gen2 Packet Switch
 
  vendor.id		pci 0x1b21
 &device.id		pci 0x1184
 &subvendor.id		pci 0x1849
 &subdevice.id		pci 0x1184
-+subdevice.name		ASM1184e PCIe Switch
++subdevice.name		ASM1184e 4-Port PCIe x1 Gen2 Packet Switch
 
  vendor.id		pci 0x1b21
 &device.id		pci 0x1242
@@ -104997,6 +107916,16 @@
  vendor.id		pci 0x1b21
 &device.id		pci 0x2142
 +device.name		ASM2142 USB 3.1 Host Controller
+
+ vendor.id		pci 0x1b21
+&device.id		pci 0x2142
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x1b21
+&device.id		pci 0x3242
++device.name		ASM3242 USB 3.2 Host Controller
 
  vendor.id		pci 0x1b26
 +vendor.name		Netcope Technologies, a.s.
@@ -105122,6 +108051,10 @@
  vendor.id		pci 0x1b36
 &device.id		pci 0x000d
 +device.name		QEMU XHCI Host Controller
+
+ vendor.id		pci 0x1b36
+&device.id		pci 0x0010
++device.name		QEMU NVM Express Controller
 
  vendor.id		pci 0x1b36
 &device.id		pci 0x0100
@@ -105251,8 +108184,40 @@
 +vendor.name		Marvell Technology Group Ltd.
 
  vendor.id		pci 0x1b4b
+&device.id		pci 0x0100
++device.name		88F3700 [Armada 3700 Family] ARM SoC
+
+ vendor.id		pci 0x1b4b
 &device.id		pci 0x0640
 +device.name		88SE9128 SATA III 6Gb/s RAID Controller
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x2241
++device.name		88NR2241 Non-Volatile memory controller
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x2241
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2112
++subdevice.name		BOSS-N1 Monolithic
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x2241
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2113
++subdevice.name		BOSS-N1 Modular
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x2241
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0306
++subdevice.name		ThinkSystem M.2 NVMe 2-Bay RAID Enablement Kit
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x2241
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0307
++subdevice.name		ThinkSystem 7mm NVMe 2-Bay Rear RAID Enablement Kit
 
  vendor.id		pci 0x1b4b
 &device.id		pci 0x9120
@@ -105299,6 +108264,10 @@
 +device.name		88SE9172 SATA III 6Gb/s RAID Controller
 
  vendor.id		pci 0x1b4b
+&device.id		pci 0x9182
++device.name		88SE9182 PCIe 2.0 x2 2-port SATA 6 Gb/s Controller
+
+ vendor.id		pci 0x1b4b
 &device.id		pci 0x9183
 +device.name		88SS9183 PCIe SSD Controller
 
@@ -105315,12 +108284,16 @@
 +device.name		88SE912x IDE Controller
 
  vendor.id		pci 0x1b4b
+&device.id		pci 0x9215
++device.name		88SE9215 PCIe 2.0 x1 4-port SATA 6 Gb/s Controller
+
+ vendor.id		pci 0x1b4b
 &device.id		pci 0x9220
 +device.name		88SE9220 PCIe 2.0 x2 2-port SATA 6 Gb/s RAID Controller
 
  vendor.id		pci 0x1b4b
 &device.id		pci 0x9230
-+device.name		88SE9230 PCIe SATA 6Gb/s Controller
++device.name		88SE9230 PCIe 2.0 x2 4-port SATA 6 Gb/s RAID Controller
 
  vendor.id		pci 0x1b4b
 &device.id		pci 0x9230
@@ -105353,6 +108326,36 @@
 +subdevice.name		ThinkSystem M.2 with Mirroring Enablement Kit
 
  vendor.id		pci 0x1b4b
+&device.id		pci 0x9230
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0301
++subdevice.name		ThinkSystem SR630 x16 PCIE with 4 SATA ports Riser
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x9230
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0302
++subdevice.name		ThinkSystem SE350 M.2 SATA 4-Bay Data RAID Mirroring Enablement Kit
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x9230
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0303
++subdevice.name		ThinkSystem SE350 M.2 SATA 4-Bay Data RAID Mirroring Enablement Kit
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x9230
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0304
++subdevice.name		ThinkSystem M.2 SATA 2-Bay RAID Enablement Kit
+
+ vendor.id		pci 0x1b4b
+&device.id		pci 0x9230
+&subvendor.id		pci 0x1d49
+&subdevice.id		pci 0x0305
++subdevice.name		ThinkSystem 7mm SATA 2-Bay Rear RAID Enablement Kit
+
+ vendor.id		pci 0x1b4b
 &device.id		pci 0x9235
 +device.name		88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller
 
@@ -105367,6 +108370,9 @@
  vendor.id		pci 0x1b4b
 &device.id		pci 0x9485
 +device.name		88SE9485 SAS/SATA 6Gb/s controller
+
+ vendor.id		pci 0x1b4c
++vendor.name		GALAX
 
  vendor.id		pci 0x1b55
 +vendor.name		NetUP Inc.
@@ -105506,6 +108512,50 @@
 
  vendor.id		pci 0x1b96
 +vendor.name		Western Digital
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2200
++device.name		Ultrastar DC SN630 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2201
++device.name		Ultrastar DC SN630 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2300
++device.name		Ultrastar DC SN840 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2400
++device.name		Ultrastar DC SN640 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2401
++device.name		Ultrastar DC SN640 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2402
++device.name		Ultrastar DC SN640 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2404
++device.name		Ultrastar DC SN640 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2500
++device.name		Ultrastar DC SN840 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x2600
++device.name		Ultrastar DC ZN540 ZNS NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x3714
++device.name		PC SN730 NVMe SSD
+
+ vendor.id		pci 0x1b96
+&device.id		pci 0x3734
++device.name		PC SN730 NVMe SSD
 
  vendor.id		pci 0x1b9a
 +vendor.name		XAVi Technologies Corp.
@@ -105708,6 +108758,14 @@
 &subdevice.id		pci 0x01a1
 +subdevice.name		Nytro XP7102
 
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x5012
++device.name		FireCuda 510 SSD
+
+ vendor.id		pci 0x1bb1
+&device.id		pci 0x5016
++device.name		FireCuda 520 SSD
+
  vendor.id		pci 0x1bb3
 +vendor.name		Bluecherry
 
@@ -105761,6 +108819,45 @@
 &device.id		pci 0x0004
 +device.name		MAX4
 
+ vendor.id		pci 0x1bc0
++vendor.name		Innodisk Corporation
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x1001
++device.name		PCIe 3TG6-P Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x1002
++device.name		PCIe 3TE6 Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x1160
++device.name		PCIe 3TE2 Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x1321
++device.name		PCIe 4TG-P Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x1322
++device.name		PCIe 4TE Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x2262
++device.name		PCIe 3TG3-P Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x5208
++device.name		PCIe 3TE7 Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x5216
++device.name		PCIe 3TE8 Controller
+
+ vendor.id		pci 0x1bc0
+&device.id		pci 0x5236
++device.name		PCIe 4TG2-P Controller
+
  vendor.id		pci 0x1bcf
 +vendor.name		NEC Corporation
 
@@ -105788,6 +108885,22 @@
 +device.name		PE1000 (Multi-Protocol PCIe/104 Interface Card)
 
  vendor.id		pci 0x1bd0
+&device.id		pci 0x1006
++device.name		webCS Wireless Aircraft Communications Server
+
+ vendor.id		pci 0x1bd0
+&device.id		pci 0x1007
++device.name		AB3000 Series Rugged Computer (Series N)
+
+ vendor.id		pci 0x1bd0
+&device.id		pci 0x1008
++device.name		ME1000 mPCIe Avionics Interface Card
+
+ vendor.id		pci 0x1bd0
+&device.id		pci 0x100a
++device.name		NG1 Series Avionics Converter
+
+ vendor.id		pci 0x1bd0
 &device.id		pci 0x1101
 +device.name		OmniBus II PCIe Multi-Protocol Interface Card
 
@@ -105798,6 +108911,22 @@
  vendor.id		pci 0x1bd0
 &device.id		pci 0x1103
 +device.name		OmniBus II cPCIe/PXIe Multi-Protocol Interface Card
+
+ vendor.id		pci 0x1bd0
+&device.id		pci 0x1200
++device.name		NG3 Series Mil-Std-1553 Interface
+
+ vendor.id		pci 0x1bd0
+&device.id		pci 0x1201
++device.name		NG3 Series ARINC 429 Interface
+
+ vendor.id		pci 0x1bd0
+&device.id		pci 0x1202
++device.name		NG3 Series Avionics Discrete & Serial Interface
+
+ vendor.id		pci 0x1bd0
+&device.id		pci 0x1203
++device.name		NG3 Series Avionics Discrete Interface
 
  vendor.id		pci 0x1bd4
 +vendor.name		Inspur Electronic Information Industry Co., Ltd.
@@ -105919,6 +109048,10 @@
 &device.id		pci 0x001d
 +device.name		Vega
 
+ vendor.id		pci 0x1c1f
+&device.id		pci 0x001f
++device.name		FD940
+
  vendor.id		pci 0x1c28
 +vendor.name		Lite-On IT Corp. / Plextor
 
@@ -105994,6 +109127,14 @@
 +device.name		PacketMover 2x10Gb [Corfu]
 
  vendor.id		pci 0x1c2c
+&device.id		pci 0x1000
++device.name		SmartNIC N5010 4x100Gb
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0x1001
++device.name		SmartNIC N5011 w/2xE810 4x100Gb
+
+ vendor.id		pci 0x1c2c
 &device.id		pci 0xa000
 +device.name		FBC2CGG3 Capture 2x40Gb [Mango_02]
 
@@ -106030,12 +109171,28 @@
 +device.name		FB2CG Capture 2x40Gb [Savona]
 
  vendor.id		pci 0x1c2c
+&device.id		pci 0xa010
++device.name		FB2CGHH Capture 2x40Gb [Tivoli]
+
+ vendor.id		pci 0x1c2c
 &device.id		pci 0xa011
 +device.name		FB2CG Capture 2x25Gb [Savona]
 
  vendor.id		pci 0x1c2c
 &device.id		pci 0xa012
 +device.name		FB2CG Capture 8x10Gb [Savona]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa013
++device.name		FB2CGHH Capture 2x25Gb [Tivoli]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa014
++device.name		FB2CGHH Capture 8x10Gb [Tivoli]
+
+ vendor.id		pci 0x1c2c
+&device.id		pci 0xa015
++device.name		FB2CGHH Capture 2x100Gb [Tivoli]
 
  vendor.id		pci 0x1c32
 +vendor.name		Highland Technology, Inc.
@@ -106127,27 +109284,75 @@
 +device.name		BC501 NVMe Solid State Drive 512GB
 
  vendor.id		pci 0x1c5c
+&device.id		pci 0x1339
++device.name		BC511
+
+ vendor.id		pci 0x1c5c
 &device.id		pci 0x1504
 +device.name		SC300 512GB M.2 2280 SATA Solid State Drive
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x1527
++device.name		PC401 NVMe Solid State Drive 256GB
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x243b
++device.name		PE6110 NVMe Solid State Drive
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x243b
+&subvendor.id		pci 0x1c5c
+&subdevice.id		pci 0x0100
++subdevice.name		PE6110 NVMe Solid State Drive
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x2839
++device.name		PE8000 Series NVMe Solid State Drive
+
+ vendor.id		pci 0x1c5c
+&device.id		pci 0x2839
+&subvendor.id		pci 0x1c5c
+&subdevice.id		pci 0x0100
++subdevice.name		PE8000 Series NVMe Solid State Drive
 
  vendor.id		pci 0x1c5f
 +vendor.name		Beijing Memblaze Technology Co. Ltd.
 
  vendor.id		pci 0x1c5f
 &device.id		pci 0x000d
-+device.name		PBlaze5 520/526 AIC
++device.name		PBlaze5 520/526
 
  vendor.id		pci 0x1c5f
 &device.id		pci 0x003d
-+device.name		PBlaze5 920/926 AIC
++device.name		PBlaze5 920/926
 
  vendor.id		pci 0x1c5f
-&device.id		pci 0x010d
-+device.name		PBlaze5 520/526 U.2
+&device.id		pci 0x003e
++device.name		PBlaze6 6920
 
  vendor.id		pci 0x1c5f
-&device.id		pci 0x013d
-+device.name		PBlaze5 920/926 U.2
+&device.id		pci 0x003e
+&subvendor.id		pci 0x1c5f
+&subdevice.id		pci 0x0a31
++subdevice.name		NVMe SSD PBlaze6 6920 3840GB 2.5" U.2
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x003e
+&subvendor.id		pci 0x1c5f
+&subdevice.id		pci 0x0a41
++subdevice.name		NVMe SSD PBlaze6 6920 7680GB 2.5" U.2
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x003e
+&subvendor.id		pci 0x1c5f
+&subdevice.id		pci 0x4a31
++subdevice.name		NVMe SSD PBlaze6 6920 3200GB 2.5" U.2
+
+ vendor.id		pci 0x1c5f
+&device.id		pci 0x003e
+&subvendor.id		pci 0x1c5f
+&subdevice.id		pci 0x4a41
++subdevice.name		NVMe SSD PBlaze6 6920 6400GB 2.5" U.2
 
  vendor.id		pci 0x1c5f
 &device.id		pci 0x0540
@@ -106200,44 +109405,90 @@
 +vendor.name		Shannon Systems
 
  vendor.id		pci 0x1cb0
+&device.id		pci 0x8266
++device.name		Andalusia Series SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0x8266
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2021
++subdevice.name		Andalusia Series OCS U.2 SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0x8266
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2121
++subdevice.name		Andalusia Series ZNS U.2 SSD
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0x8266
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2f21
++subdevice.name		Andalusia Series NVMe U.2 SSD
+
+ vendor.id		pci 0x1cb0
 &device.id		pci 0xd000
 +device.name		Venice NVMe SSD
 
  vendor.id		pci 0x1cb0
 &device.id		pci 0xd000
 &subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2010
++subdevice.name		Venice-E Series OCS U.2
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2011
++subdevice.name		Venice Series OCS U.2
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0x2012
++subdevice.name		Venice-X Series OCS U.2
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
 &subdevice.id		pci 0x2f10
-+subdevice.name		Venice-E Series U.2 SSD
++subdevice.name		Venice-E Series NVMe U.2
 
  vendor.id		pci 0x1cb0
 &device.id		pci 0xd000
 &subvendor.id		pci 0x1cb0
 &subdevice.id		pci 0x2f11
-+subdevice.name		Venice Series U.2 SSD
++subdevice.name		Venice Series NVMe U.2
 
  vendor.id		pci 0x1cb0
 &device.id		pci 0xd000
 &subvendor.id		pci 0x1cb0
 &subdevice.id		pci 0x2f12
-+subdevice.name		Venice-X Series U.2 SSD
++subdevice.name		Venice-X Series NVMe U.2
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0xa010
++subdevice.name		Venice-E Series OCS AIC
+
+ vendor.id		pci 0x1cb0
+&device.id		pci 0xd000
+&subvendor.id		pci 0x1cb0
+&subdevice.id		pci 0xa012
++subdevice.name		Venice-X Series OCS AIC
 
  vendor.id		pci 0x1cb0
 &device.id		pci 0xd000
 &subvendor.id		pci 0x1cb0
 &subdevice.id		pci 0xaf10
-+subdevice.name		Venice-E Series AIC SSD
-
- vendor.id		pci 0x1cb0
-&device.id		pci 0xd000
-&subvendor.id		pci 0x1cb0
-&subdevice.id		pci 0xaf11
-+subdevice.name		Venice Series AIC SSD
++subdevice.name		Venice-E Series NVMe AIC
 
  vendor.id		pci 0x1cb0
 &device.id		pci 0xd000
 &subvendor.id		pci 0x1cb0
 &subdevice.id		pci 0xaf12
-+subdevice.name		Venice-X Series AIC SSD
++subdevice.name		Venice-X Series NVMe AIC
 
  vendor.id		pci 0x1cb1
 +vendor.name		Collion UG & Co.KG
@@ -106317,6 +109568,10 @@
  vendor.id		pci 0x1cd2
 &device.id		pci 0x0306
 +device.name		Simulyzer-RT CompactPCI Serial CAN-2 card (CAN-FD)
+
+ vendor.id		pci 0x1cd2
+&device.id		pci 0x0307
++device.name		Simulyzer-RT CompactPCI Serial DIO-2 card [Xilinx Zynq UltraScale+]
 
  vendor.id		pci 0x1cd7
 +vendor.name		Nanjing Magewell Electronics Co., Ltd.
@@ -106400,6 +109655,10 @@
 +device.name		ExaNIC V9P
 
  vendor.id		pci 0x1ce4
+&device.id		pci 0x000c
++device.name		ExaNIC V9P-3
+
+ vendor.id		pci 0x1ce4
 &device.id		pci 0x0100
 +device.name		ExaDISK FX1
 
@@ -106419,6 +109678,10 @@
 +vendor.name		Amazon.com, Inc.
 
  vendor.id		pci 0x1d0f
+&device.id		pci 0x8061
++device.name		NVMe EBS Controller
+
+ vendor.id		pci 0x1d0f
 &device.id		pci 0xcd01
 +device.name		NVMe SSD Controller
 
@@ -106428,6 +109691,10 @@
 
  vendor.id		pci 0x1d0f
 &device.id		pci 0xefa0
++device.name		Elastic Fabric Adapter (EFA)
+
+ vendor.id		pci 0x1d0f
+&device.id		pci 0xefa1
 +device.name		Elastic Fabric Adapter (EFA)
 
  vendor.id		pci 0x1d17
@@ -106779,6 +110046,10 @@
 +device.name		AQC107 NBase-T/IEEE 802.3bz Ethernet Controller [AQtion]
 
  vendor.id		pci 0x1d6a
+&device.id		pci 0x00b1
++device.name		AQC100 10G Ethernet MAC controller [AQtion]
+
+ vendor.id		pci 0x1d6a
 &device.id		pci 0x07b1
 +device.name		AQC107 NBase-T/IEEE 802.3bz Ethernet Controller [AQtion]
 
@@ -106908,6 +110179,38 @@
 +device.name		AR-MAN-U280 [Manitou Class Accelerator for U280]
 
  vendor.id		pci 0x1d6c
+&device.id		pci 0x1015
++device.name		AR-ARK-BBDEV-FX0 [Arkville 32B DPDK Baseband Device]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1016
++device.name		AR-ARK-BBDEV-FX1 [Arkville 64B DPDK Baseband Device]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1017
++device.name		AR-ARK-FX1 [Arkville 64B Multi-Homed Primary Endpoint]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1018
++device.name		AR-ARK-FX1 [Arkville 64B Multi-Homed Secondary Endpoint]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x1019
++device.name		AR-ARK-FX1 [Arkville 64B Multi-Homed Tertiary Endpoint]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x101a
++device.name		AR-ARK-SRIOV-FX0 [Arkville 32B Primary Physical Function]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x101b
++device.name		AR-ARK-SRIOV-FX1 [Arkville 64B Primary Physical Function]
+
+ vendor.id		pci 0x1d6c
+&device.id		pci 0x101c
++device.name		AR-ARK-SRIOV-VF [Arkville Virtual Function]
+
+ vendor.id		pci 0x1d6c
 &device.id		pci 0x4200
 +device.name		A5PL-E1-10GETI [10 GbE Ethernet Traffic Instrument]
 
@@ -106915,10 +110218,90 @@
 +vendor.name		Xiaomi
 
  vendor.id		pci 0x1d78
-+vendor.name		DERA
++vendor.name		DERA Storage
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
++device.name		TAI NVMe Controller
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x2004
++subdevice.name		D5437 HHHL 2TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x2006
++subdevice.name		D5437 HHHL 4TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x2008
++subdevice.name		D5437 HHHL 8TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x2104
++subdevice.name		D5437 U.2 2TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x2106
++subdevice.name		D5437 U.2 4TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x2108
++subdevice.name		D5437 U.2 8TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x3003
++subdevice.name		D5457 HHHL 1.6TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x3005
++subdevice.name		D5457 HHHL 3.2TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x3007
++subdevice.name		D5457 HHHL 6.4TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x3103
++subdevice.name		D5457 U.2 1.6TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x3105
++subdevice.name		D5457 U.2 3.2TB NVMe SSD
+
+ vendor.id		pci 0x1d78
+&device.id		pci 0x1512
+&subvendor.id		pci 0x1d78
+&subdevice.id		pci 0x3107
++subdevice.name		D5457 U.2 6.4TB NVMe SSD
 
  vendor.id		pci 0x1d7c
 +vendor.name		Aerotech, Inc.
+
+ vendor.id		pci 0x1d7c
+&device.id		pci 0x0001
++device.name		HyperWire Adapter
 
  vendor.id		pci 0x1d82
 +vendor.name		NETINT Technologies Inc.
@@ -106936,7 +110319,7 @@
 +device.name		Codensity T408 Video Encoding-Decoding Accelerator
 
  vendor.id		pci 0x1d87
-+vendor.name		Fuzhou Rockchip Electronics Co., Ltd
++vendor.name		Rockchip Electronics Co., Ltd
 
  vendor.id		pci 0x1d87
 &device.id		pci 0x0100
@@ -106946,11 +110329,15 @@
 &device.id		pci 0x1808
 +device.name		RK1808 Neural Network Processor Card
 
+ vendor.id		pci 0x1d87
+&device.id		pci 0x3566
++device.name		RK3568 Remote Signal Processor
+
  vendor.id		pci 0x1d8f
 +vendor.name		Enyx
 
  vendor.id		pci 0x1d93
-+vendor.name		YADRO (KNS Group)
++vendor.name		YADRO
 
  vendor.id		pci 0x1d94
 +vendor.name		Chengdu Haiguang IC Design Co., Ltd.
@@ -107082,6 +110469,13 @@
 &device.id		pci 0x0002
 +device.name		Colossus GC1 [S1]
 
+ vendor.id		pci 0x1d97
++vendor.name		Shenzhen Longsys Electronics Co., Ltd.
+
+ vendor.id		pci 0x1d97
+&device.id		pci 0x2263
++device.name		SM2263EN/SM2263XT-based OEM SSD
+
  vendor.id		pci 0x1d9b
 +vendor.name		Facebook, Inc.
 
@@ -107099,6 +110493,10 @@
  vendor.id		pci 0x1da2
 +vendor.name		Sapphire Technology Limited
 
+ vendor.id		pci 0x1da2
+&device.id		pci 0xe26a
++device.name		Radeon R7 250
+
  vendor.id		pci 0x1da3
 +vendor.name		Habana Labs Ltd.
 
@@ -107109,6 +110507,13 @@
  vendor.id		pci 0x1da3
 &device.id		pci 0x1000
 +device.name		HL-2000 AI Training Accelerator [Gaudi]
+
+ vendor.id		pci 0x1da3
+&device.id		pci 0x1010
++device.name		HL-2000 AI Training Accelerator [Gaudi secured]
+
+ vendor.id		pci 0x1db2
++vendor.name		ATP ELECTRONICS INC
 
  vendor.id		pci 0x1dbb
 +vendor.name		NGD Systems, Inc.
@@ -107127,7 +110532,7 @@
 +vendor.name		Liqid Inc.
 
  vendor.id		pci 0x1dd8
-+vendor.name		Pensando Systems Inc
++vendor.name		Pensando Systems
 
  vendor.id		pci 0x1dd8
 &device.id		pci 0x1000
@@ -107152,6 +110557,42 @@
 +subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
 
  vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4007
++subdevice.name		DSP DSC-25 Ent 10/25G OCP3 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4008
++subdevice.name		DSP DSC-25 10/25G 2p SFP28 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400a
++subdevice.name		DSC-100 40/100G 2-port 8G RAM 16G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400c
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400d
++subdevice.name		DSP DSC-100 Ent 100Gb Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1000
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400e
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
 &device.id		pci 0x1001
 +device.name		DSC Virtual Downstream Port
 
@@ -107172,6 +110613,42 @@
 &subvendor.id		pci 0x1dd8
 &subdevice.id		pci 0x4002
 +subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4007
++subdevice.name		DSP DSC-25 Ent 10/25G OCP3 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4008
++subdevice.name		DSP DSC-25 10/25G 2p SFP28 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400a
++subdevice.name		DSC-100 40/100G 2-port 8G RAM 16G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400c
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400d
++subdevice.name		DSP DSC-100 Ent 100Gb Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1001
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400e
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
 
  vendor.id		pci 0x1dd8
 &device.id		pci 0x1002
@@ -107196,6 +110673,42 @@
 +subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
 
  vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4007
++subdevice.name		DSP DSC-25 Ent 10/25G OCP3 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4008
++subdevice.name		DSP DSC-25 10/25G 2p SFP28 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400a
++subdevice.name		DSC-100 40/100G 2-port 8G RAM 16G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400c
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400d
++subdevice.name		DSP DSC-100 Ent 100Gb Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1002
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400e
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
 &device.id		pci 0x1003
 +device.name		DSC Ethernet Controller VF
 
@@ -107216,6 +110729,42 @@
 &subvendor.id		pci 0x1dd8
 &subdevice.id		pci 0x4002
 +subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4007
++subdevice.name		DSP DSC-25 Ent 10/25G OCP3 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4008
++subdevice.name		DSP DSC-25 10/25G 2p SFP28 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400a
++subdevice.name		DSC-100 40/100G 2-port 8G RAM 16G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400c
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400d
++subdevice.name		DSP DSC-100 Ent 100Gb Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1003
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400e
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
 
  vendor.id		pci 0x1dd8
 &device.id		pci 0x1004
@@ -107240,6 +110789,42 @@
 +subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
 
  vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4007
++subdevice.name		DSP DSC-25 Ent 10/25G OCP3 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4008
++subdevice.name		DSP DSC-25 10/25G 2p SFP28 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400a
++subdevice.name		DSC-100 40/100G 2-port 8G RAM 16G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400c
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400d
++subdevice.name		DSP DSC-100 Ent 100Gb Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1004
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400e
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
 &device.id		pci 0x1007
 +device.name		DSC Storage Accelerator
 
@@ -107261,12 +110846,48 @@
 &subdevice.id		pci 0x4002
 +subdevice.name		Naples 25Gb 2-port SFP28 x8 4GB
 
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4007
++subdevice.name		DSP DSC-25 Ent 10/25G OCP3 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x4008
++subdevice.name		DSP DSC-25 10/25G 2p SFP28 Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400a
++subdevice.name		DSC-100 40/100G 2-port 8G RAM 16G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400c
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400d
++subdevice.name		DSP DSC-100 Ent 100Gb Card
+
+ vendor.id		pci 0x1dd8
+&device.id		pci 0x1007
+&subvendor.id		pci 0x1dd8
+&subdevice.id		pci 0x400e
++subdevice.name		DSC-25 10/25G 2-port 4G RAM 8G eMMC G1 Services Card
+
  vendor.id		pci 0x1de0
 +vendor.name		Groq
 
  vendor.id		pci 0x1de0
 &device.id		pci 0x0000
-+device.name		Q100 Tensor Streaming Processor
++device.name		TSP100 Tensor Streaming Processor
 
  vendor.id		pci 0x1de1
 +vendor.name		Tekram Technology Co.,Ltd.
@@ -107277,7 +110898,7 @@
 
  vendor.id		pci 0x1de1
 &device.id		pci 0x2020
-+device.name		DC-390
++device.name		DC-390 Series SCSI Adapter [AMD Am53C974]
 
  vendor.id		pci 0x1de1
 &device.id		pci 0x690c
@@ -107297,6 +110918,13 @@
  vendor.id		pci 0x1de5
 &device.id		pci 0x2000
 +device.name		NoLoad Hardware Development Kit
+
+ vendor.id		pci 0x1de5
+&device.id		pci 0x3000
++device.name		eBPF-based PCIe Accelerator
+
+ vendor.id		pci 0x1dee
++vendor.name		Biwin Storage Technology Co., Ltd.
 
  vendor.id		pci 0x1def
 +vendor.name		Ampere Computing, LLC
@@ -107332,6 +110960,78 @@
  vendor.id		pci 0x1def
 &device.id		pci 0xe00c
 +device.name		eMAG PCI Express Root Port 7
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe100
++device.name		Altra PCI Express Root Complex A
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe101
++device.name		Altra PCI Express Root Port a0
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe102
++device.name		Altra PCI Express Root Port a1
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe103
++device.name		Altra PCI Express Root Port a2
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe104
++device.name		Altra PCI Express Root Port a3
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe105
++device.name		Altra PCI Express Root Port a4
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe106
++device.name		Altra PCI Express Root Port a5
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe107
++device.name		Altra PCI Express Root Port a6
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe108
++device.name		Altra PCI Express Root Port a7
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe110
++device.name		Altra PCI Express Root Complex B
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe111
++device.name		Altra PCI Express Root Port b0
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe112
++device.name		Altra PCI Express Root Port b1
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe113
++device.name		Altra PCI Express Root Port b2
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe114
++device.name		Altra PCI Express Root Port b3
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe115
++device.name		Altra PCI Express Root Port b4
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe116
++device.name		Altra PCI Express Root Port b5
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe117
++device.name		Altra PCI Express Root Port b6
+
+ vendor.id		pci 0x1def
+&device.id		pci 0xe118
++device.name		Altra PCI Express Root Port b7
 
  vendor.id		pci 0x1df3
 +vendor.name		Ethernity Networks
@@ -107424,6 +111124,70 @@
 &subdevice.id		pci 0x0002
 +subdevice.name		ENA1020ZS
 
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0205
++device.name		ACE-NIC250 Programmable Network Accelerator
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0205
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0000
++subdevice.name		Maintenance Mode
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0205
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0001
++subdevice.name		ENA2250F
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0206
++device.name		ACE-NIC200 Programmable Network Accelerator
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0206
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0000
++subdevice.name		Maintenance Mode
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0206
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0001
++subdevice.name		ENA2200F
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0207
++device.name		ACE-NIC50RN Programmable Network Accelerator
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0207
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0000
++subdevice.name		Maintenance Mode
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0207
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0001
++subdevice.name		ENA2050RN
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0208
++device.name		ACE-NIC100RN Programmable Network Accelerator
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0208
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0000
++subdevice.name		Maintenance Mode
+
+ vendor.id		pci 0x1df3
+&device.id		pci 0x0208
+&subvendor.id		pci 0x1df3
+&subdevice.id		pci 0x0001
++subdevice.name		ENA2100RN
+
  vendor.id		pci 0x1df7
 +vendor.name		opencpi.org
 
@@ -107452,6 +111216,136 @@
  vendor.id		pci 0x1e0f
 &device.id		pci 0x0007
 +device.name		NVMe SSD Controller Cx6
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2078
++subdevice.name		DC NVMe CD6 RI 960GB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2079
++subdevice.name		DC NVMe CD6 RI 1.92TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x207a
++subdevice.name		DC NVMe CD6 RI 3.84TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x207b
++subdevice.name		DC NVMe CD6 RI 7.68TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x207c
++subdevice.name		DC NVMe CD6 RI 15.36TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x207e
++subdevice.name		Dell Ent NVMe CM6 RI 1.92TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x207f
++subdevice.name		Dell Ent NVMe CM6 RI 3.84TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2080
++subdevice.name		Dell Ent NVMe CM6 RI 7.68TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2081
++subdevice.name		Dell Ent NVMe CM6 RI 15.36TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2084
++subdevice.name		Dell Ent NVMe CM6 MU 1.6TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2085
++subdevice.name		Dell Ent NVMe CM6 MU 3.2TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2086
++subdevice.name		Dell Ent NVMe CM6 MU 6.4TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x210a
++subdevice.name		Dell Ent NVMe FIPS CM6 RI 1.92TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x210b
++subdevice.name		Dell Ent NVMe FIPS CM6 RI 3.84TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x210c
++subdevice.name		Dell Ent NVMe FIPS CM6 RI 7.68TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x210d
++subdevice.name		Dell Ent NVMe FIPS CM6 RI15.36TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x210e
++subdevice.name		Dell Ent NVMe FIPS CM6 MU 1.6TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x210f
++subdevice.name		Dell Ent NVMe FIPS CM6 MU 3.2TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2110
++subdevice.name		Dell Ent NVMe FIPS CM6 MU 6.4TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0007
+&subvendor.id		pci 0x1e0f
+&subdevice.id		pci 0x0001
++subdevice.name		Generic NVMe CM6 RI 3.84TB
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0009
++device.name		NVMe SSD
+
+ vendor.id		pci 0x1e0f
+&device.id		pci 0x0009
+&subvendor.id		pci 0x1e0f
+&subdevice.id		pci 0x0001
++subdevice.name		Toshiba RC500 NVMe SSD 500GB
 
  vendor.id		pci 0x1e17
 +vendor.name		Arnold & Richter Cine Technik GmbH & Co. Betriebs KG
@@ -107497,8 +111391,179 @@
 &device.id		pci 0x0001
 +device.name		T10 [CloudBlazer]
 
+ vendor.id		pci 0x1e36
+&device.id		pci 0x0002
++device.name		T11 [CloudBlazer]
+
+ vendor.id		pci 0x1e36
+&device.id		pci 0x0003
++device.name		T10(QSFP-DD) [CloudBlazer]
+
+ vendor.id		pci 0x1e36
+&device.id		pci 0x8011
++device.name		I10 [CloudBlazer]
+
+ vendor.id		pci 0x1e36
+&device.id		pci 0x8012
++device.name		I10L [CloudBlazer]
+
  vendor.id		pci 0x1e38
 +vendor.name		Blaize, Inc
+
+ vendor.id		pci 0x1e38
+&device.id		pci 0x0102
++device.name		Xplorer X1600
+
+ vendor.id		pci 0x1e3b
++vendor.name		Shenzhen DAPU Microelectronics Co., Ltd
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
++device.name		Haishen NVMe SSD
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0001
++subdevice.name		Enterprise NVMe SSD U.2 0.8TB (H2100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0002
++subdevice.name		Enterprise NVMe SSD U.2 0.96TB (H2200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0004
++subdevice.name		Enterprise NVMe SSD U.2 1.6TB (H2100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0005
++subdevice.name		Enterprise NVMe SSD U.2 1.92TB (H2200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0009
++subdevice.name		Enterprise NVMe SSD U.2 0.8TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x000a
++subdevice.name		Enterprise NVMe SSD U.2 0.96TB (H3200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x000c
++subdevice.name		Enterprise NVMe SSD U.2 1.6TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x000d
++subdevice.name		Enterprise NVMe SSD U.2 1.92TB (H3200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0014
++subdevice.name		Enterprise NVMe SSD U.2 3.2TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0015
++subdevice.name		Enterprise NVMe SSD U.2 3.84TB (H3200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0021
++subdevice.name		Enterprise NVMe SSD U.2 6.4TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0022
++subdevice.name		Enterprise NVMe SSD U.2 7.68TB (H3200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0061
++subdevice.name		Enterprise NVMe SSD HHHL 0.8TB (H2100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0062
++subdevice.name		Enterprise NVMe SSD HHHL 0.96TB (H2200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0064
++subdevice.name		Enterprise NVMe SSD HHHL 1.6TB (H2100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0065
++subdevice.name		Enterprise NVMe SSD HHHL 1.92TB (H2200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x006c
++subdevice.name		Enterprise NVMe SSD HHHL 0.8TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x006d
++subdevice.name		Enterprise NVMe SSD HHHL 0.96TB (H3200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x006f
++subdevice.name		Enterprise NVMe SSD HHHL 1.6TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0070
++subdevice.name		Enterprise NVMe SSD HHHL 1.92TB (H3200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x007c
++subdevice.name		Enterprise NVMe SSD HHHL 3.2TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x007d
++subdevice.name		Enterprise NVMe SSD HHHL 3.84TB (H3200)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x007f
++subdevice.name		Enterprise NVMe SSD HHHL 6.4TB (H3100)
+
+ vendor.id		pci 0x1e3b
+&device.id		pci 0x1098
+&subvendor.id		pci 0x1e3b
+&subdevice.id		pci 0x0080
++subdevice.name		Enterprise NVMe SSD HHHL 7.68TB (H3200)
 
  vendor.id		pci 0x1e3d
 +vendor.name		Burlywood, Inc
@@ -107506,12 +111571,39 @@
  vendor.id		pci 0x1e49
 +vendor.name		Yangtze Memory Technologies Co.,Ltd
 
+ vendor.id		pci 0x1e4b
++vendor.name		MAXIO Technology (Hangzhou) Ltd.
+
+ vendor.id		pci 0x1e4b
+&device.id		pci 0x1001
++device.name		NVMe SSD Controller MAP1001
+
+ vendor.id		pci 0x1e4b
+&device.id		pci 0x1002
++device.name		NVMe SSD Controller MAP1002
+
+ vendor.id		pci 0x1e4b
+&device.id		pci 0x1003
++device.name		NVMe SSD Controller MAP1003
+
+ vendor.id		pci 0x1e4b
+&device.id		pci 0x1201
++device.name		NVMe SSD Controller MAP1201
+
+ vendor.id		pci 0x1e4b
+&device.id		pci 0x1202
++device.name		NVMe SSD Controller MAP1202
+
+ vendor.id		pci 0x1e4b
+&device.id		pci 0x1601
++device.name		NVMe SSD Controller MAP1601
+
  vendor.id		pci 0x1e4c
 +vendor.name		GSI Technology
 
  vendor.id		pci 0x1e4c
 &device.id		pci 0x0010
-+device.name		Gemini [ Lida ]
++device.name		APU [Leda]
 
  vendor.id		pci 0x1e4c
 &device.id		pci 0x0010
@@ -107532,8 +111624,25 @@
 &subdevice.id		pci 0x0100
 +subdevice.name		PY8800 64GB Accelerator
 
+ vendor.id		pci 0x1e60
++vendor.name		Hailo Technologies Ltd.
+
+ vendor.id		pci 0x1e60
+&device.id		pci 0x2864
++device.name		Hailo-8 AI Processor
+
  vendor.id		pci 0x1e6b
 +vendor.name		Axiado Corp.
+
+ vendor.id		pci 0x1e7b
++vendor.name		Dataland
+
+ vendor.id		pci 0x1e7c
++vendor.name		Brainchip Inc
+
+ vendor.id		pci 0x1e7c
+&device.id		pci 0xbca1
++device.name		AKD1000 Neural Network Coprocessor [Akida]
 
  vendor.id		pci 0x1e85
 +vendor.name		Heitec AG
@@ -107551,6 +111660,60 @@
 
  vendor.id		pci 0x1e94
 +vendor.name		Calian SED
+
+ vendor.id		pci 0x1e95
++vendor.name		Solid State Storage Technology Corporation
+
+ vendor.id		pci 0x1ea0
++vendor.name		Tencent Technology (Shenzhen) Company Limited
+
+ vendor.id		pci 0x1ea0
+&device.id		pci 0x2a16
++device.name		Cloud Intelligent Inference Controller
+
+ vendor.id		pci 0x1eab
++vendor.name		Hefei DATANG Storage Technology Co.,LTD.
+
+ vendor.id		pci 0x1eab
+&device.id		pci 0x300a
++device.name		NVMe SSD Controller 300A
+
+ vendor.id		pci 0x1eab
+&device.id		pci 0x300b
++device.name		NVMe SSD Controller 300B
+
+ vendor.id		pci 0x1eae
++vendor.name		XFX Limited
+
+ vendor.id		pci 0x1eb1
++vendor.name		VeriSilicon Inc
+
+ vendor.id		pci 0x1eb1
+&device.id		pci 0x1001
++device.name		Video Accelerator
+
+ vendor.id		pci 0x1ebd
++vendor.name		EMERGETECH Company Ltd.
+
+ vendor.id		pci 0x1ebd
+&device.id		pci 0x0101
++device.name		Seirios 2063 Video Codec
+
+ vendor.id		pci 0x1ed3
++vendor.name		Yeston
+
+ vendor.id		pci 0x1ed8
++vendor.name		Digiteq Automotive
+
+ vendor.id		pci 0x1ed8
+&device.id		pci 0x0101
++device.name		FG4 PCIe Frame Grabber
+
+ vendor.id		pci 0x1ed9
++vendor.name		Myrtle.ai
+
+ vendor.id		pci 0x1ee9
++vendor.name		SUSE LLC
 
  vendor.id		pci 0x1fc0
 +vendor.name		Ascom (Finland) Oy
@@ -107913,6 +112076,26 @@
  vendor.id		pci 0x2646
 +vendor.name		Kingston Technology Company, Inc.
 
+ vendor.id		pci 0x2646
+&device.id		pci 0x0010
++device.name		HyperX Predator PCIe AHCI SSD
+
+ vendor.id		pci 0x2646
+&device.id		pci 0x2262
++device.name		KC2000 NVMe SSD
+
+ vendor.id		pci 0x2646
+&device.id		pci 0x2263
++device.name		A2000 NVMe SSD
+
+ vendor.id		pci 0x2646
+&device.id		pci 0x5008
++device.name		U-SNS8154P3 NVMe SSD
+
+ vendor.id		pci 0x2646
+&device.id		pci 0x500d
++device.name		OM3PDP3 NVMe SSD
+
  vendor.id		pci 0x270b
 +vendor.name		Xantel Corporation
 
@@ -108104,7 +112287,7 @@
 +device.name		AS-i 3.0 PCI Master
 
  vendor.id		pci 0x3475
-+vendor.name		Arastra Inc.
++vendor.name		Arista Networks, Inc.
 
  vendor.id		pci 0x3513
 +vendor.name		ARCOM Control Systems Ltd
@@ -108344,6 +112527,12 @@
  vendor.id		pci 0x3d3d
 &device.id		pci 0x07a2
 +device.name		Sun XVR-500 Graphics Accelerator
+
+ vendor.id		pci 0x3d3d
+&device.id		pci 0x07a2
+&subvendor.id		pci 0x3d3d
+&subdevice.id		pci 0x1047
++subdevice.name		Sun XVR-600 Graphics Accelerator
 
  vendor.id		pci 0x3d3d
 &device.id		pci 0x07a3
@@ -108611,7 +112800,10 @@
 +device.name		CH355 PCI Quad Serial Port Controller
 
  vendor.id		pci 0x434e
-+vendor.name		CAST Navigation LLC
++vendor.name		Cornelis Networks
+
+ vendor.id		pci 0x43bc
++vendor.name		Tiger Lake-H PCIe Root Port #5
 
  vendor.id		pci 0x4444
 +vendor.name		Internext Compression Inc
@@ -111218,6 +115410,12 @@
 +subdevice.name		P8P67/P8H67 Series Motherboard
 
  vendor.id		pci 0x8086
+&device.id		pci 0x0100
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x0101
 +device.name		Xeon E3-1200/2nd Generation Core Processor Family PCI Express Root Port
 
@@ -111624,12 +115822,56 @@
 +device.name		3rd Gen Core processor Graphics Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x0201
++device.name		Arctic Sound
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0284
++device.name		Comet Lake PCH-LP LPC Premium Controller/eSPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02a3
++device.name		Comet Lake PCH-LP SMBus Host Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x02a4
 +device.name		Comet Lake SPI (flash) Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x02a6
 +device.name		Comet Lake North Peak
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02b0
++device.name		Comet Lake PCI Express Root Port #9
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02b1
++device.name		Comet Lake PCI Express Root Port #10
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02b3
++device.name		Comet Lake PCI Express Root Port #12
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02b4
++device.name		Comet Lake PCI Express Root Port #13
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02b8
++device.name		Comet Lake PCI Express Root Port #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02bc
++device.name		Comet Lake PCI Express Root Port #5
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02c5
++device.name		Comet Lake Serial IO I2C Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02c8
++device.name		Comet Lake PCH-LP cAVS
 
  vendor.id		pci 0x8086
 &device.id		pci 0x02d3
@@ -111648,8 +115890,48 @@
 +device.name		Comet Lake Serial IO I2C Host Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x02ea
++device.name		Comet Lake PCH-LP LPSS: I2C Controller #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02ed
++device.name		Comet Lake PCH-LP USB 3.1 xHCI Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02ef
++device.name		Comet Lake PCH-LP Shared SRAM
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x02f0
-+device.name		Wireless-AC 9462
++device.name		Comet Lake PCH-LP CNVi WiFi
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0034
++subdevice.name		Wireless-AC 9560 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0070
++subdevice.name		Wi-Fi 6 AX201 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0074
++subdevice.name		Wi-Fi 6 AX201 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4070
++subdevice.name		Wireless-AC 9462 80MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x02f5
++device.name		Comet Lake PCH-LP SCS3
 
  vendor.id		pci 0x8086
 &device.id		pci 0x02f9
@@ -111782,6 +116064,24 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x0412
 +device.name		Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0412
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0412
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0412
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0412
@@ -112012,6 +116312,10 @@
 +device.name		Comet Lake PCI Express Root Port #9
 
  vendor.id		pci 0x8086
+&device.id		pci 0x06bd
++device.name		Comet Lake PCIe Port #6
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x06c0
 +device.name		Comet Lake PCI Express Root Port #17
 
@@ -112020,8 +116324,16 @@
 +device.name		Comet Lake PCH cAVS
 
  vendor.id		pci 0x8086
+&device.id		pci 0x06d2
++device.name		Comet Lake SATA AHCI Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x06e0
 +device.name		Comet Lake HECI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06e3
++device.name		Comet Lake Keyboard and Text (KT) Redirection
 
  vendor.id		pci 0x8086
 &device.id		pci 0x06e8
@@ -112049,7 +116361,25 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x06f0
-+device.name		Wi-Fi 6 AX201
++device.name		Comet Lake PCH CNVi WiFi
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0034
++subdevice.name		Wireless-AC 9560
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0074
++subdevice.name		Wi-Fi 6 AX201 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x06f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x02a4
++subdevice.name		Wireless-AC 9462
 
  vendor.id		pci 0x8086
 &device.id		pci 0x06f9
@@ -113785,7 +118115,7 @@
 &device.id		pci 0x0a54
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4308
-+subdevice.name		Intel SSD D5-P4320 and D5-P4326
++subdevice.name		SSD D5-P4320 and D5-P4326
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0a54
@@ -113874,6 +118204,112 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x1fe9
 +subdevice.name		Express Flash NVMe 4.0TB HHHL AIC (P4600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b26
++device.name		Thunderbolt 4 Bridge [Goshen Ridge 2020]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b27
++device.name		Thunderbolt 4 USB Controller [Goshen Ridge 2020]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
++device.name		NVMe DC SSD [3DNAND, Sentinel Rock Controller]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2060
++subdevice.name		NVMe SED MU U.2 1.6TB (P5600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2061
++subdevice.name		NVMe SED MU U.2 3.2TB (P5600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2062
++subdevice.name		NVMe SED MU U.2 6.4TB (P5600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2064
++subdevice.name		NVMe SED RI U.2 1.92TB (P5500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2065
++subdevice.name		NVMe SED RI U.2 3.84TB (P5500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2066
++subdevice.name		NVMe SED RI U.2 7.68TB (P5500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x209e
++subdevice.name		NVMe MU U.2 1.6TB (P5600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x209f
++subdevice.name		NVMe MU U.2 3.2TB (P5600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2100
++subdevice.name		NVMe MU U.2 6.4TB (P5600)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2102
++subdevice.name		NVMe RI U.2 1.92TB (P5500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2103
++subdevice.name		NVMe RI U.2 3.84TB (P5500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2104
++subdevice.name		NVMe RI U.2 7.68TB (P5500)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x8008
++subdevice.name		NVMe Datacenter SSD [3DNAND] SE 2.5" U.2 (P5510)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x8d08
++subdevice.name		NVMe Datacenter SSD [3DNAND] VE 2.5" U.2 (P5316)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0b60
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x8d1d
++subdevice.name		NVMe Datacenter SSD [3DNAND] VE E1.L 9.5/18mm (P5316)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0bd0
++device.name		Ponte Vecchio 2T
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0be0
@@ -113989,6 +118425,24 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0c00
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0c00
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0c00
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0c00
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x309f
 +subdevice.name		ThinkCentre M83
@@ -114028,6 +118482,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x0c0c
 +device.name		Xeon E3-1200 v3/4th Gen Core Processor HD Audio Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0c0c
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0c0c
@@ -114276,6 +118736,10 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x0001
 +subdevice.name		Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x0d9f
++device.name		Ethernet Controller (2) I225-IT
 
  vendor.id		pci 0x8086
 &device.id		pci 0x0e00
@@ -117659,7 +122123,7 @@
 &device.id		pci 0x10fb
 &subvendor.id		pci 0x15d9
 &subdevice.id		pci 0x0611
-+subdevice.name		AOC-STGN-I2S [REV 1.01]
++subdevice.name		AOC-STGN-i2S
 
  vendor.id		pci 0x8086
 &device.id		pci 0x10fb
@@ -117864,6 +122328,18 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4557
 +subdevice.name		D815EGEW Mainboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1136
++device.name		Thunderbolt 4 Bridge [Maple Ridge 4C 2020]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1137
++device.name		Thunderbolt 4 NHI [Maple Ridge 4C 2020]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1138
++device.name		Thunderbolt 4 USB Controller [Maple Ridge 4C 2020]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1161
@@ -119044,6 +123520,22 @@
 +device.name		82380FB (MPCI2) Mobile Docking Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x124c
++device.name		Ethernet Connection E823-L for backplane
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x124d
++device.name		Ethernet Connection E823-L for SFP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x124e
++device.name		Ethernet Connection E823-L/X557-AT 10GBASE-T
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x124f
++device.name		Ethernet Connection E823-L 1GbE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1250
 +device.name		430HX - 82439HX TXC [Triton II]
 
@@ -119138,6 +123630,12 @@
 &subvendor.id		pci 0x10cf
 &subdevice.id		pci 0x161c
 +subdevice.name		LIFEBOOK E752
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1503
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1507
@@ -119290,6 +123788,10 @@
 &subvendor.id		pci 0x108e
 &subdevice.id		pci 0x7b13
 +subdevice.name		Dual 10GBASE-T LP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x151d
++device.name		Ethernet Connection E823-L for QSFP
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1520
@@ -119458,6 +123960,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1521
 &subvendor.id		pci 0x15d9
+&subdevice.id		pci 0x0000
++subdevice.name		AOC-SGP-i4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1521
+&subvendor.id		pci 0x15d9
 &subdevice.id		pci 0x0652
 +subdevice.name		Dual Port i350 GbE MicroLP [AOC-CGP-i2]
 
@@ -119490,6 +123998,12 @@
 &subvendor.id		pci 0x193d
 &subdevice.id		pci 0x1007
 +subdevice.name		360T-L
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1521
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1080
++subdevice.name		NIC-ETH360T-3S-4P
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1521
@@ -119989,6 +124503,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x153a
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x153a
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x220e
 +subdevice.name		ThinkPad T440p
@@ -120308,6 +124828,12 @@
 +subdevice.name		EliteBook 840 G3
 
  vendor.id		pci 0x8086
+&device.id		pci 0x156f
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1570
 +device.name		Ethernet Connection I219-V
 
@@ -120411,9 +124937,39 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1572
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1020
++subdevice.name		NIC-ETH561F-sL-4x10G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1021
++subdevice.name		NIC-ETH561F-sL-2x10G
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1081
++subdevice.name		NIC-ETH561F-3S-2P
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
 &subvendor.id		pci 0x19e5
 &subdevice.id		pci 0xd11c
 +subdevice.name		Ethernet 2-port X710 10Gb SFP+ Adapter SP330
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0042
++subdevice.name		10G SFP+ DP EP102Fi4 Adapter
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1572
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0056
++subdevice.name		Ethernet Network Adapter X710-BM2 for OCP NIC 3.0
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1572
@@ -120590,6 +125146,12 @@
 +device.name		I210 Gigabit Network Connection
 
  vendor.id		pci 0x8086
+&device.id		pci 0x157b
+&subvendor.id		pci 0xea50
+&subdevice.id		pci 0xcc10
++subdevice.name		RXi2-BP
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x157c
 +device.name		I210 Gigabit Backplane Connection
 
@@ -120650,6 +125212,12 @@
 &subvendor.id		pci 0x1590
 &subdevice.id		pci 0x00f8
 +subdevice.name		Ethernet 2-port 563i Adapter
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1581
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x100e
++subdevice.name		NIC-ETH561i-Mb-4x10G
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1581
@@ -121068,12 +125636,6 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x158b
 &subvendor.id		pci 0x8086
-&subdevice.id		pci 0x000c
-+subdevice.name		Ethernet Network Adapter XXV710-DA2 for OCP 3.0
-
- vendor.id		pci 0x8086
-&device.id		pci 0x158b
-&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4001
 +subdevice.name		Ethernet Network Adapter XXV710-2
 
@@ -121090,6 +125652,18 @@
 &subvendor.id		pci 0x1137
 &subdevice.id		pci 0x02bf
 +subdevice.name		E810CQDA2 2x100 GbE QSFP28 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1050
++subdevice.name		NIC-ETH1060F-LP-2P 2x100GbE Ethernet PCIe Card
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0001
++subdevice.name		Ethernet Network Adapter E810-C-Q1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1592
@@ -121120,6 +125694,36 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x0009
 +subdevice.name		Ethernet Network Adapter E810-C-Q1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000a
++subdevice.name		Ethernet Network Adapter E810-C-Q1 for OCP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000b
++subdevice.name		Ethernet 100G 2P E810-C Adapter
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000c
++subdevice.name		Ethernet 100G 2P E810-C OCP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000d
++subdevice.name		Ethernet Network Adapter E810-L-Q2 for OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1592
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000e
++subdevice.name		Ethernet Network Adapter E810-2C-Q2
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1593
@@ -121168,6 +125772,12 @@
 +subdevice.name		Ethernet Network Adapter E810-XXV-2 for OCP 2.0
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1593
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x000a
++subdevice.name		Ethernet 25G 4P E810-XXV Adapter
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1599
 +device.name		Ethernet Controller E810-XXV for backplane
 
@@ -121184,6 +125794,18 @@
 &subvendor.id		pci 0x1137
 &subdevice.id		pci 0x02be
 +subdevice.name		E810XXVDA2 2x25/10 GbE SFP28 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0057
++subdevice.name		Ethernet Network Adapter E810-XXVAM2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x159b
+&subvendor.id		pci 0x1bd4
+&subdevice.id		pci 0x0058
++subdevice.name		Ethernet Network Adapter E810-XXVAM2 for OCP 3.0
 
  vendor.id		pci 0x8086
 &device.id		pci 0x159b
@@ -121322,6 +125944,12 @@
 +device.name		Ethernet Connection (2) I219-V
 
  vendor.id		pci 0x8086
+&device.id		pci 0x15b8
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x15b9
 +device.name		Ethernet Connection (3) I219-LM
 
@@ -121449,7 +126077,7 @@
 &device.id		pci 0x15d5
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x0001
-+subdevice.name		Intel(R) Ethernet SDI Adapter FM10420-25GbE-DA2
++subdevice.name		Ethernet SDI Adapter FM10420-25GbE-DA2
 
  vendor.id		pci 0x8086
 &device.id		pci 0x15d6
@@ -121554,6 +126182,32 @@
 +device.name		JHL7540 Thunderbolt 3 USB Controller [Titan Ridge DD 2018]
 
  vendor.id		pci 0x8086
+&device.id		pci 0x15f2
++device.name		Ethernet Controller I225-LM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15f2
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0001
++subdevice.name		Ethernet Network Adapter I225-T1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15f2
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0002
++subdevice.name		Ethernet Network Adapter I225-T1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15f3
++device.name		Ethernet Controller I225-V
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15f3
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0003
++subdevice.name		Intel(R) Ethernet Controller (3) I225-V
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x15f4
 +device.name		Ethernet Connection (15) I219-LM
 
@@ -121602,6 +126256,24 @@
 &subvendor.id		pci 0x1137
 &subdevice.id		pci 0x02c2
 +subdevice.name		X710T4LG 4x10 GbE RJ45 PCIe NIC
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02d9
++subdevice.name		Ethernet Network Adapter X710-T2L OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x1137
+&subdevice.id		pci 0x02da
++subdevice.name		Ethernet Network Adapter X710-T4L OCP 3.0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x15ff
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1082
++subdevice.name		NIC-ETH565T-3S-2P
 
  vendor.id		pci 0x8086
 &device.id		pci 0x15ff
@@ -121846,6 +126518,42 @@
 +device.name		Ethernet Adaptive Virtual Function
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1890
++device.name		Ethernet Connection E822-C for backplane
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1891
++device.name		Ethernet Connection E822-C for QSFP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1892
++device.name		Ethernet Connection E822-C for SFP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1893
++device.name		Ethernet Connection E822-C/X557-AT 10GBASE-T
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1894
++device.name		Ethernet Connection E822-C 1GbE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1897
++device.name		Ethernet Connection E822-L for backplane
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1898
++device.name		Ethernet Connection E822-L for SFP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1899
++device.name		Ethernet Connection E822-L/X557-AT 10GBASE-T
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x189a
++device.name		Ethernet Connection E822-L 1GbE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x18a0
 +device.name		C4xxx Series QAT
 
@@ -121859,7 +126567,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1901
-+device.name		Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor PCIe Controller (x16)
++device.name		6th-10th Gen Core Processor PCIe Controller (x16)
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1902
@@ -121886,6 +126594,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06e4
 +subdevice.name		XPS 15 9550
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1903
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1903
@@ -121920,6 +126634,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x8079
 +subdevice.name		EliteBook 840 G3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1904
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1904
@@ -121960,6 +126680,12 @@
 +subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
+&device.id		pci 0x190c
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x190f
 +device.name		Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 
@@ -121988,6 +126714,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x0869
 +subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1911
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1911
@@ -122034,6 +126766,12 @@
 +subdevice.name		EliteBook 840 G3
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1916
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1918
 +device.name		Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 
@@ -122046,6 +126784,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06d6
 +subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1919
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x191b
@@ -122076,6 +126820,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06d6
 +subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x191e
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x191f
@@ -122596,6 +127346,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1c02
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1c02
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x7270
 +subdevice.name		Server Board S1200BT Family
 
@@ -122860,6 +127616,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1c20
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1c20
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x7270
 +subdevice.name		Apple MacBookPro8,2 [Core i7, 15", 2011]
 
@@ -122902,6 +127664,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x21cf
 +subdevice.name		ThinkPad T520
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1c22
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1c22
@@ -122956,6 +127724,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x21cf
 +subdevice.name		ThinkPad T520
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1c26
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1c26
@@ -123026,6 +127800,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x1c2d
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1c2d
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x7270
 +subdevice.name		Server Board S1200BT Family / Apple MacBook Pro 8,1/8,2
 
@@ -123076,6 +127856,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x21cf
 +subdevice.name		ThinkPad T520
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1c3a
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1c3a
@@ -123272,6 +128058,12 @@
 +device.name		H61 Express Chipset LPC Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1c5c
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x200d
++subdevice.name		DH61CR motherboard
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1c5d
 +device.name		6 Series/C200 Series Chipset Family LPC Controller
 
@@ -123444,6 +128236,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x04f7
 +subdevice.name		C602J on PowerEdge R320 server
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x1d2d
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x18a9
++subdevice.name		HP DL360e G8
 
  vendor.id		pci 0x8086
 &device.id		pci 0x1d2d
@@ -124536,6 +129334,12 @@
 +device.name		Atom processor C2000 USB Enhanced Host Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x1f2c
+&subvendor.id		pci 0x0200
+&subdevice.id		pci 0x1028
++subdevice.name		Atom C2338 on Dell 0K8Y0N motherboard
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x1f2e
 +device.name		Atom processor C2000 RAID SATA2 Controller
 
@@ -125376,6 +130180,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2442
 &subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4d44
++subdevice.name		D850EMV2 motherboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2442
+&subvendor.id		pci 0x8086
 &subdevice.id		pci 0x5744
 +subdevice.name		S845WD1-E mainboard
 
@@ -125612,6 +130422,12 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4656
 +subdevice.name		Desktop Board D815EFV
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2445
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4d44
++subdevice.name		D850EMV2 motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2446
@@ -126046,6 +130862,12 @@
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x4557
 +subdevice.name		D815EGEW Mainboard
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x244b
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4d44
++subdevice.name		D850EMV2 motherboard
 
  vendor.id		pci 0x8086
 &device.id		pci 0x244b
@@ -128959,6 +133781,12 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x24f0
+&subvendor.id		pci 0x434e
+&subdevice.id		pci 0x0001
++subdevice.name		Omni-Path HFI 100 Series, 1 Port, OCP 3.0 Adapter
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x24f0
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x2628
 +subdevice.name		Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x16
@@ -129084,6 +133912,22 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2521
 +device.name		82804AA MRH-S Memory Repeater Hub for SDRAM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2522
++device.name		NVMe Optane Memory Series
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2522
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x3806
++subdevice.name		Optane Memory 16GB
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2522
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x3810
++subdevice.name		Optane Memory M10 16GB
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2526
@@ -129540,6 +134384,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x099c
 +subdevice.name		NX6110/NC6120
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2590
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x82d9
++subdevice.name		Asus Eee PC 900
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2590
@@ -131805,9 +136655,97 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2723
+&subvendor.id		pci 0x1a56
+&subdevice.id		pci 0x1654
++subdevice.name		Killer™ Wi-Fi 6 AX1650x (AX200NGW)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2723
 &subvendor.id		pci 0x8086
-&subdevice.id		pci 0x2723
-+subdevice.name		Wireless AX200
+&subdevice.id		pci 0x0084
++subdevice.name		Wi-Fi 6 AX200NGW
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
++device.name		Wi-Fi 6 AX210/AX211/AX411 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0020
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0024
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0090
++subdevice.name		Wi-Fi 6 AX211 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x00b0
++subdevice.name		Wi-Fi 6 AX411 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0310
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0510
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0a10
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x2020
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x4020
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x6020
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x6024
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0xe020
++subdevice.name		Wi-Fi 6 AX210 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2725
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0xe024
++subdevice.name		Wi-Fi 6 AX210 160MHz
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2770
@@ -131942,6 +136880,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x277d
 +device.name		82975X PCI Express Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2780
++device.name		82915G/GV/GL/910GL [Grantsdale] Graphics Device
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2782
@@ -133962,10 +138904,6 @@
 &subvendor.id		pci 0x1775
 &subdevice.id		pci 0x11cc
 +subdevice.name		CC11/CL11
-
- vendor.id		pci 0x8086
-&device.id		pci 0x280b
-+device.name		Intel(R) Display Audio
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2810
@@ -137366,6 +142304,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2a00
 &subvendor.id		pci 0x103c
+&subdevice.id		pci 0x30c5
++subdevice.name		Compaq 8510p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2a00
+&subvendor.id		pci 0x103c
 &subdevice.id		pci 0x30cc
 +subdevice.name		Pavilion dv6700
 
@@ -137656,6 +142600,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x2a42
 +device.name		Mobile 4 Series Chipset Integrated Graphics Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x2a42
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x02aa
++subdevice.name		Dell Inspiron 1545
 
  vendor.id		pci 0x8086
 &device.id		pci 0x2a42
@@ -139316,6 +144266,10 @@
 +device.name		Xeon E7 v3/Xeon E5 v3/Core i7 System Address Decoder & Broadcast Registers
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3140
++device.name		Easel/Monette Hill Image Processor [Pixel Visual Core]
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x3165
 +device.name		Wireless 3165
 
@@ -139343,11 +144297,11 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3184
-+device.name		UHD Graphics 605
++device.name		GeminiLake [UHD Graphics 605]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3185
-+device.name		UHD Graphics 605
++device.name		GeminiLake [UHD Graphics 600]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x318c
@@ -139358,6 +144312,10 @@
 +device.name		Celeron/Pentium Silver Processor NorthPeak
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3190
++device.name		Celeron/Pentium Silver Processor Gaussian Mixture Model
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x3192
 +device.name		Gemini Lake P2SB
 
@@ -139366,12 +144324,32 @@
 +device.name		Celeron/Pentium Silver Processor PCI-default ISA-bridge
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3198
++device.name		Celeron/Pentium Silver Processor High Definition Audio
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3198
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x380b
++subdevice.name		V130-15IGM Laptop (Lenovo) - Type 81HL
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x319a
 +device.name		Celeron/Pentium Silver Processor Trusted Execution Engine Interface
 
  vendor.id		pci 0x8086
 &device.id		pci 0x31a2
 +device.name		Celeron/Pentium Silver Processor Integrated Sensor Solution
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31a8
++device.name		Celeron/Pentium Silver Processor USB 3.0 xHCI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31a8
+&subvendor.id		pci 0x1849
+&subdevice.id		pci 0x31a8
++subdevice.name		Celeron/Pentium Silver Processor USB 3.0 xHCI Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x31ac
@@ -139436,6 +144414,30 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x31db
 +device.name		Gemini Lake PCI Express Root Port
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31dc
++device.name		Gemini Lake PCH CNVi WiFi
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31dc
+&subvendor.id		pci 0x1a56
+&subdevice.id		pci 0x1552
++subdevice.name		Killer(R) Wireless-AC 1550i Wireless Network Adapter (9560NGW)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31dc
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0034
++subdevice.name		Wireless-AC 9560
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31e3
++device.name		Celeron/Pentium Silver Processor SATA Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x31e8
++device.name		Celeron/Pentium Silver Processor LPC Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x31ee
@@ -139824,6 +144826,10 @@
 +device.name		Ice Lake-LP PCI Express Root Port #9
 
  vendor.id		pci 0x8086
+&device.id		pci 0x34b7
++device.name		Ice Lake-LP PCI Express Root Port #16
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x34bc
 +device.name		Ice Lake-LP PCI Express Root Port #5
 
@@ -139837,7 +144843,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x34c8
-+device.name		Smart Sound Technology Audio Controller
++device.name		Ice Lake-LP Smart Sound Technology Audio Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x34d3
@@ -139845,7 +144851,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x34e0
-+device.name		Management Engine Interface
++device.name		Ice Lake-LP Management Engine
 
  vendor.id		pci 0x8086
 &device.id		pci 0x34e8
@@ -139868,12 +144874,38 @@
 +device.name		Ice Lake-LP USB 3.1 xHCI Host Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x34ef
++device.name		Ice Lake-LP DRAM Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x34f0
-+device.name		Killer Wi-Fi 6 AX1650i 160MHz Wireless Network Adapter (201NGW)
++device.name		Ice Lake-LP PCH CNVi WiFi
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x34f0
+&subvendor.id		pci 0x1a56
+&subdevice.id		pci 0x1552
++subdevice.name		Killer(R) Wireless-AC 1550i Wireless Network Adapter (9560NGW)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x34f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0074
++subdevice.name		Wi-Fi 6 AX201
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x34f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0264
++subdevice.name		Wireless-AC 9461
 
  vendor.id		pci 0x8086
 &device.id		pci 0x34f8
 +device.name		Ice Lake-LP SD Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x34fc
++device.name		Ice Lake-LP Integrated Sensor Solution
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3500
@@ -140832,6 +145864,18 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x37c8
 +device.name		C62x Chipset QuickAssist Technology
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x37c8
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0001
++subdevice.name		QuickAssist Adapter 8960
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x37c8
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0002
++subdevice.name		QuickAssist Adapter 8970
 
  vendor.id		pci 0x8086
 &device.id		pci 0x37cc
@@ -142879,7 +147923,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e30
-+device.name		8th Gen Core 8-core Desktop Processor Host Bridge/DRAM Registers [Coffee Lake S]
++device.name		8th/9th Gen Core 8-core Desktop Processor Host Bridge/DRAM Registers [Coffee Lake S]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e33
@@ -142888,6 +147932,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x3e34
 +device.name		Coffee Lake HOST and DRAM Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x3e35
++device.name		Coffee Lake Host Bridge/DRAM Registers
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e81
@@ -142902,12 +147950,16 @@
 +device.name		8th Gen Core Processor PCIe Controller (x4)
 
  vendor.id		pci 0x8086
+&device.id		pci 0x3e90
++device.name		CoffeeLake-S GT1 [UHD Graphics 610]
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x3e91
-+device.name		8th Gen Core Processor Gaussian Mixture Model
++device.name		CoffeeLake-S GT2 [UHD Graphics 630]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e92
-+device.name		UHD Graphics 630 (Desktop)
++device.name		CometLake-S GT2 [UHD Graphics 630]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e92
@@ -142917,23 +147969,23 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e93
-+device.name		UHD Graphics 610
++device.name		CoffeeLake-S GT1 [UHD Graphics 610]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e96
-+device.name		HD Graphics P630
++device.name		CoffeeLake-S GT2 [UHD Graphics P630]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e98
-+device.name		UHD Graphics 630 (Desktop 9 Series)
++device.name		CoffeeLake-S GT2 [UHD Graphics 630]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3e9b
-+device.name		UHD Graphics 630 (Mobile)
++device.name		CoffeeLake-H GT2 [UHD Graphics 630]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3ea0
-+device.name		UHD Graphics 620 (Whiskey Lake)
++device.name		WhiskeyLake-U GT2 [UHD Graphics 620]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3ea0
@@ -142943,7 +147995,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3ea5
-+device.name		Iris Plus Graphics 655
++device.name		CoffeeLake-U GT3e [Iris Plus Graphics 655]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x3ec2
@@ -143058,6 +148110,10 @@
 +device.name		5400 Chipset FBD Registers
 
  vendor.id		pci 0x8086
+&device.id		pci 0x4041
++device.name		NVMe Datacenter SSD [Optane]
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x4100
 +device.name		Moorestown Graphics and Video
 
@@ -143108,6 +148164,46 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x4117
 +device.name		Atom Processor E6xx PCI Host Bridge #4
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4140
++device.name		NVMe Datacenter SSD [Optane]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4140
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2134
++subdevice.name		NVMe Datacenter SSD [Optane] SED 400GB 2.5" U.2 (P5800X)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4140
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2135
++subdevice.name		NVMe Datacenter SSD [Optane] SED 800GB 2.5" U.2 (P5800X)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4140
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2136
++subdevice.name		NVMe Datacenter SSD [Optane] SED 1.6TB 2.5" U.2 (P5800X)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4140
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2137
++subdevice.name		NVMe Datacenter SSD [Optane] 400GB 2.5" U.2 (P5800X)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4140
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2138
++subdevice.name		NVMe Datacenter SSD [Optane] 800GB 2.5" U.2 (P5800X)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4140
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x2139
++subdevice.name		NVMe Datacenter SSD [Optane] 1.6TB 2.5" U.2 (P5800X)
 
  vendor.id		pci 0x8086
 &device.id		pci 0x4220
@@ -143606,6 +148702,74 @@
 +subdevice.name		WiMAX/WiFi Link 5150 ABG
 
  vendor.id		pci 0x8086
+&device.id		pci 0x438b
++device.name		Tiger Lake-H LPC/eSPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43a3
++device.name		Tiger Lake-H SMBus Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43a4
++device.name		Tiger Lake-H SPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43b0
++device.name		Tiger Lake-H PCI Express Root Port #9
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43bc
++device.name		Tiger Lake-H PCI Express Root Port #5
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43c8
++device.name		Tiger Lake-H HD Audio Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43e0
++device.name		Tiger Lake-H Management Engine Interface
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43e8
++device.name		Tiger Lake-H Serial IO I2C Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43ed
++device.name		Tiger Lake-H USB 3.2 Gen 2x1 xHCI Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43ef
++device.name		Tiger Lake-H Shared SRAM
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43f0
++device.name		Tiger Lake PCH CNVi WiFi
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0034
++subdevice.name		Wireless-AC 9560
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0074
++subdevice.name		Wi-Fi 6 AX201 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0264
++subdevice.name		Wireless-AC 9461
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x43f0
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x02a4
++subdevice.name		Wireless-AC 9462
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x444e
 +device.name		Turbo Memory Controller
 
@@ -143614,8 +148778,108 @@
 +device.name		Volume Management Device NVMe RAID Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x4680
++device.name		AlderLake-S GT1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x46a0
++device.name		AlderLake-P GT2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x46c0
++device.name		AlderLake-M GT1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4905
++device.name		DG1 [Iris Xe MAX Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4906
++device.name		DG1 [Iris Xe Pod]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4907
++device.name		SG1 [Server GPU SG-18M]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4908
++device.name		DG1 [Iris Xe Graphics]
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x4c3d
 +device.name		Volume Management Device NVMe RAID Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4c8a
++device.name		RocketLake-S GT1 [UHD Graphics 750]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4c8b
++device.name		RocketLake-S GT1 [UHD Graphics 730]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4c90
++device.name		RocketLake-S GT1 [UHD Graphics P750]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4c9a
++device.name		RocketLake-S [UHD Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4da3
++device.name		JaserLake SMBus
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4da4
++device.name		JaserLake SPI (flash) Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4de0
++device.name		Management Engine Interface
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4de8
++device.name		Serial IO I2C Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4de9
++device.name		Serial IO I2C Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4df0
++device.name		Wi-Fi 6 AX201 160MHz
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4e03
++device.name		Dynamic Tuning service
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4e19
++device.name		JasperLake IPU
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4e55
++device.name		JasperLake [UHD Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4e61
++device.name		JasperLake [UHD Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4e71
++device.name		JasperLake [UHD Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4f80
++device.name		DG2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4f81
++device.name		DG2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x4f82
++device.name		DG2
 
  vendor.id		pci 0x8086
 &device.id		pci 0x5001
@@ -143824,6 +149088,14 @@
 +device.name		80310 (IOP) IO Processor
 
  vendor.id		pci 0x8086
+&device.id		pci 0x5502
++device.name		Ethernet Controller (2) I225-LMvP
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x5504
++device.name		Ethernet Controller I226-K
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x5845
 +device.name		QEMU NVM Express Controller
 
@@ -143890,6 +149162,12 @@
 +subdevice.name		B250 KRAIT GAMING (MS-7A68)
 
  vendor.id		pci 0x8086
+&device.id		pci 0x590f
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x5910
 +device.name		Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 
@@ -143900,6 +149178,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x5912
 +device.name		HD Graphics 630
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x5912
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
 
  vendor.id		pci 0x8086
 &device.id		pci 0x5914
@@ -145560,6 +150844,10 @@
 +subdevice.name		mGuard-PCI AV#0
 
  vendor.id		pci 0x8086
+&device.id		pci 0x8603
++device.name		Ice Lake-LP Dynamic Tuning Processor Participant
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x87c0
 +device.name		UHD Graphics 617
 
@@ -145672,12 +150960,20 @@
 +device.name		Ice Lake Thunderbolt 3 NHI #1
 
  vendor.id		pci 0x8086
+&device.id		pci 0x8a12
++device.name		Ice Lake-LP Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x8a13
 +device.name		Ice Lake Thunderbolt 3 USB Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8a17
 +device.name		Ice Lake Thunderbolt 3 NHI #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8a19
++device.name		Image Signal Processor
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8a1d
@@ -145697,7 +150993,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8a51
-+device.name		Intel Iris Plus Graphics G7 (Ice Lake)
++device.name		Iris Plus Graphics G7 (Ice Lake)
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8a52
@@ -145713,7 +151009,7 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8a5c
-+device.name		Intel Iris Plus Graphics G4 (Ice Lake)
++device.name		Iris Plus Graphics G4 (Ice Lake)
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c00
@@ -145726,6 +151022,24 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x8c02
 +device.name		8 Series/C220 Series Chipset Family 6-port SATA Controller 1 [AHCI mode]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c02
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c02
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c02
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c02
@@ -145787,9 +151101,27 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c10
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c10
+&subvendor.id		pci 0x1043
+&subdevice.id		pci 0x8534
++subdevice.name		ASUS H81I-PLUS
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c10
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x220e
 +subdevice.name		ThinkPad T440p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c10
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c11
@@ -145798,6 +151130,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x8c12
 +device.name		8 Series/C220 Series Chipset Family PCI Express Root Port #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c12
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c12
@@ -145838,6 +151176,12 @@
 +device.name		8 Series/C220 Series Chipset Family PCI Express Root Port #6
 
  vendor.id		pci 0x8086
+&device.id		pci 0x8c1a
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x8c1b
 +device.name		8 Series/C220 Series Chipset Family PCI Express Root Port #6
 
@@ -145863,9 +151207,21 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c20
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c20
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1909
 +subdevice.name		ZBook 15
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c20
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c20
@@ -145889,15 +151245,33 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c22
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c22
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1909
 +subdevice.name		ZBook 15
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c22
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c22
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x220e
 +subdevice.name		ThinkPad T440p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c22
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c22
@@ -145919,9 +151293,21 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c26
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c26
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1909
 +subdevice.name		ZBook 15
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c26
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c26
@@ -145934,6 +151320,12 @@
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x2210
 +subdevice.name		ThinkPad T540p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c26
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c26
@@ -145953,15 +151345,33 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c2d
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c2d
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1909
 +subdevice.name		ZBook 15
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c2d
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c2d
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x220e
 +subdevice.name		ThinkPad T440p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c2d
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c2d
@@ -145975,15 +151385,33 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c31
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c31
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1909
 +subdevice.name		ZBook 15
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c31
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c31
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x220e
 +subdevice.name		ThinkPad T440p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c31
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c31
@@ -146005,15 +151433,33 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c3a
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c3a
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x1909
 +subdevice.name		ZBook 15
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c3a
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c3a
 &subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x220e
 +subdevice.name		ThinkPad T440p
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c3a
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c3a
@@ -146032,6 +151478,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x8c3d
 +device.name		8 Series/C220 Series Chipset Family KT Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c3d
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c40
@@ -146078,6 +151530,12 @@
 +device.name		H87 Express LPC Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x8c4a
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x05d7
++subdevice.name		Alienware X51 R2
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x8c4b
 +device.name		HM87 Express LPC Controller
 
@@ -146098,6 +151556,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x8c4e
 +device.name		Q87 Express LPC Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c4e
+&subvendor.id		pci 0x103c
+&subdevice.id		pci 0x1998
++subdevice.name		EliteDesk 800 G1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c4f
@@ -146166,6 +151630,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x8c5c
 +device.name		H81 Express LPC Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x8c5c
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x3098
++subdevice.name		ThinkCentre E73
 
  vendor.id		pci 0x8086
 &device.id		pci 0x8c5d
@@ -146658,6 +152128,14 @@
 +device.name		Integrated RAID
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9a01
++device.name		11th Gen Core Processor PCIe Controller #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a03
++device.name		TigerLake-LP Dynamic Tuning Processor Participant
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9a09
 +device.name		11th Gen Core Processor PCIe Controller
 
@@ -146666,51 +152144,129 @@
 +device.name		Volume Management Device NVMe RAID Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9a0d
++device.name		Tigerlake Telemetry Aggregator Driver
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a0f
++device.name		11th Gen Core Processor PCIe Controller #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a11
++device.name		GNA Scoring Accelerator module
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9a13
-+device.name		Tiger Lake-LP Thunderbolt USB Controller
++device.name		Tiger Lake-LP Thunderbolt 4 USB Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9a14
 +device.name		11th Gen Core Processor Host Bridge/DRAM Registers
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9a17
++device.name		Tiger Lake-H Thunderbolt 4 USB Controller
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9a1b
-+device.name		Tiger Lake-LP Thunderbolt NHI #0
++device.name		Tiger Lake-LP Thunderbolt 4 NHI #0
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9a1d
-+device.name		Tiger Lake-LP Thunderbolt NHI #1
++device.name		Tiger Lake-LP Thunderbolt 4 NHI #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a1f
++device.name		Tiger Lake-H Thunderbolt 4 NHI #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a21
++device.name		Tiger Lake-H Thunderbolt 4 NHI #1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9a23
-+device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #0
++device.name		Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #0
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9a25
-+device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #1
++device.name		Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a26
++device.name		11th Gen Core Processor Host Bridge/DRAM Registers
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9a27
-+device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #2
++device.name		Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #2
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9a29
-+device.name		Tiger Lake-LP Thunderbolt PCI Express Root Port #3
++device.name		Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a2b
++device.name		Tiger Lake-H Thunderbolt 4 PCI Express Root Port #0
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a2d
++device.name		Tiger Lake-H Thunderbolt 4 PCI Express Root Port #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a2f
++device.name		Tiger Lake-H Thunderbolt 4 PCI Express Root Port #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a31
++device.name		Tiger Lake-H Thunderbolt 4 PCI Express Root Port #3
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9a33
 +device.name		Tiger Lake Trace Hub
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9a36
++device.name		11th Gen Core Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9a49
-+device.name		UHD Graphics
++device.name		TigerLake-LP GT2 [Iris Xe Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a60
++device.name		TigerLake-H GT1 [UHD Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9a68
++device.name		TigerLake-H GT1 [UHD Graphics]
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9b41
-+device.name		UHD Graphics
++device.name		CometLake-U GT2 [UHD Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b41
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x09bd
++subdevice.name		Latitude 7310
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b44
++device.name		10th Gen Core Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b53
++device.name		Comet Lake-S 6c Host Bridge/DRAM Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9b54
++device.name		10th Gen Core Processor Host Bridge/DRAM Registers
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b61
++device.name		Comet Lake-U v1 4c Host Bridge/DRAM Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9b63
 +device.name		10th Gen Core Processor Host Bridge/DRAM Registers
 
  vendor.id		pci 0x8086
@@ -146719,7 +152275,19 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9bc4
-+device.name		UHD Graphics
++device.name		CometLake-H GT2 [UHD Graphics]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9bc5
++device.name		CometLake-S GT2 [UHD Graphics 630]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9bc8
++device.name		CometLake-S GT2 [UHD Graphics 630]
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9bca
++device.name		Comet Lake UHD Graphics
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9c00
@@ -147178,6 +152746,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d03
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d03
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06f3
 +subdevice.name		Latitude 3570
 
@@ -147250,6 +152824,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d18
 &subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d18
+&subvendor.id		pci 0x17aa
 &subdevice.id		pci 0x382a
 +subdevice.name		B51-80 Laptop
 
@@ -147286,6 +152866,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d21
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d21
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06f3
 +subdevice.name		Latitude 3570
 
@@ -147294,6 +152880,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x8079
 +subdevice.name		EliteBook 840 G3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d21
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d21
@@ -147334,6 +152926,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06dc
 +subdevice.name		Latitude E7470
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d23
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d23
@@ -147416,6 +153014,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d2f
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d2f
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06f3
 +subdevice.name		Latitude 3570
 
@@ -147468,6 +153072,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d31
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d31
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06f3
 +subdevice.name		Latitude 3570
 
@@ -147512,6 +153122,12 @@
 +subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9d32
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9d35
 +device.name		Sunrise Point-LP Integrated Sensor Hub
 
@@ -147520,6 +153136,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06d6
 +subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d35
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d3a
@@ -147542,6 +153164,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06dc
 +subdevice.name		Latitude E7470
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d3a
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d3a
@@ -147590,6 +153218,12 @@
 +subdevice.name		EliteBook 840 G3
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9d3d
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9d43
 +device.name		Sunrise Point-LP LPC Controller
 
@@ -147608,6 +153242,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06d6
 +subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d46
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d48
@@ -147630,6 +153270,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x8079
 +subdevice.name		EliteBook 840 G3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d48
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d4e
@@ -147690,6 +153336,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d60
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d60
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06f3
 +subdevice.name		Latitude 3570
 
@@ -147722,6 +153374,12 @@
 +subdevice.name		Latitude 7275 tablet
 
  vendor.id		pci 0x8086
+&device.id		pci 0x9d61
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
 &device.id		pci 0x9d62
 +device.name		Sunrise Point-LP Serial IO I2C Controller #2
 
@@ -147730,6 +153388,12 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06d6
 +subdevice.name		Latitude 7275 tablet
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d62
+&subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d63
@@ -147766,6 +153430,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9d70
 &subvendor.id		pci 0x1028
+&subdevice.id		pci 0x06e6
++subdevice.name		Latitude 11 5175 2-in-1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d70
+&subvendor.id		pci 0x1028
 &subdevice.id		pci 0x06f3
 +subdevice.name		Latitude 3570
 
@@ -147774,6 +153444,12 @@
 &subvendor.id		pci 0x103c
 &subdevice.id		pci 0x8079
 +subdevice.name		EliteBook 840 G3
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9d70
+&subvendor.id		pci 0x17aa
+&subdevice.id		pci 0x2247
++subdevice.name		ThinkPad T570
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9d70
@@ -147820,6 +153496,14 @@
  vendor.id		pci 0x8086
 &device.id		pci 0x9da4
 +device.name		Cannon Point-LP SPI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9da8
++device.name		Cannon Point-LP Serial IO UART Controller #2
+
+ vendor.id		pci 0x8086
+&device.id		pci 0x9daa
++device.name		Cannon Point-LP Serial IO SPI Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0x9db0
@@ -148068,6 +153752,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0xa0b0
 +device.name		Tiger Lake-LP PCI Express Root Port #9
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa0bd
++device.name		Tigerlake PCH-LP PCI Express Root Port #6
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa0bf
@@ -148874,6 +154562,12 @@
 +device.name		200 Series PCH SATA controller [AHCI mode]
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa282
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa286
 +device.name		200 Series PCH SATA controller [RAID mode]
 
@@ -148898,6 +154592,12 @@
 +device.name		200 Series PCH PCI Express Root Port #5
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa294
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa295
 +device.name		200 Series PCH PCI Express Root Port #6
 
@@ -148906,12 +154606,24 @@
 +device.name		200 Series PCH PCI Express Root Port #7
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa296
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa297
 +device.name		200 Series PCH PCI Express Root Port #8
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa298
 +device.name		200 Series PCH PCI Express Root Port #9
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa298
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa299
@@ -148950,8 +154662,20 @@
 +device.name		200 Series/Z370 Chipset Family Power Management Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa2a1
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa2a3
 +device.name		200 Series/Z370 Chipset Family SMBus Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa2a3
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa2a4
@@ -148986,12 +154710,30 @@
 +device.name		200 Series/Z370 Chipset Family USB 3.0 xHCI Controller
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa2af
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa2b1
 +device.name		200 Series PCH Thermal Subsystem
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa2b1
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa2ba
 +device.name		200 Series PCH CSME HECI #1
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa2ba
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa2bb
@@ -149000,6 +154742,12 @@
  vendor.id		pci 0x8086
 &device.id		pci 0xa2c4
 +device.name		200 Series PCH LPC Controller (H270)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa2c4
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa2c5
@@ -149086,6 +154834,18 @@
 +device.name		200 Series PCH HD Audio
 
  vendor.id		pci 0x8086
+&device.id		pci 0xa2f0
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0x7a72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa2f0
+&subvendor.id		pci 0x1462
+&subdevice.id		pci 0xfa72
++subdevice.name		H270 PC MATE
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xa304
 +device.name		H370 Chipset LPC/eSPI Controller
 
@@ -149142,6 +154902,10 @@
  vendor.id		pci 0x8086
 &device.id		pci 0xa328
 +device.name		Cannon Lake PCH Serial IO UART Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa32b
++device.name		Cannon Lake PCH SPI Host Controller
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa32c
@@ -149313,7 +155077,19 @@
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa370
-+device.name		Wireless-AC 9560 [Jefferson Peak]
++device.name		Cannon Lake PCH CNVi WiFi
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa370
+&subvendor.id		pci 0x1a56
+&subdevice.id		pci 0x1552
++subdevice.name		Killer(R) Wireless-AC 1550i Wireless Network Adapter (9560NGW)
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa370
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x0034
++subdevice.name		Wireless-AC 9560
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa379
@@ -149324,6 +155100,26 @@
 &subvendor.id		pci 0x1028
 &subdevice.id		pci 0x0869
 +subdevice.name		Vostro 3470
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa382
++device.name		400 Series Chipset Family SATA AHCI Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa3a1
++device.name		Memory controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa3a3
++device.name		Comet Lake PCH-V SMBus Host Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa3af
++device.name		Comet Lake PCH-V USB Controller
+
+ vendor.id		pci 0x8086
+&device.id		pci 0xa3b1
++device.name		Comet Lake PCH-V Thermal Subsystem
 
  vendor.id		pci 0x8086
 &device.id		pci 0xa620
@@ -149506,6 +155302,12 @@
 +device.name		SSD 600P Series
 
  vendor.id		pci 0x8086
+&device.id		pci 0xf1a5
+&subvendor.id		pci 0x8086
+&subdevice.id		pci 0x390a
++subdevice.name		SSDPEKKW256G7 256GB
+
+ vendor.id		pci 0x8086
 &device.id		pci 0xf1a6
 +device.name		SSD Pro 7600p/760p/E 6100p Series
 
@@ -149513,7 +155315,7 @@
 &device.id		pci 0xf1a6
 &subvendor.id		pci 0x8086
 &subdevice.id		pci 0x390b
-+subdevice.name		Intel Corporation SSD Pro 7600p/760p/E 6100p Series [NVM Express]
++subdevice.name		SSD Pro 7600p/760p/E 6100p Series [NVM Express]
 
  vendor.id		pci 0x8086
 &device.id		pci 0xf1a8
@@ -149531,6 +155333,24 @@
 &subvendor.id		pci 0x8088
 &subdevice.id		pci 0x0201
 +subdevice.name		Dual-Port Ethernet Network Adaptor SF200T
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0101
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x4201
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200T (WOL)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0101
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x8201
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200T (NCSI)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0101
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0xc201
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200T (WOL, NCSI)
 
  vendor.id		pci 0x8088
 &device.id		pci 0x0102
@@ -149559,6 +155379,24 @@
 +subdevice.name		Qual-Port Ethernet Network Adaptor SF400-OCP
 
  vendor.id		pci 0x8088
+&device.id		pci 0x0103
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x4103
++subdevice.name		Quad-Port Ethernet Network Adaptor SF400T (WOL)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0103
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x8103
++subdevice.name		Quad-Port Ethernet Network Adaptor SF400T (NCSI)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0103
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0xc103
++subdevice.name		Quad-Port Ethernet Network Adaptor SF400T (WOL, NCSI)
+
+ vendor.id		pci 0x8088
 &device.id		pci 0x0104
 +device.name		WX1860A4S Gigabit Ethernet Controller
 
@@ -149577,6 +155415,24 @@
 &subvendor.id		pci 0x8088
 &subdevice.id		pci 0x0202
 +subdevice.name		Dual-Port Ethernet Network Adaptor SF200HT
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0105
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x4202
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200HT (WOL)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0105
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x8202
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200HT (NCSI)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0105
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0xc202
++subdevice.name		Dual-Port Ethernet Network Adaptor SF200HT (WOL, NCSI)
 
  vendor.id		pci 0x8088
 &device.id		pci 0x0106
@@ -149599,6 +155455,24 @@
 +subdevice.name		Qual-Port Ethernet Network Adaptor SF400HT
 
  vendor.id		pci 0x8088
+&device.id		pci 0x0107
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x4402
++subdevice.name		Quad-Port Ethernet Network Adaptor SF400HT (WOL)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0107
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x8402
++subdevice.name		Quad-Port Ethernet Network Adaptor SF400HT (NCSI)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0107
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0xc402
++subdevice.name		Quad-Port Ethernet Network Adaptor SF400HT (WOL, NCSI)
+
+ vendor.id		pci 0x8088
 &device.id		pci 0x0108
 +device.name		WX1860AL4S Gigabit Ethernet Controller
 
@@ -149609,6 +155483,74 @@
 +subdevice.name		Qual-Port Ethernet Network Adaptor SF400HT-S
 
  vendor.id		pci 0x8088
+&device.id		pci 0x0109
++device.name		WX1860-LC Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x010a
++device.name		WX1860A1 Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x010b
++device.name		WX1860AL1 Gigabit Ethernet Controller
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x010b
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x0102
++subdevice.name		Single-Port Ethernet Network Adaptor SF100HT
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x010b
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x4102
++subdevice.name		Single-Port Ethernet Network Adaptor SF100HT (WOL)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x010b
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0x8102
++subdevice.name		Single-Port Ethernet Network Adaptor SF100HT (NCSI)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x010b
+&subvendor.id		pci 0x8088
+&subdevice.id		pci 0xc102
++subdevice.name		Single-Port Ethernet Network Adaptor SF100HT (WOL, NCSI)
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0111
++device.name		WX1860A2 Ethernet Controller Virtual Function
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0113
++device.name		WX1860A4 Ethernet Controller Virtual Function
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0115
++device.name		WX1860AL2 Ethernet Controller Virtual Function
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0117
++device.name		WX1860AL4 Ethernet Controller Virtual Function
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x0119
++device.name		WX1860-LC Gigabit Ethernet Controller Virtual Function
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x011a
++device.name		WX1860A1 Gigabit Ethernet Controller Virtual Function
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x011b
++device.name		WX1860AL1 Gigabit Ethernet Controller Virtual Function
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x1000
++device.name		Ethernet Controller RP1000 Virtual Function for 10GbE SFP+
+
+ vendor.id		pci 0x8088
 &device.id		pci 0x1001
 +device.name		Ethernet Controller RP1000 for 10GbE SFP+
 
@@ -149617,6 +155559,10 @@
 &subvendor.id		pci 0x8088
 &subdevice.id		pci 0x0000
 +subdevice.name		Ethernet Network Adaptor RP1000 for 10GbE SFP+
+
+ vendor.id		pci 0x8088
+&device.id		pci 0x2000
++device.name		Ethernet Controller RP2000 Virtual Function for 10GbE SFP+
 
  vendor.id		pci 0x8088
 &device.id		pci 0x2001
@@ -149665,6 +155611,13 @@
  vendor.id		pci 0x8800
 &device.id		pci 0x2008
 +device.name		Video assistant component
+
+ vendor.id		pci 0x8820
++vendor.name		Stryker Corporation
+
+ vendor.id		pci 0x8820
+&device.id		pci 0x2724
++device.name		Mako Front Side Motor Controller [cPCI]
 
  vendor.id		pci 0x8866
 +vendor.name		T-Square Design Inc.
@@ -151292,7 +157245,7 @@
 
  vendor.id		pci 0x9005
 &device.id		pci 0x028f
-+device.name		Smart Storage PQI 12G SAS/PCIe 3
++device.name		Smart Storage PQI SAS
 
  vendor.id		pci 0x9005
 &device.id		pci 0x028f
@@ -151419,6 +157372,30 @@
 &subvendor.id		pci 0x152d
 &subdevice.id		pci 0x8a37
 +subdevice.name		QS-8242-24i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1104
++subdevice.name		RAID P2404-Mf-4i-2GB
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1105
++subdevice.name		RAID P4408-Mf-8i-2GB
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1106
++subdevice.name		RAID P2404-Mf-4i-1GB
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x193d
+&subdevice.id		pci 0x1107
++subdevice.name		RAID P4408-Mf-8i-4GB
 
  vendor.id		pci 0x9005
 &device.id		pci 0x028f
@@ -151597,6 +157574,18 @@
  vendor.id		pci 0x9005
 &device.id		pci 0x028f
 &subvendor.id		pci 0x9005
+&subdevice.id		pci 0x0808
++subdevice.name		SmartRAID 3101E-4i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x9005
+&subdevice.id		pci 0x0809
++subdevice.name		SmartRAID 3102E-8i
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x9005
 &subdevice.id		pci 0x0900
 +subdevice.name		SmartHBA 2100-8i
 
@@ -151683,6 +157672,12 @@
 &subvendor.id		pci 0x9005
 &subdevice.id		pci 0x1281
 +subdevice.name		HBA 1100-16e
+
+ vendor.id		pci 0x9005
+&device.id		pci 0x028f
+&subvendor.id		pci 0x9005
+&subdevice.id		pci 0x1282
++subdevice.name		SmartHBA 2100-16i
 
  vendor.id		pci 0x9005
 &device.id		pci 0x028f
@@ -152189,6 +158184,39 @@
 &device.id		pci 0x0003
 +device.name		SG1010 Starfabric Switch and PCI Bridge
 
+ vendor.id		pci 0x9a11
++vendor.name		Tiger Lake-H Gaussian & Neural Accelerator
+
+ vendor.id		pci 0x9d32
++vendor.name		Beijing Starblaze Technology Co. Ltd.
+
+ vendor.id		pci 0x9d32
+&device.id		pci 0x0000
++device.name		STAR1000 PCIe NVMe SSD Controller
+
+ vendor.id		pci 0x9d32
+&device.id		pci 0x1001
++device.name		STAR1000P PCIe NVMe SSD Controller
+
+ vendor.id		pci 0x9d32
+&device.id		pci 0x1201
++device.name		STAR1200C NVMe SSD
+
+ vendor.id		pci 0x9d32
+&device.id		pci 0x1202
++device.name		STAR1200I NVMe SSD
+
+ vendor.id		pci 0x9d32
+&device.id		pci 0x1203
++device.name		STAR1200L NVMe SSD
+
+ vendor.id		pci 0x9d32
+&device.id		pci 0x1204
++device.name		STAR1200E NVMe SSD
+
+ vendor.id		pci 0xa000
++vendor.name		Asix Electronics Corporation (Wrong ID)
+
  vendor.id		pci 0xa0a0
 +vendor.name		AOPEN Inc.
 
@@ -152492,6 +158520,10 @@
  vendor.id		pci 0xc0a9
 &device.id		pci 0x2263
 +device.name		P1 NVMe PCIe SSD
+
+ vendor.id		pci 0xc0a9
+&device.id		pci 0x540a
++device.name		P2 NVMe PCIe SSD
 
  vendor.id		pci 0xc0de
 +vendor.name		Motorola
@@ -152970,7 +159002,7 @@
 +device.name		W89C940
 
  vendor.id		pci 0xe159
-+vendor.name		Tiger Jet Network Inc.
++vendor.name		Tiger Jet Network Inc. / ICP DAS
 
  vendor.id		pci 0xe159
 &device.id		pci 0x0001
@@ -153098,6 +159130,9 @@
  vendor.id		pci 0xea01
 &device.id		pci 0x0800
 +device.name		PCI-800 Digital I/O Card
+
+ vendor.id		pci 0xea50
++vendor.name		Emerson Automation Solutions
 
  vendor.id		pci 0xea60
 +vendor.name		RME
@@ -153536,6 +159571,10 @@
 +device.name		Corvid 44 12g
 
  vendor.id		pci 0xf1d0
+&device.id		pci 0xeb26
++device.name		T-Tap Pro
+
+ vendor.id		pci 0xf1d0
 &device.id		pci 0xefac
 +device.name		Xena SD-MM/SD-22-MM
 
@@ -153607,6 +159646,10 @@
  baseclass.id		0x000
 &subclass.id		0x01
 +subclass.name		VGA compatible unclassified device
+
+ baseclass.id		0x000
+&subclass.id		0x05
++subclass.name		Image coprocessor
 
  baseclass.id		0x001
 +baseclass.name		Mass storage controller
@@ -154142,6 +160185,15 @@
  baseclass.id		0x008
 &subclass.id		0x80
 +subclass.name		System peripheral
+
+ baseclass.id		0x008
+&subclass.id		0x99
++subclass.name		Timing Card
+
+ baseclass.id		0x008
+&subclass.id		0x99
+&progif.id		0x01
++progif.name		TAP Timing Card
 
  baseclass.id		0x009
 +baseclass.name		Input device controller

--- a/src/ids/src/usb
+++ b/src/ids/src/usb
@@ -8,6 +8,10 @@
  vendor.id		usb 0x0002
 +vendor.name		Ingram
 
+ vendor.id		usb 0x0002
+&device.id		usb 0x0002
++device.name		passport00
+
  vendor.id		usb 0x0003
 +vendor.name		Club Mac
 
@@ -63,11 +67,11 @@
 +device.name		Mayflash GameCube Controller
 
  vendor.id		usb 0x0080
-+vendor.name		Assmann Electronic GmbH
++vendor.name		Unknown
 
  vendor.id		usb 0x0080
 &device.id		usb 0xa001
-+device.name		Digitus DA-71114 SATA
++device.name		JMS578 based SATA bridge
 
  vendor.id		usb 0x0085
 +vendor.name		Boeye Technology Co., Ltd.
@@ -1757,6 +1761,10 @@
 +device.name		Atheros AR9285 Malbec Bluetooth Adapter
 
  vendor.id		usb 0x03f0
+&device.id		usb 0x312a
++device.name		LaserJet Pro M701n
+
+ vendor.id		usb 0x03f0
 &device.id		usb 0x3202
 +device.name		PhotoSmart 1215
 
@@ -1819,6 +1827,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0x3517
 +device.name		LaserJet 3390
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x354a
++device.name		Slim Keyboard
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x3602
@@ -1951,6 +1963,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0x3f11
 +device.name		PSC-1315/PSC-1317
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x3f17
++device.name		Laserjet P1505
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x4002
@@ -2241,6 +2257,10 @@
 +device.name		Color LaserJet 4730mfp
 
  vendor.id		usb 0x03f0
+&device.id		usb 0x632a
++device.name		LaserJet M203-M206
+
+ vendor.id		usb 0x03f0
 &device.id		usb 0x6402
 +device.name		PhotoSmart 715 (ptp)
 
@@ -2435,6 +2455,10 @@
  vendor.id		usb 0x03f0
 &device.id		usb 0x7a04
 +device.name		DeskJet D2460
+
+ vendor.id		usb 0x03f0
+&device.id		usb 0x7a11
++device.name		Photosmart B109
 
  vendor.id		usb 0x03f0
 &device.id		usb 0x7a17
@@ -2975,6 +2999,10 @@
 +device.name		M5667 MP3 player
 
  vendor.id		usb 0x0402
+&device.id		usb 0x8841
++device.name		Newmine Camera
+
+ vendor.id		usb 0x0402
 &device.id		usb 0x9665
 +device.name		Gateway Webcam
 
@@ -3036,6 +3064,10 @@
  vendor.id		usb 0x0403
 &device.id		usb 0x6015
 +device.name		Bridge(I2C/SPI/UART/FIFO)
+
+ vendor.id		usb 0x0403
+&device.id		usb 0x601f
++device.name		Myriad-RF LimeSDR-Mini
 
  vendor.id		usb 0x0403
 &device.id		usb 0x6f70
@@ -3126,12 +3158,20 @@
 +device.name		CallerID
 
  vendor.id		usb 0x0403
+&device.id		usb 0x9134
++device.name		Virtual keyboard
+
+ vendor.id		usb 0x0403
 &device.id		usb 0x9135
 +device.name		Rotary Pub alarm
 
  vendor.id		usb 0x0403
 &device.id		usb 0x9136
 +device.name		Pulsecounter
+
+ vendor.id		usb 0x0403
+&device.id		usb 0x9137
++device.name		Ledbutton interface
 
  vendor.id		usb 0x0403
 &device.id		usb 0x9e90
@@ -3745,6 +3785,10 @@
 +device.name		Optical Touch Screen
 
  vendor.id		usb 0x0408
+&device.id		usb 0x3008
++device.name		Optical Touch Screen
+
+ vendor.id		usb 0x0408
 &device.id		usb 0xa060
 +device.name		HD Webcam
 
@@ -3890,6 +3934,10 @@
  vendor.id		usb 0x0409
 &device.id		usb 0x011d
 +device.name		e228 Mobile Phone
+
+ vendor.id		usb 0x0409
+&device.id		usb 0x0193
++device.name		RVT-R Writer
 
  vendor.id		usb 0x0409
 &device.id		usb 0x0203
@@ -5041,6 +5089,38 @@
 +device.name		Virtual Com Port
 
  vendor.id		usb 0x0416
+&device.id		usb 0x511b
++device.name		Nuvoton Nu-Link1 ICE
+
+ vendor.id		usb 0x0416
+&device.id		usb 0x511c
++device.name		Nuvoton Nu-Link1 ICE
+
+ vendor.id		usb 0x0416
+&device.id		usb 0x511d
++device.name		Nuvoton Nu-Link1 ICE/VCOM
+
+ vendor.id		usb 0x0416
+&device.id		usb 0x511e
++device.name		Nuvoton Nu-Link1 MSC/VCOM
+
+ vendor.id		usb 0x0416
+&device.id		usb 0x5200
++device.name		Nuvoton Nu-Link2-ME ICE/MSC/VCOM
+
+ vendor.id		usb 0x0416
+&device.id		usb 0x5201
++device.name		Nuvoton Nu-Link2-Pro ICE/MSC/VCOM
+
+ vendor.id		usb 0x0416
+&device.id		usb 0x5210
++device.name		Nuvoton Nu-Link2 MSC FW UPGRADE
+
+ vendor.id		usb 0x0416
+&device.id		usb 0x5211
++device.name		Nuvoton Nu-Link2 HID FW UPGRADE
+
+ vendor.id		usb 0x0416
 &device.id		usb 0x5518
 +device.name		4-Port Hub
 
@@ -5279,6 +5359,14 @@
 
  vendor.id		usb 0x041e
 &device.id		usb 0x3237
++device.name		SB X-Fi Surround 5.1 Pro
+
+ vendor.id		usb 0x041e
+&device.id		usb 0x3241
++device.name		Sound Blaster JAM
+
+ vendor.id		usb 0x041e
+&device.id		usb 0x3263
 +device.name		SB X-Fi Surround 5.1 Pro
 
  vendor.id		usb 0x041e
@@ -5871,6 +5959,10 @@
 +device.name		5800 XpressMusic (Imaging mode)
 
  vendor.id		usb 0x0421
+&device.id		usb 0x0189
++device.name		N810 Internet Tablet WiMAX
+
+ vendor.id		usb 0x0421
 &device.id		usb 0x0199
 +device.name		6700 Classic (msc)
 
@@ -5900,7 +5992,7 @@
 
  vendor.id		usb 0x0421
 &device.id		usb 0x01c8
-+device.name		N900 (PC-Suite Mode)
++device.name		N900/N950 (PC-Suite Mode)
 
  vendor.id		usb 0x0421
 &device.id		usb 0x0228
@@ -5980,7 +6072,11 @@
 
  vendor.id		usb 0x0421
 &device.id		usb 0x03d1
-+device.name		N950
++device.name		N950 (Storage Mode)
+
+ vendor.id		usb 0x0421
+&device.id		usb 0x03d2
++device.name		N950 (PC Suite mode)
 
  vendor.id		usb 0x0421
 &device.id		usb 0x0400
@@ -6104,7 +6200,7 @@
 
  vendor.id		usb 0x0421
 &device.id		usb 0x0431
-+device.name		770 Internet Tablet
++device.name		770/N800 Internet Tablet
 
  vendor.id		usb 0x0421
 &device.id		usb 0x0432
@@ -6240,7 +6336,15 @@
 
  vendor.id		usb 0x0421
 &device.id		usb 0x0518
-+device.name		N9 Phone
++device.name		N9 (Storage mode)
+
+ vendor.id		usb 0x0421
+&device.id		usb 0x0519
++device.name		N9 (RNDIS/Ethernet mode)
+
+ vendor.id		usb 0x0421
+&device.id		usb 0x051a
++device.name		N9 (PC Suite mode)
 
  vendor.id		usb 0x0421
 &device.id		usb 0x054d
@@ -6438,6 +6542,10 @@
  vendor.id		usb 0x0424
 &device.id		usb 0x2807
 +device.name		Hub
+
+ vendor.id		usb 0x0424
+&device.id		usb 0x3fc7
++device.name		RME Babyface audio system
 
  vendor.id		usb 0x0424
 &device.id		usb 0x3fcc
@@ -7686,6 +7794,10 @@
 +device.name		Firestorm Dual Analog 3
 
  vendor.id		usb 0x044f
+&device.id		usb 0xb320
++device.name		Dual Trigger gamepad PC/PS2 2.0
+
+ vendor.id		usb 0x044f
 &device.id		usb 0xb323
 +device.name		Dual Trigger 3-in-1 (PC Mode)
 
@@ -7798,6 +7910,10 @@
  vendor.id		usb 0x0451
 &device.id		usb 0x2f90
 +device.name		SM-USB-DIG
+
+ vendor.id		usb 0x0451
+&device.id		usb 0x3200
++device.name		TUSB3200 Boot Loader
 
  vendor.id		usb 0x0451
 &device.id		usb 0x3410
@@ -8135,6 +8251,10 @@
  vendor.id		usb 0x0458
 &device.id		usb 0x0087
 +device.name		Ergo 525V Laser Mouse
+
+ vendor.id		usb 0x0458
+&device.id		usb 0x0088
++device.name		Genius Traveler 515 Laser
 
  vendor.id		usb 0x0458
 &device.id		usb 0x0089
@@ -8545,6 +8665,10 @@
  vendor.id		usb 0x045a
 &device.id		usb 0x503f
 +device.name		Cali256 MP3 Player
+
+ vendor.id		usb 0x045a
+&device.id		usb 0x5042
++device.name		Rio Forge
 
  vendor.id		usb 0x045a
 &device.id		usb 0x5202
@@ -9725,7 +9849,7 @@
 
  vendor.id		usb 0x045e
 &device.id		usb 0x07c6
-+device.name		RTL8153 GigE [Surface Dock Ethernet]
++device.name		RTL8153 GigE [Surface Ethernet Adapter]
 
  vendor.id		usb 0x045e
 &device.id		usb 0x07ca
@@ -9744,8 +9868,16 @@
 +device.name		Nano Transceiver 1.1
 
  vendor.id		usb 0x045e
+&device.id		usb 0x0800
++device.name		Wireless keyboard (All-in-One-Media)
+
+ vendor.id		usb 0x045e
 &device.id		usb 0x0810
 +device.name		LifeCam HD-3000
+
+ vendor.id		usb 0x045e
+&device.id		usb 0x0823
++device.name		Classic IntelliMouse
 
  vendor.id		usb 0x045e
 &device.id		usb 0x0900
@@ -9784,12 +9916,32 @@
 +device.name		Hub
 
  vendor.id		usb 0x045e
+&device.id		usb 0x0927
++device.name		RTL8153B GigE [Surface Ethernet Adapter]
+
+ vendor.id		usb 0x045e
+&device.id		usb 0x0955
++device.name		Hub
+
+ vendor.id		usb 0x045e
+&device.id		usb 0x0957
++device.name		Hub
+
+ vendor.id		usb 0x045e
+&device.id		usb 0x09a0
++device.name		RTL8153B GigE [Surface Ethernet Adapter]
+
+ vendor.id		usb 0x045e
 &device.id		usb 0x09c0
 +device.name		Surface Type Cover
 
  vendor.id		usb 0x045e
 &device.id		usb 0x0a00
 +device.name		Lumia 950 Dual SIM (RM-1118)
+
+ vendor.id		usb 0x045e
+&device.id		usb 0x0b12
++device.name		Xbox Wireless Controller (model 1914)
 
  vendor.id		usb 0x045e
 &device.id		usb 0x930a
@@ -10403,7 +10555,11 @@
 
  vendor.id		usb 0x046d
 &device.id		usb 0x0892
-+device.name		OrbiCam
++device.name		C920 HD Pro Webcam
+
+ vendor.id		usb 0x046d
+&device.id		usb 0x0893
++device.name		StreamCam
 
  vendor.id		usb 0x046d
 &device.id		usb 0x0894
@@ -10778,6 +10934,10 @@
 +device.name		Clear Chat Comfort USB Headset
 
  vendor.id		usb 0x046d
+&device.id		usb 0x0a10
++device.name		V10 Notebook Speakers
+
+ vendor.id		usb 0x046d
 &device.id		usb 0x0a13
 +device.name		Z-5 Speakers
 
@@ -10832,6 +10992,10 @@
  vendor.id		usb 0x046d
 &device.id		usb 0x0a66
 +device.name		[G533 Wireless Headset Dongle]
+
+ vendor.id		usb 0x046d
+&device.id		usb 0x0a8f
++device.name		H390 headset with microphone
 
  vendor.id		usb 0x046d
 &device.id		usb 0x0b02
@@ -11146,6 +11310,14 @@
 +device.name		G203 Gaming Mouse
 
  vendor.id		usb 0x046d
+&device.id		usb 0xc08b
++device.name		G502 SE HERO Gaming Mouse
+
+ vendor.id		usb 0x046d
+&device.id		usb 0xc092
++device.name		G203 LIGHTSYNC Gaming Mouse
+
+ vendor.id		usb 0x046d
 &device.id		usb 0xc101
 +device.name		UltraX Media Remote
 
@@ -11338,6 +11510,10 @@
 +device.name		G13 Virtual Mouse
 
  vendor.id		usb 0x046d
+&device.id		usb 0xc232
++device.name		Gaming Virtual Keyboard
+
+ vendor.id		usb 0x046d
 &device.id		usb 0xc245
 +device.name		G400 Optical Mouse
 
@@ -11368,6 +11544,18 @@
  vendor.id		usb 0x046d
 &device.id		usb 0xc24e
 +device.name		G500s Laser Gaming Mouse
+
+ vendor.id		usb 0x046d
+&device.id		usb 0xc24f
++device.name		G29 Driving Force Racing Wheel [PS3]
+
+ vendor.id		usb 0x046d
+&device.id		usb 0xc260
++device.name		G29 Driving Force Racing Wheel [PS4]
+
+ vendor.id		usb 0x046d
+&device.id		usb 0xc262
++device.name		G920 Driving Force Racing Wheel
 
  vendor.id		usb 0x046d
 &device.id		usb 0xc281
@@ -11558,6 +11746,10 @@
 +device.name		G413 Gaming Keyboard
 
  vendor.id		usb 0x046d
+&device.id		usb 0xc33f
++device.name		G815 Mechanical Keyboard
+
+ vendor.id		usb 0x046d
 &device.id		usb 0xc401
 +device.name		TrackMan Marble Wheel
 
@@ -11716,6 +11908,10 @@
  vendor.id		usb 0x046d
 &device.id		usb 0xc53a
 +device.name		PowerPlay Wireless Charging System
+
+ vendor.id		usb 0x046d
+&device.id		usb 0xc53d
++device.name		G631 Keyboard
 
  vendor.id		usb 0x046d
 &device.id		usb 0xc603
@@ -12355,6 +12551,10 @@
 +device.name		SPC230NC Webcam
 
  vendor.id		usb 0x0471
+&device.id		usb 0x2721
++device.name		PTA 317 TV Camera
+
+ vendor.id		usb 0x0471
 &device.id		usb 0x485d
 +device.name		Senselock SenseIV v2.x
 
@@ -12818,6 +13018,10 @@
 &device.id		usb 0x5003
 +device.name		VideoCam
 
+ vendor.id		usb 0x047d
+&device.id		usb 0x8018
++device.name		Expert Wireless Trackball Mouse (K72359WW)
+
  vendor.id		usb 0x047e
 +vendor.name		Agere Systems, Inc. (Lucent)
 
@@ -12895,6 +13099,14 @@
  vendor.id		usb 0x047f
 &device.id		usb 0xc03b
 +device.name		HD1
+
+ vendor.id		usb 0x047f
+&device.id		usb 0xca01
++device.name		Calisto 800 Series
+
+ vendor.id		usb 0x047f
+&device.id		usb 0xda60
++device.name		DA60
 
  vendor.id		usb 0x0480
 +vendor.name		Toshiba America Inc
@@ -13052,6 +13264,10 @@
  vendor.id		usb 0x0482
 &device.id		usb 0x069b
 +device.name		ECOSYS M2635dn
+
+ vendor.id		usb 0x0482
+&device.id		usb 0x06b4
++device.name		ECOSYS M5526cdw
 
  vendor.id		usb 0x0483
 +vendor.name		STMicroelectronics
@@ -13321,7 +13537,7 @@
 
  vendor.id		usb 0x048d
 &device.id		usb 0x1234
-+device.name		Mass storage
++device.name		Chipsbank CBM2199 Flash Drive
 
  vendor.id		usb 0x048d
 &device.id		usb 0x1336
@@ -13330,6 +13546,10 @@
  vendor.id		usb 0x048d
 &device.id		usb 0x1345
 +device.name		Multi Cardreader
+
+ vendor.id		usb 0x048d
+&device.id		usb 0x8297
++device.name		IT8297 RGB LED Controller
 
  vendor.id		usb 0x048d
 &device.id		usb 0x9006
@@ -14368,6 +14588,10 @@
 &device.id		usb 0x04cd
 +device.name		Xerox Travel Scanner 150
 
+ vendor.id		usb 0x04a7
+&device.id		usb 0x04ee
++device.name		Duplex Combo Scanner
+
  vendor.id		usb 0x04a8
 +vendor.name		Multivideo Labs, Inc.
 
@@ -15191,6 +15415,10 @@
 +device.name		CanoScan LiDE 220
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x1913
++device.name		CanoScan LiDE 300
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x2200
 +device.name		CanoScan LiDE 25
 
@@ -15757,6 +15985,10 @@
  vendor.id		usb 0x04a9
 &device.id		usb 0x2737
 +device.name		MF4410
+
+ vendor.id		usb 0x04a9
+&device.id		usb 0x2742
++device.name		imageRUNNER1133 series
 
  vendor.id		usb 0x04a9
 &device.id		usb 0x2771
@@ -17031,6 +17263,10 @@
 +device.name		PowerShot SX420 IS
 
  vendor.id		usb 0x04a9
+&device.id		usb 0x32c0
++device.name		PowerShot ELPH 190IS
+
+ vendor.id		usb 0x04a9
 &device.id		usb 0x32c1
 +device.name		PowerShot ELPH 180 / IXUS 175
 
@@ -17538,12 +17774,20 @@
 +device.name		CY7C63x0x Thermometer
 
  vendor.id		usb 0x04b4
+&device.id		usb 0x0008
++device.name		CDC ACM serial port
+
+ vendor.id		usb 0x04b4
 &device.id		usb 0x0033
 +device.name		Mouse
 
  vendor.id		usb 0x04b4
 &device.id		usb 0x0060
 +device.name		Wireless optical mouse
+
+ vendor.id		usb 0x04b4
+&device.id		usb 0x00f3
++device.name		FX3 micro-controller (DFU mode)
 
  vendor.id		usb 0x04b4
 &device.id		usb 0x0100
@@ -17568,6 +17812,10 @@
  vendor.id		usb 0x04b4
 &device.id		usb 0x0407
 +device.name		Optical Skype Mouse
+
+ vendor.id		usb 0x04b4
+&device.id		usb 0x0818
++device.name		AE-SMKD92-* [Thumb Keyboard]
 
  vendor.id		usb 0x04b4
 &device.id		usb 0x0bad
@@ -17734,8 +17982,16 @@
 +device.name		Mono embedded computer
 
  vendor.id		usb 0x04b4
+&device.id		usb 0xfd10
++device.name		Gembird MSIS-PM
+
+ vendor.id		usb 0x04b4
 &device.id		usb 0xfd13
-+device.name		Programmable power socket
++device.name		Energenie EG-PMS
+
+ vendor.id		usb 0x04b4
+&device.id		usb 0xfd15
++device.name		Energenie EG-PMS2
 
  vendor.id		usb 0x04b5
 +vendor.name		ROHM LSI Systems USA, LLC
@@ -18477,6 +18733,10 @@
 &device.id		usb 0x1129
 +device.name		ET-4750 [WorkForce ET-4750 EcoTank All-in-One]
 
+ vendor.id		usb 0x04b8
+&device.id		usb 0x1168
++device.name		Workforce WF-7820/7840 Series
+
  vendor.id		usb 0x04b9
 +vendor.name		Rainbow Technologies, Inc.
 
@@ -18581,6 +18841,10 @@
  vendor.id		usb 0x04bb
 &device.id		usb 0x0101
 +device.name		USB2-IDE/ATAPI Bridge Adapter
+
+ vendor.id		usb 0x04bb
+&device.id		usb 0x014a
++device.name		HDCL-UT
 
  vendor.id		usb 0x04bb
 &device.id		usb 0x0201
@@ -18929,6 +19193,10 @@
  vendor.id		usb 0x04c5
 &device.id		usb 0x132e
 +device.name		fi-7160
+
+ vendor.id		usb 0x04c5
+&device.id		usb 0x159f
++device.name		ScanSnap iX1500
 
  vendor.id		usb 0x04c5
 &device.id		usb 0x200f
@@ -19402,6 +19670,10 @@
 +device.name		FinePix F47 (PTP)
 
  vendor.id		usb 0x04cb
+&device.id		usb 0x01e7
++device.name		Fujifilm A850 Digital Camera
+
+ vendor.id		usb 0x04cb
 &device.id		usb 0x01f7
 +device.name		FinePix J250 (PTP)
 
@@ -19428,6 +19700,10 @@
  vendor.id		usb 0x04cb
 &device.id		usb 0x02c5
 +device.name		FinePix S9900W Digital Camera (PTP)
+
+ vendor.id		usb 0x04cb
+&device.id		usb 0x02e0
++device.name		X-T200 Digital Camera
 
  vendor.id		usb 0x04cb
 &device.id		usb 0x5006
@@ -19649,6 +19925,10 @@
 +device.name		Microchip REAL ICE
 
  vendor.id		usb 0x04d8
+&device.id		usb 0x9009
++device.name		ICD3
+
+ vendor.id		usb 0x04d8
 &device.id		usb 0x900a
 +device.name		PICkit3
 
@@ -19756,12 +20036,20 @@
 +vendor.name		Holtek Semiconductor, Inc.
 
  vendor.id		usb 0x04d9
+&device.id		usb 0x0006
++device.name		Wired Keyboard (78/79 key) [RPI Wired Keyboard 5]
+
+ vendor.id		usb 0x04d9
 &device.id		usb 0x0022
 +device.name		Portable Keyboard
 
  vendor.id		usb 0x04d9
 &device.id		usb 0x0348
 +device.name		Keyboard
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0x0407
++device.name		Keyboard [TEX Shinobi]
 
  vendor.id		usb 0x04d9
 &device.id		usb 0x048e
@@ -19852,6 +20140,10 @@
 +device.name		Keyboard
 
  vendor.id		usb 0x04d9
+&device.id		usb 0xa075
++device.name		Optical Gaming Mouse
+
+ vendor.id		usb 0x04d9
 &device.id		usb 0xa096
 +device.name		Keyboard
 
@@ -19868,6 +20160,10 @@
 +device.name		Mouse [MX-3200]
 
  vendor.id		usb 0x04d9
+&device.id		usb 0xa153
++device.name		Optical Gaming Mouse
+
+ vendor.id		usb 0x04d9
 &device.id		usb 0xa29f
 +device.name		Microarray fingerprint reader
 
@@ -19878,6 +20174,22 @@
  vendor.id		usb 0x04d9
 &device.id		usb 0xe002
 +device.name		MCU
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0xfc2a
++device.name		Gaming Mouse [Redragon M709]
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0xfc30
++device.name		Gaming Mouse [Redragon M711]
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0xfc4d
++device.name		Gaming Mouse [Redragon M908]
+
+ vendor.id		usb 0x04d9
+&device.id		usb 0xfc55
++device.name		Venus MMO Gaming Mouse
 
  vendor.id		usb 0x04da
 +vendor.name		Panasonic (Matsushita)
@@ -20616,6 +20928,10 @@
  vendor.id		usb 0x04e8
 &device.id		usb 0x0300
 +device.name		E2530 / GT-C3350 Phones (Mass storage mode)
+
+ vendor.id		usb 0x04e8
+&device.id		usb 0x04e8
++device.name		Galaxy (MIDI mode)
 
  vendor.id		usb 0x04e8
 &device.id		usb 0x1003
@@ -21399,7 +21715,7 @@
 
  vendor.id		usb 0x04e8
 &device.id		usb 0x6860
-+device.name		Galaxy series, misc. (MTP mode)
++device.name		Galaxy A5 (MTP)
 
  vendor.id		usb 0x04e8
 &device.id		usb 0x6863
@@ -21873,6 +22189,10 @@
 +device.name		Asus Integrated Webcam
 
  vendor.id		usb 0x04f2
+&device.id		usb 0xb1bb
++device.name		2.0M UVC WebCam
+
+ vendor.id		usb 0x04f2
 &device.id		usb 0xb1cf
 +device.name		Lenovo Integrated Camera
 
@@ -21985,6 +22305,14 @@
 +device.name		Integrated Camera
 
  vendor.id		usb 0x04f2
+&device.id		usb 0xb5ab
++device.name		Integrated Camera
+
+ vendor.id		usb 0x04f2
+&device.id		usb 0xb5ac
++device.name		Integrated IR Camera
+
+ vendor.id		usb 0x04f2
 &device.id		usb 0xb5ce
 +device.name		Integrated Camera
 
@@ -22066,6 +22394,10 @@
  vendor.id		usb 0x04f3
 &device.id		usb 0x04a0
 +device.name		Dream Cheeky Stress/Panic Button
+
+ vendor.id		usb 0x04f3
+&device.id		usb 0x0c28
++device.name		fingerprint sensor [FeinTech FPS00200]
 
  vendor.id		usb 0x04f3
 &device.id		usb 0x2234
@@ -22236,6 +22568,14 @@
  vendor.id		usb 0x04f9
 &device.id		usb 0x002d
 +device.name		Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0037
++device.name		HL-3040CN series
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0038
++device.name		HL-3070CW series
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x0039
@@ -22956,6 +23296,10 @@
  vendor.id		usb 0x04f9
 &device.id		usb 0x01f4
 +device.name		MFC-5890CN
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0204
++device.name		DCP-165C
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x020a
@@ -24070,6 +24414,58 @@
 +device.name		ADS-2700W
 
  vendor.id		usb 0x04f9
+&device.id		usb 0x043f
++device.name		MFC-L3770CDW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0440
++device.name		MFC-9350CDW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0441
++device.name		MFC-L3750CDW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0442
++device.name		MFC-L3745CDW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0443
++device.name		MFC-L3735CDN
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0444
++device.name		MFC-9150CDN
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0445
++device.name		MFC-L3730CDN
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0446
++device.name		MFC-L3710CW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0447
++device.name		DCP-9030CDN
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x0448
++device.name		DCP-L3550CDW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x044a
++device.name		HL-L3290CDW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x044b
++device.name		DCP-L3510CDW
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x044c
++device.name		DCP-L3551CDW
+
+ vendor.id		usb 0x04f9
 &device.id		usb 0x1000
 +device.name		Printer
 
@@ -24091,11 +24487,11 @@
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2015
-+device.name		QL-500 P-touch label printer
++device.name		QL-500 label printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2016
-+device.name		QL-550 P-touch label printer
++device.name		QL-550 printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x201a
@@ -24103,15 +24499,23 @@
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x201b
-+device.name		QL-650TD P-touch Label Printer
++device.name		QL-650TD Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x2020
++device.name		QL-1050 Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2027
-+device.name		QL-560 P-touch Label Printer
++device.name		QL-560 Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2028
-+device.name		QL-570 P-touch Label Printer
++device.name		QL-570 Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x202a
++device.name		QL-1060N Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x202b
@@ -24120,6 +24524,10 @@
  vendor.id		usb 0x04f9
 &device.id		usb 0x202c
 +device.name		PT-1230PC P-touch Label Printer E mode
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x202d
++device.name		PT-2430PC P-touch Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2030
@@ -24131,7 +24539,19 @@
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2042
-+device.name		QL-700 P-touch Label Printer
++device.name		QL-700 Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x2043
++device.name		QL-710W Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x2044
++device.name		QL-720NW Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x204d
++device.name		QL-720NW Label Printer (mass storage mode)
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2061
@@ -24142,16 +24562,48 @@
 +device.name		PT-P700 P-touch Label Printer RemovableDisk
 
  vendor.id		usb 0x04f9
+&device.id		usb 0x2074
++device.name		PT-D600 P-touch Label Printer
+
+ vendor.id		usb 0x04f9
 &device.id		usb 0x209b
-+device.name		QL-800 P-touch Label Printer
++device.name		QL-800 Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x209c
-+device.name		QL-810W P-touch Label Printer
++device.name		QL-810W Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x209d
-+device.name		QL-820NWB P-touch Label Printer
++device.name		QL-820NWB Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x20a7
++device.name		QL-1100 Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x20a8
++device.name		QL-1110NWB Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x20a9
++device.name		QL-1100 Label Printer (mass storage)
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x20aa
++device.name		QL-1110NWB Label Printer (mass storage)
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x20ab
++device.name		QL-1115NWB Label Printer
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x20ac
++device.name		QL-1115NWB Label Printer (mass storage)
+
+ vendor.id		usb 0x04f9
+&device.id		usb 0x20c0
++device.name		QL-600 Label Printer
 
  vendor.id		usb 0x04f9
 &device.id		usb 0x2100
@@ -25072,7 +25524,7 @@
 
  vendor.id		usb 0x0525
 &device.id		usb 0x3424
-+device.name		Lumidigm Venus fingerprint sensor
++device.name		V30x/V4xx fingerprint sensor [Lumidigm]
 
  vendor.id		usb 0x0525
 &device.id		usb 0xa0f0
@@ -25112,7 +25564,7 @@
 
  vendor.id		usb 0x0525
 &device.id		usb 0xa4a5
-+device.name		Pocketbook Pro 903 / Mobius 2 Action Cam
++device.name		Linux-USB File-backed Storage Gadget
 
  vendor.id		usb 0x0525
 &device.id		usb 0xa4a6
@@ -25133,6 +25585,14 @@
  vendor.id		usb 0x0525
 &device.id		usb 0xa4aa
 +device.name		Linux-USB CDC Composite Gadge (Ethernet and ACM)
+
+ vendor.id		usb 0x0525
+&device.id		usb 0xa4ab
++device.name		Linux-USB Multifunction Composite Gadget
+
+ vendor.id		usb 0x0525
+&device.id		usb 0xa4ac
++device.name		Linux-USB HID Gadget
 
  vendor.id		usb 0x0526
 +vendor.name		Temic MHS S.A.
@@ -26321,6 +26781,10 @@
 +device.name		UP-DR200 Photo Printer
 
  vendor.id		usb 0x054c
+&device.id		usb 0x0360
++device.name		M2 Card Reader
+
+ vendor.id		usb 0x054c
 &device.id		usb 0x0382
 +device.name		Memory Stick PRO-HG Duo Adaptor (MSAC-UAH1)
 
@@ -26409,6 +26873,10 @@
 +device.name		RC-S380
 
  vendor.id		usb 0x054c
+&device.id		usb 0x07c3
++device.name		ILCE-6000 (aka Alpha-6000) in Mass Storage mode
+
+ vendor.id		usb 0x054c
 &device.id		usb 0x07c4
 +device.name		ILCE-6000 (aka Alpha-6000) in Mass Storage mode
 
@@ -26419,6 +26887,10 @@
  vendor.id		usb 0x054c
 &device.id		usb 0x0847
 +device.name		WG-C10 Portable Wireless Server
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x0877
++device.name		UP-D898/X898 series
 
  vendor.id		usb 0x054c
 &device.id		usb 0x0884
@@ -26465,12 +26937,24 @@
 +device.name		ILCE-7M3 [A7III] in PC Remote mode
 
  vendor.id		usb 0x054c
+&device.id		usb 0x0c7f
++device.name		WH-CH700N [Wireless Noise-Canceling Headphones]
+
+ vendor.id		usb 0x054c
 &device.id		usb 0x0cd3
 +device.name		WH-1000XM3 [Wireless Noise-Canceling Headphones]
 
  vendor.id		usb 0x054c
 &device.id		usb 0x0cda
 +device.name		PlayStation Classic controller
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x0ce0
++device.name		WF-1000XM3 [Wireless Noise-Canceling Headphones]
+
+ vendor.id		usb 0x054c
+&device.id		usb 0x0d58
++device.name		WH-1000XM4 [Wireless Noise-Canceling Headphones]
 
  vendor.id		usb 0x054c
 &device.id		usb 0x1000
@@ -26636,6 +27120,10 @@
  vendor.id		usb 0x0557
 &device.id		usb 0x2404
 +device.name		4-port switch
+
+ vendor.id		usb 0x0557
+&device.id		usb 0x2419
++device.name		Virtual mouse/keyboard device
 
  vendor.id		usb 0x0557
 &device.id		usb 0x2600
@@ -28087,6 +28575,298 @@
 +device.name		M-BL10UB Mouse
 
  vendor.id		usb 0x056e
+&device.id		usb 0x00aa
++device.name		M-BL11DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00ac
++device.name		M-A-BL01UL / M-BL15DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00b4
++device.name		Track on Glass Mouse M-TG02DL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00b5
++device.name		Track on Glass Mouse M-TG03UL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00b6
++device.name		Track on Glass Mouse M-TG04DL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00b8
++device.name		M-A-BL01UL or M-ASKL2 Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00b9
++device.name		M-A-BL02DB or M-ASKL Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00cb
++device.name		M-BL21DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00cd
++device.name		M-XG1UB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00ce
++device.name		M-XG1DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00cf
++device.name		M-XG1BB Bluetooth Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00d0
++device.name		M-XG2UB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00d1
++device.name		M-XG2DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00d2
++device.name		M-XG2BB Bluetooth Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00d3
++device.name		M-XG3DL Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00d4
++device.name		M-LS11DL Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00da
++device.name		M-XG4UB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00db
++device.name		M-XG4DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00dc
++device.name		M-XG4BB Bluetooth Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00dd
++device.name		M-LS12UL Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00de
++device.name		M-LS13UL Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00df
++device.name		M-BL22DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00e1
++device.name		M-WK01DB or M-A-BL04DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00e2
++device.name		M-A-BL03DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00e3
++device.name		M-XGx10UB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00e4
++device.name		M-XGx10DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00e5
++device.name		M-XGx10BB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00e6
++device.name		M-XGx20DL or M-XGx20DB UltimateLaser Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00f1
++device.name		M-XT1DRBK USB EX-G Wireless Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00f2
++device.name		M-XT1URBK EX-G Optical Trackball
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00f3
++device.name		M-BL23DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00f4
++device.name		M-BT13BL LBT-UAN05C2
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00f7
++device.name		M-KN1DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00f8
++device.name		M-BL22DB Mouse (other version)
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00f9
++device.name		M-XT2URBK EX-G Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00fa
++device.name		M-XT2DRBK EX-G Wireless Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00fb
++device.name		M-XT3URBK EX-G Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00fc
++device.name		M-XT3DRBK EX-G Wireless Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00fd
++device.name		M-XT4DRBK EX-G Wireless Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00fe
++device.name		M-DT1URBK or M-DT2URBK DEFT Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x00ff
++device.name		M-DT1DRBK or M-DT2DRBK DEFT Wireless Optical Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0101
++device.name		M-BL25UBS
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0103
++device.name		M-BT16BBS
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0104
++device.name		M-BL26UBC
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0105
++device.name		M-BL26DBC
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0107
++device.name		M-LS15UL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0108
++device.name		M-LS15DL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0109
++device.name		M-LS16UL Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x010a
++device.name		M-LS16DL / M-KN2DLS
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x010b
++device.name		M-BL21DB Mouse
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x010c
++device.name		M-HT1URBK HUGE Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x010d
++device.name		M-HT1DRBK HUGE Wireless Optical TrackBall
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x010e
++device.name		M-KS1DBS / M-FPG3DBS
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x010f
++device.name		M-FBG3DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0115
++device.name		M-BT13BL
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0121
++device.name		M-ED01DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0122
++device.name		M-NK01DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0124
++device.name		Dual connect Mouse M-DC01MB Bluetooth
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0128
++device.name		TrackBall Mouse M-XPT1MR Wired
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0129
++device.name		TrackBall Mouse M-XPT1MR Wireless
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0130
++device.name		TrackBall Mouse M-XPT1MR Bluetooth
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0131
++device.name		TrackBall Mouse M-DPT1MR Wired
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0132
++device.name		TrackBall Mouse M-DPT1MR Wireless
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0133
++device.name		TrackBall Mouse M-DPT1MR Bluetooth
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0136
++device.name		M-BT20BB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0137
++device.name		BlueTooth 4.0 Mouse M-BT21BB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0138
++device.name		M-A-BL07DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0140
++device.name		M-G01UR
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0141
++device.name		M-Y9UB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0142
++device.name		M-DY13DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x0144
++device.name		M-FBL01DB
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x1055
++device.name		TK-DCP03 WIRED
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x1057
++device.name		TK-DCP03 BT
+
+ vendor.id		usb 0x056e
 &device.id		usb 0x2003
 +device.name		JC-U3613M
 
@@ -28097,6 +28877,10 @@
  vendor.id		usb 0x056e
 &device.id		usb 0x200c
 +device.name		LD-USB/TX
+
+ vendor.id		usb 0x056e
+&device.id		usb 0x200f
++device.name		JC-U4013S Gamepad
 
  vendor.id		usb 0x056e
 &device.id		usb 0x2012
@@ -28699,6 +29483,14 @@
 +vendor.name		Nintendo Co., Ltd
 
  vendor.id		usb 0x057e
+&device.id		usb 0x0300
++device.name		USB-EXI Adapter (GCP-2000)
+
+ vendor.id		usb 0x057e
+&device.id		usb 0x0304
++device.name		RVT-H Reader
+
+ vendor.id		usb 0x057e
 &device.id		usb 0x0305
 +device.name		Broadcom BCM2045A Bluetooth Radio [Nintendo Wii]
 
@@ -28711,12 +29503,28 @@
 +device.name		Wii U GameCube Controller Adapter
 
  vendor.id		usb 0x057e
+&device.id		usb 0x2000
++device.name		Switch
+
+ vendor.id		usb 0x057e
 &device.id		usb 0x2006
 +device.name		Joy-Con L
 
  vendor.id		usb 0x057e
 &device.id		usb 0x2007
 +device.name		Joy-Con R
+
+ vendor.id		usb 0x057e
+&device.id		usb 0x2009
++device.name		Switch Pro Controller
+
+ vendor.id		usb 0x057e
+&device.id		usb 0x200e
++device.name		Joy-Con Charging Grip
+
+ vendor.id		usb 0x057e
+&device.id		usb 0x3000
++device.name		SDK Debugger
 
  vendor.id		usb 0x057f
 +vendor.name		QuickShot, Ltd
@@ -28730,6 +29538,14 @@
 
  vendor.id		usb 0x0581
 +vendor.name		Racal Data Group
+
+ vendor.id		usb 0x0581
+&device.id		usb 0x0107
++device.name		Tera Barcode Scanner 2.4 GHz Receiver
+
+ vendor.id		usb 0x0581
+&device.id		usb 0x020c
++device.name		Tera 2D Barcode Scanner EVHK0012
 
  vendor.id		usb 0x0582
 +vendor.name		Roland Corp.
@@ -29383,6 +30199,30 @@
 +device.name		R-88
 
  vendor.id		usb 0x0582
+&device.id		usb 0x01b5
++device.name		Boutique Series Synthesizer (Normal mode)
+
+ vendor.id		usb 0x0582
+&device.id		usb 0x01b6
++device.name		Boutique Series Synthesizer (Storage mode)
+
+ vendor.id		usb 0x0582
+&device.id		usb 0x01df
++device.name		Rubix22
+
+ vendor.id		usb 0x0582
+&device.id		usb 0x01e0
++device.name		Rubix24
+
+ vendor.id		usb 0x0582
+&device.id		usb 0x01e1
++device.name		Rubix44
+
+ vendor.id		usb 0x0582
+&device.id		usb 0x01ef
++device.name		Go:KEYS MIDI
+
+ vendor.id		usb 0x0582
 &device.id		usb 0x0505
 +device.name		EDIROL UA-101
 
@@ -29420,6 +30260,10 @@
  vendor.id		usb 0x0583
 &device.id		usb 0x205f
 +device.name		PSX/USB converter
+
+ vendor.id		usb 0x0583
+&device.id		usb 0x2060
++device.name		2-axis 8-button gamepad
 
  vendor.id		usb 0x0583
 &device.id		usb 0x206f
@@ -29978,6 +30822,10 @@
 +device.name		Flash Drive
 
  vendor.id		usb 0x058f
+&device.id		usb 0x198b
++device.name		Webcam (Gigatech P-09)
+
+ vendor.id		usb 0x058f
 &device.id		usb 0x2412
 +device.name		SCard R/W CSR-145
 
@@ -30048,6 +30896,10 @@
  vendor.id		usb 0x058f
 &device.id		usb 0x6391
 +device.name		IDE Bridge
+
+ vendor.id		usb 0x058f
+&device.id		usb 0x6998
++device.name		AU6998 Flash Disk Controller
 
  vendor.id		usb 0x058f
 &device.id		usb 0x9213
@@ -30163,6 +31015,10 @@
  vendor.id		usb 0x0590
 &device.id		usb 0x0028
 +device.name		HJ-720IT / HEM-7080IT-E / HEM-790IT
+
+ vendor.id		usb 0x0590
+&device.id		usb 0x0051
++device.name		FT232BM [E58CIFQ1 with FTDI USB2Serial Converter]
 
  vendor.id		usb 0x0591
 +vendor.name		Questra Consulting
@@ -30462,6 +31318,10 @@
 +device.name		Mobile Hard Drive
 
  vendor.id		usb 0x059f
+&device.id		usb 0x0828
++device.name		d2 Quadra
+
+ vendor.id		usb 0x059f
 &device.id		usb 0x0829
 +device.name		BigDisk Extreme+
 
@@ -30502,12 +31362,20 @@
 +device.name		Rikiki Hard Drive
 
  vendor.id		usb 0x059f
+&device.id		usb 0x103d
++device.name		D2
+
+ vendor.id		usb 0x059f
 &device.id		usb 0x1049
 +device.name		rikiki Harddrive
 
  vendor.id		usb 0x059f
 &device.id		usb 0x1052
 +device.name		P'9220 Mobile Drive
+
+ vendor.id		usb 0x059f
+&device.id		usb 0x1053
++device.name		P'9230 2TB [Porsche Design Desktop Drive 2TB]
 
  vendor.id		usb 0x059f
 &device.id		usb 0x1061
@@ -30528,6 +31396,14 @@
  vendor.id		usb 0x059f
 &device.id		usb 0x106e
 +device.name		Porsche Design Desktop Drive
+
+ vendor.id		usb 0x059f
+&device.id		usb 0x1094
++device.name		Rugged THB
+
+ vendor.id		usb 0x059f
+&device.id		usb 0x1095
++device.name		Rugged
 
  vendor.id		usb 0x059f
 &device.id		usb 0xa601
@@ -30564,6 +31440,10 @@
  vendor.id		usb 0x05a3
 &device.id		usb 0x9331
 +device.name		Camera
+
+ vendor.id		usb 0x05a3
+&device.id		usb 0x9332
++device.name		Camera - 1080p
 
  vendor.id		usb 0x05a3
 &device.id		usb 0x9422
@@ -30635,6 +31515,10 @@
 +device.name		CVA122E Cable Voice Adapter (WDM)
 
  vendor.id		usb 0x05a6
+&device.id		usb 0x0008
++device.name		STA1520 Tuning Adapter
+
+ vendor.id		usb 0x05a6
 &device.id		usb 0x0a00
 +device.name		Integrated Management Controller Hub
 
@@ -30670,6 +31554,14 @@
 +device.name		Bluetooth Headset Series 2 in DFU mode
 
  vendor.id		usb 0x05a7
+&device.id		usb 0x400d
++device.name		SoundLink Color II speaker in DFU mode
+
+ vendor.id		usb 0x05a7
+&device.id		usb 0x40fe
++device.name		SoundLink Color II speaker
+
+ vendor.id		usb 0x05a7
 &device.id		usb 0xbc50
 +device.name		SoundLink Wireless Mobile speaker
 
@@ -30702,6 +31594,10 @@
  vendor.id		usb 0x05a9
 &device.id		usb 0x2640
 +device.name		OV2640 Webcam
+
+ vendor.id		usb 0x05a9
+&device.id		usb 0x2642
++device.name		Integrated Webcam for Dell XPS 2010
 
  vendor.id		usb 0x05a9
 &device.id		usb 0x2643
@@ -31025,6 +31921,10 @@
 +device.name		Internal Keyboard/Trackpad (MacBook Air) (ISO)
 
  vendor.id		usb 0x05ac
+&device.id		usb 0x024f
++device.name		Aluminium Keyboard (ANSI)
+
+ vendor.id		usb 0x05ac
 &device.id		usb 0x0250
 +device.name		Aluminium Keyboard (ISO)
 
@@ -31042,6 +31942,10 @@
 
  vendor.id		usb 0x05ac
 &device.id		usb 0x0259
++device.name		Internal Keyboard/Trackpad
+
+ vendor.id		usb 0x05ac
+&device.id		usb 0x025a
 +device.name		Internal Keyboard/Trackpad
 
  vendor.id		usb 0x05ac
@@ -31322,7 +32226,7 @@
 
  vendor.id		usb 0x05ac
 &device.id		usb 0x12a8
-+device.name		iPhone5/5C/5S/6
++device.name		iPhone 5/5C/5S/6/SE
 
  vendor.id		usb 0x05ac
 &device.id		usb 0x12a9
@@ -31351,6 +32255,22 @@
  vendor.id		usb 0x05ac
 &device.id		usb 0x1303
 +device.name		iPod Shuffle 4.Gen
+
+ vendor.id		usb 0x05ac
+&device.id		usb 0x1392
++device.name		Apple Watch charger
+
+ vendor.id		usb 0x05ac
+&device.id		usb 0x1393
++device.name		AirPods case
+
+ vendor.id		usb 0x05ac
+&device.id		usb 0x1395
++device.name		Smart Battery Case [iPhone 6]
+
+ vendor.id		usb 0x05ac
+&device.id		usb 0x1398
++device.name		Smart Battery Case
 
  vendor.id		usb 0x05ac
 &device.id		usb 0x1401
@@ -31397,6 +32317,10 @@
 +device.name		Bluetooth HCI
 
  vendor.id		usb 0x05ac
+&device.id		usb 0x8207
++device.name		Built-in Bluetooth
+
+ vendor.id		usb 0x05ac
 &device.id		usb 0x820a
 +device.name		Bluetooth HID Keyboard
 
@@ -31437,6 +32361,10 @@
 +device.name		Built-in Bluetooth 2.0+EDR HCI
 
  vendor.id		usb 0x05ac
+&device.id		usb 0x8233
++device.name		iBridge
+
+ vendor.id		usb 0x05ac
 &device.id		usb 0x8240
 +device.name		Built-in IR Receiver
 
@@ -31457,6 +32385,10 @@
 +device.name		Bluetooth Host Controller
 
  vendor.id		usb 0x05ac
+&device.id		usb 0x8289
++device.name		Bluetooth Host Controller
+
+ vendor.id		usb 0x05ac
 &device.id		usb 0x828c
 +device.name		Bluetooth Host Controller
 
@@ -31474,6 +32406,10 @@
 
  vendor.id		usb 0x05ac
 &device.id		usb 0x8404
++device.name		Internal Memory Card Reader
+
+ vendor.id		usb 0x05ac
+&device.id		usb 0x8406
 +device.name		Internal Memory Card Reader
 
  vendor.id		usb 0x05ac
@@ -31507,6 +32443,10 @@
  vendor.id		usb 0x05ac
 &device.id		usb 0x8510
 +device.name		FaceTime HD Camera (Built-in)
+
+ vendor.id		usb 0x05ac
+&device.id		usb 0x8600
++device.name		iBridge
 
  vendor.id		usb 0x05ac
 &device.id		usb 0x911c
@@ -31628,11 +32568,15 @@
 +vendor.name		Medianix Semiconductor, Inc.
 
  vendor.id		usb 0x05b8
-+vendor.name		Agiler, Inc.
++vendor.name		SYSGRATION
 
  vendor.id		usb 0x05b8
 &device.id		usb 0x3002
 +device.name		Scroll Mouse
+
+ vendor.id		usb 0x05b8
+&device.id		usb 0x3126
++device.name		APT-905 Wireless presenter
 
  vendor.id		usb 0x05b8
 &device.id		usb 0x3223
@@ -31707,6 +32651,18 @@
 +device.name		Select RW-200 CDMA Wireless Modem
 
  vendor.id		usb 0x05c6
+&device.id		usb 0x0a02
++device.name		Jolla Device Developer Mode
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x0a07
++device.name		Jolla Device MTP
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x0afe
++device.name		Jolla Device Charging Only
+
+ vendor.id		usb 0x05c6
 &device.id		usb 0x1000
 +device.name		Mass Storage Device
 
@@ -31764,7 +32720,31 @@
 
  vendor.id		usb 0x05c6
 &device.id		usb 0x9025
-+device.name		Qualcomm HSUSB Device
++device.name		HSUSB Device
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x9090
++device.name		Quectel UC15
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x9091
++device.name		Intex Aqua Fish & Jolla C Diagnostic Mode
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x9092
++device.name		Nokia 8110 4G
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x90ba
++device.name		Audio 1.0 device
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x90bb
++device.name		Snapdragon interface (MIDI + ADB)
+
+ vendor.id		usb 0x05c6
+&device.id		usb 0x90dc
++device.name		Fairphone 2 (Charging & ADB)
 
  vendor.id		usb 0x05c6
 &device.id		usb 0x9201
@@ -31796,7 +32776,7 @@
 
  vendor.id		usb 0x05c6
 &device.id		usb 0x9215
-+device.name		Acer Gobi 2000 Wireless Modem
++device.name		Quectel EC20 LTE modem / Acer Gobi 2000 Wireless Modem
 
  vendor.id		usb 0x05c6
 &device.id		usb 0x9221
@@ -31850,6 +32830,10 @@
 &device.id		usb 0x9275
 +device.name		iRex Technologies Gobi 2000 Wireless Modem
 
+ vendor.id		usb 0x05c6
+&device.id		usb 0xf003
++device.name		Nokia 8110 4G
+
  vendor.id		usb 0x05c7
 +vendor.name		Qtronix Corp.
 
@@ -31889,6 +32873,10 @@
 +device.name		HP Webcam
 
  vendor.id		usb 0x05c8
+&device.id		usb 0x0233
++device.name		HP Webcam
+
+ vendor.id		usb 0x05c8
 &device.id		usb 0x0318
 +device.name		Webcam
 
@@ -31899,6 +32887,30 @@
  vendor.id		usb 0x05c8
 &device.id		usb 0x036e
 +device.name		Webcam
+
+ vendor.id		usb 0x05c8
+&device.id		usb 0x0374
++device.name		HP EliteBook integrated HD Webcam
+
+ vendor.id		usb 0x05c8
+&device.id		usb 0x038e
++device.name		HP Wide Vision HD integrated webcam
+
+ vendor.id		usb 0x05c8
+&device.id		usb 0x03a1
++device.name		XiaoMi Webcam
+
+ vendor.id		usb 0x05c8
+&device.id		usb 0x03b1
++device.name		Webcam
+
+ vendor.id		usb 0x05c8
+&device.id		usb 0x03bc
++device.name		HP Wide Vision HD Integrated Webcam
+
+ vendor.id		usb 0x05c8
+&device.id		usb 0x03cb
++device.name		HP Wide Vision HD Integrated Webcam
 
  vendor.id		usb 0x05c8
 &device.id		usb 0x0403
@@ -31945,6 +32957,14 @@
  vendor.id		usb 0x05ca
 &device.id		usb 0x0406
 +device.name		Type 102
+
+ vendor.id		usb 0x05ca
+&device.id		usb 0x0437
++device.name		Aficio SP 3510SF
+
+ vendor.id		usb 0x05ca
+&device.id		usb 0x044e
++device.name		SP C250SF (multifunction device: printer, scanner, fax)
 
  vendor.id		usb 0x05ca
 &device.id		usb 0x1803
@@ -32019,12 +33039,20 @@
 +device.name		Visual Communication Camera VGP-VCC9 [R5U870]
 
  vendor.id		usb 0x05ca
+&device.id		usb 0x183f
++device.name		Sony Visual Communication Camera Integrated Webcam
+
+ vendor.id		usb 0x05ca
 &device.id		usb 0x1841
 +device.name		Fujitsu F01/ Lifebook U810 [R5U870]
 
  vendor.id		usb 0x05ca
 &device.id		usb 0x1870
 +device.name		Webcam 1000
+
+ vendor.id		usb 0x05ca
+&device.id		usb 0x1880
++device.name		R5U880
 
  vendor.id		usb 0x05ca
 &device.id		usb 0x18b0
@@ -32886,6 +33914,10 @@
 +device.name		MP3 Player
 
  vendor.id		usb 0x05dc
+&device.id		usb 0xa201
++device.name		JumpDrive S70 4GB
+
+ vendor.id		usb 0x05dc
 &device.id		usb 0xa209
 +device.name		JumpDrive S70
 
@@ -33039,6 +34071,10 @@
 
  vendor.id		usb 0x05dd
 +vendor.name		Delta Electronics, Inc.
+
+ vendor.id		usb 0x05dd
+&device.id		usb 0xa011
++device.name		HID UPS Battery
 
  vendor.id		usb 0x05dd
 &device.id		usb 0xff31
@@ -33212,12 +34248,16 @@
 +device.name		HID Keyboard Filter
 
  vendor.id		usb 0x05e3
+&device.id		usb 0x0510
++device.name		Camera
+
+ vendor.id		usb 0x05e3
 &device.id		usb 0x0604
 +device.name		USB 1.1 Hub
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0605
-+device.name		USB 2.0 Hub
++device.name		Hub
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0606
@@ -33233,7 +34273,7 @@
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0610
-+device.name		4-port hub
++device.name		Hub
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0612
@@ -33321,7 +34361,7 @@
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0716
-+device.name		USB 2.0 Multislot Card Reader/Writer
++device.name		Multislot Card Reader/Writer
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0717
@@ -33361,7 +34401,7 @@
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0736
-+device.name		microSD Reader/Writer
++device.name		Colour arc SD Card Reader [PISEN]
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0738
@@ -33382,6 +34422,10 @@
  vendor.id		usb 0x05e3
 &device.id		usb 0x0748
 +device.name		All-in-One Cardreader
+
+ vendor.id		usb 0x05e3
+&device.id		usb 0x0749
++device.name		SD Card Reader and Writer
 
  vendor.id		usb 0x05e3
 &device.id		usb 0x0751
@@ -33579,6 +34623,10 @@
 +device.name		Gryphon series (OEM mode)
 
  vendor.id		usb 0x05f9
+&device.id		usb 0x120c
++device.name		Gryphon GD4430-BK
+
+ vendor.id		usb 0x05f9
 &device.id		usb 0x2202
 +device.name		Point of Sale Handheld Scanner
 
@@ -33633,6 +34681,10 @@
 +device.name		Soundcraft Si MADI combo card
 
  vendor.id		usb 0x05fc
+&device.id		usb 0x0021
++device.name		Soundcraft Signature 12 MTK
+
+ vendor.id		usb 0x05fc
 &device.id		usb 0x7849
 +device.name		Harman/Kardon SoundSticks
 
@@ -33654,6 +34706,10 @@
  vendor.id		usb 0x05fd
 &device.id		usb 0x0286
 +device.name		SV-286 Cyclone Digital
+
+ vendor.id		usb 0x05fd
+&device.id		usb 0x1007
++device.name		Mad Catz Controller
 
  vendor.id		usb 0x05fd
 &device.id		usb 0x107a
@@ -33714,6 +34770,14 @@
 &device.id		usb 0x2001
 +device.name		Microsoft Wireless Receiver 700
 
+ vendor.id		usb 0x05fe
+&device.id		usb 0x3030
++device.name		Controller
+
+ vendor.id		usb 0x05fe
+&device.id		usb 0x3031
++device.name		Controller
+
  vendor.id		usb 0x05ff
 +vendor.name		LeCroy Corp.
 
@@ -33736,6 +34800,10 @@
 
  vendor.id		usb 0x0603
 +vendor.name		Novatek Microelectronics Corp.
+
+ vendor.id		usb 0x0603
+&device.id		usb 0x0002
++device.name		Sino Wealth keyboard/mouse 2.4 GHz receiver
 
  vendor.id		usb 0x0603
 &device.id		usb 0x00f1
@@ -33820,6 +34888,10 @@
  vendor.id		usb 0x060b
 &device.id		usb 0x2270
 +device.name		Gigabyte K8100 Aivia Gaming Keyboard
+
+ vendor.id		usb 0x060b
+&device.id		usb 0x500a
++device.name		Cougar 500k Gaming Keyboard
 
  vendor.id		usb 0x060b
 &device.id		usb 0x5253
@@ -34011,6 +35083,10 @@
 +vendor.name		Avocent Corp.
 
  vendor.id		usb 0x0624
+&device.id		usb 0x0013
++device.name		SC Secure KVM
+
+ vendor.id		usb 0x0624
 &device.id		usb 0x0248
 +device.name		Virtual Hub
 
@@ -34023,6 +35099,10 @@
 +device.name		Virtual Mass Storage
 
  vendor.id		usb 0x0624
+&device.id		usb 0x0252
++device.name		Virtual SD card reader
+
+ vendor.id		usb 0x0624
 &device.id		usb 0x0294
 +device.name		Dell 03R874 KVM dongle
 
@@ -34033,6 +35113,10 @@
  vendor.id		usb 0x0624
 &device.id		usb 0x0403
 +device.name		Cisco Virtual Mass Storage
+
+ vendor.id		usb 0x0624
+&device.id		usb 0x1774
++device.name		Cybex SC985
 
  vendor.id		usb 0x0625
 +vendor.name		TiMedia Technology Co., Ltd
@@ -34061,6 +35145,14 @@
 +device.name		Notebook Optical Mouse
 
  vendor.id		usb 0x062a
+&device.id		usb 0x0020
++device.name		Logic3 Gamepad
+
+ vendor.id		usb 0x062a
+&device.id		usb 0x0033
++device.name		Competition Pro Steering Wheel
+
+ vendor.id		usb 0x062a
 &device.id		usb 0x0102
 +device.name		Wireless Keyboard/Mouse Combo [MK1152WC]
 
@@ -34083,6 +35175,18 @@
  vendor.id		usb 0x062a
 &device.id		usb 0x4101
 +device.name		Wireless Keyboard/Mouse
+
+ vendor.id		usb 0x062a
+&device.id		usb 0x4102
++device.name		Wireless Mouse
+
+ vendor.id		usb 0x062a
+&device.id		usb 0x4106
++device.name		Wireless Mouse 2.4G
+
+ vendor.id		usb 0x062a
+&device.id		usb 0x4c01
++device.name		2,4Ghz Wireless Transceiver [for Delux M618 Plus Wireless Vertical Mouse]
 
  vendor.id		usb 0x062a
 &device.id		usb 0x6301
@@ -34160,6 +35264,10 @@
  vendor.id		usb 0x0638
 &device.id		usb 0x0a16
 +device.name		Konica Minolta SC-215
+
+ vendor.id		usb 0x0638
+&device.id		usb 0x0a2a
++device.name		AV220 C2
 
  vendor.id		usb 0x0638
 &device.id		usb 0x0a30
@@ -34322,6 +35430,10 @@
 +device.name		Sony Visual Communication Camera
 
  vendor.id		usb 0x064e
+&device.id		usb 0x3410
++device.name		RGBIR Camera
+
+ vendor.id		usb 0x064e
 &device.id		usb 0x9700
 +device.name		Asus Integrated Webcam
 
@@ -34352,6 +35464,10 @@
  vendor.id		usb 0x064e
 &device.id		usb 0xa116
 +device.name		UVC 1.3MPixel WebCam
+
+ vendor.id		usb 0x064e
+&device.id		usb 0xa127
++device.name		HP Integrated Webcam
 
  vendor.id		usb 0x064e
 &device.id		usb 0xa136
@@ -34404,6 +35520,10 @@
  vendor.id		usb 0x064e
 &device.id		usb 0xf103
 +device.name		Lenovo Integrated Webcam [R5U877]
+
+ vendor.id		usb 0x064e
+&device.id		usb 0xf207
++device.name		Lenovo EasyCamera Integrated Webcam
 
  vendor.id		usb 0x064e
 &device.id		usb 0xf209
@@ -35077,6 +36197,10 @@
 +device.name		MP3 Player
 
  vendor.id		usb 0x066f
+&device.id		usb 0x83b5
++device.name		Transcend T.sonic 530 MP3 Player
+
+ vendor.id		usb 0x066f
 &device.id		usb 0x9000
 +device.name		MP3 Player
 
@@ -35192,8 +36316,12 @@
 +device.name		AlDiga AL-11U Quad-band GSM/GPRS/EDGE modem
 
  vendor.id		usb 0x067b
+&device.id		usb 0x1231
++device.name		Orico SATA External Hard Disk Drive Lay-Flat Docking Station with USB 3.0 & eSATA interfaces.
+
+ vendor.id		usb 0x067b
 &device.id		usb 0x2303
-+device.name		PL2303 Serial Port
++device.name		PL2303 Serial Port / Mobile Action MA-8910P
 
  vendor.id		usb 0x067b
 &device.id		usb 0x2305
@@ -35246,6 +36374,10 @@
  vendor.id		usb 0x067b
 &device.id		usb 0x2528
 +device.name		Storage device (8gB thumb drive)
+
+ vendor.id		usb 0x067b
+&device.id		usb 0x2571
++device.name		LG Electronics GE24LU21
 
  vendor.id		usb 0x067b
 &device.id		usb 0x25a1
@@ -35502,6 +36634,14 @@
 +device.name		PagePro 1300W
 
  vendor.id		usb 0x0686
+&device.id		usb 0x301b
++device.name		Develop D 1650iD
+
+ vendor.id		usb 0x0686
+&device.id		usb 0x3023
++device.name		Develop D 2050iD
+
+ vendor.id		usb 0x0686
 &device.id		usb 0x302e
 +device.name		Develop D 1650iD PCL
 
@@ -35670,6 +36810,13 @@
 &device.id		usb 0x0504
 +device.name		F-16 Combat Stick
 
+ vendor.id		usb 0x068f
++vendor.name		Nihon KOHDEN
+
+ vendor.id		usb 0x068f
+&device.id		usb 0xc00d
++device.name		MEK-6500
+
  vendor.id		usb 0x0690
 +vendor.name		Golden Bridge Electech, Inc.
 
@@ -35740,6 +36887,10 @@
  vendor.id		usb 0x0699
 &device.id		usb 0x0347
 +device.name		AFG 3022B
+
+ vendor.id		usb 0x0699
+&device.id		usb 0x0365
++device.name		TDS 2004B
 
  vendor.id		usb 0x0699
 &device.id		usb 0x036a
@@ -35924,7 +37075,11 @@
 
  vendor.id		usb 0x06a3
 &device.id		usb 0x0200
-+device.name		Xbox Adrenalin Hub
++device.name		Racing Wheel
+
+ vendor.id		usb 0x06a3
+&device.id		usb 0x0201
++device.name		Adrenalin Gamepad
 
  vendor.id		usb 0x06a3
 &device.id		usb 0x0241
@@ -36147,6 +37302,10 @@
 +device.name		P3200 Rumble Force Game Pad
 
  vendor.id		usb 0x06a3
+&device.id		usb 0xf51a
++device.name		P3600
+
+ vendor.id		usb 0x06a3
 &device.id		usb 0xff04
 +device.name		R440 Force Wheel
 
@@ -36314,6 +37473,10 @@
  vendor.id		usb 0x06bc
 &device.id		usb 0x02bb
 +device.name		OKI PT390 POS Printer
+
+ vendor.id		usb 0x06bc
+&device.id		usb 0x0383
++device.name		MC563 Multifunction Printer
 
  vendor.id		usb 0x06bc
 &device.id		usb 0x0a91
@@ -36593,6 +37756,18 @@
 +device.name		DisplayPad
 
  vendor.id		usb 0x06cb
+&device.id		usb 0x009a
++device.name		Metallica MIS Touch Fingerprint Reader
+
+ vendor.id		usb 0x06cb
+&device.id		usb 0x00a2
++device.name		Metallica MOH Touch Fingerprint Reader
+
+ vendor.id		usb 0x06cb
+&device.id		usb 0x00bd
++device.name		Prometheus MIS Touch Fingerprint Reader
+
+ vendor.id		usb 0x06cb
 &device.id		usb 0x2970
 +device.name		touchpad
 
@@ -36854,6 +38029,10 @@
 +device.name		CP-9800DW-S
 
  vendor.id		usb 0x06d3
+&device.id		usb 0x0f10
++device.name		Hori/Namco FlightStick 2
+
+ vendor.id		usb 0x06d3
 &device.id		usb 0x3b10
 +device.name		P95D
 
@@ -36880,6 +38059,10 @@
  vendor.id		usb 0x06d3
 &device.id		usb 0x3b60
 +device.name		CP-D90DW
+
+ vendor.id		usb 0x06d3
+&device.id		usb 0x3b80
++device.name		CP-M1
 
  vendor.id		usb 0x06d4
 +vendor.name		Cisco Systems
@@ -37683,6 +38866,10 @@
 +device.name		PS/2 to USB Converter
 
  vendor.id		usb 0x0711
+&device.id		usb 0x0260
++device.name		PS/2 Keyboard and Mouse
+
+ vendor.id		usb 0x0711
 &device.id		usb 0x0300
 +device.name		BAY-3U1S1P Parallel Port
 
@@ -38205,32 +39392,52 @@
 +vendor.name		Mad Catz, Inc.
 
  vendor.id		usb 0x0738
+&device.id		usb 0x2215
++device.name		X-55 Rhino Stick
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x2237
++device.name		V.1 Stick
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4506
++device.name		Wireless Controller
+
+ vendor.id		usb 0x0738
 &device.id		usb 0x4507
 +device.name		XBox Device
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4516
-+device.name		XBox Device
++device.name		Control Pad
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4520
-+device.name		XBox Device
++device.name		Control Pad Pro
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4522
++device.name		LumiCON
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4526
-+device.name		XBox Device
++device.name		Control Pad Pro
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4530
++device.name		Universal MC2 Racing Wheel and Pedals
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4536
-+device.name		XBox Device
++device.name		MicroCON
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4540
-+device.name		XBox Device
++device.name		Beat Pad
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4556
-+device.name		XBox Device
++device.name		Lynx Wireless Controller
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4566
@@ -38242,15 +39449,107 @@
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4586
-+device.name		XBox Device
++device.name		MicroCON Wireless Controller
 
  vendor.id		usb 0x0738
 &device.id		usb 0x4588
-+device.name		XBox Device
++device.name		Blaster
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x45ff
++device.name		Beat Pad
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4716
++device.name		Wired Xbox 360 Controller
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4718
++device.name		Street Fighter IV FightStick SE for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4726
++device.name		Xbox 360 Controller
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4728
++device.name		Street Fighter IV FightPad for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4730
++device.name		MC2 Racing Wheel for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4736
++device.name		MicroCON for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4738
++device.name		Street Fighter IV Wired Controller for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4740
++device.name		Beat Pad for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4743
++device.name		Beat Pad Pro
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4758
++device.name		Arcade Game Stick
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x4a01
++device.name		FightStick TE 2 for Xbox One
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x6040
++device.name		Beat Pad Pro
 
  vendor.id		usb 0x0738
 &device.id		usb 0x8818
 +device.name		Street Fighter IV Arcade FightStick (PS3)
+
+ vendor.id		usb 0x0738
+&device.id		usb 0x9871
++device.name		Portable Drum Kit
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xa109
++device.name		S.T.R.I.K.E.7 Keyboard
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xa215
++device.name		X-55 Rhino Throttle
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xb726
++device.name		Modern Warfare 2 Controller for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xb738
++device.name		Marvel VS Capcom 2 TE FightStick for Xbox 360
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xbeef
++device.name		Joytech Neo SE Advanced Gamepad
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xcb02
++device.name		Saitek Cyborg Rumble Pad
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xcb03
++device.name		Saitek P3200 Rumble Pad
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xcb29
++device.name		Saitek Aviator Stick AV8R02
+
+ vendor.id		usb 0x0738
+&device.id		usb 0xf738
++device.name		Super Street Fighter IV FightStick TE S for Xbox 360
 
  vendor.id		usb 0x073a
 +vendor.name		Chaplet Systems, Inc.
@@ -38305,6 +39604,10 @@
 +vendor.name		Eutron S.p.a.
 
  vendor.id		usb 0x073d
+&device.id		usb 0x0000
++device.name		SmartKey
+
+ vendor.id		usb 0x073d
 &device.id		usb 0x0005
 +device.name		Crypto Token
 
@@ -38351,6 +39654,10 @@
 
  vendor.id		usb 0x0746
 +vendor.name		Onkyo Corp.
+
+ vendor.id		usb 0x0746
+&device.id		usb 0x4700
++device.name		Integra MZA-4.7
 
  vendor.id		usb 0x0746
 &device.id		usb 0x5500
@@ -38405,6 +39712,10 @@
 
  vendor.id		usb 0x0757
 +vendor.name		Network Technologies, Inc.
+
+ vendor.id		usb 0x0757
+&device.id		usb 0x0a00
++device.name		SUN Adapter
 
  vendor.id		usb 0x0758
 +vendor.name		Carl Zeiss Microscopy GmbH
@@ -38701,6 +40012,10 @@
 +vendor.name		Jess-Link Products Co., Ltd
 
  vendor.id		usb 0x0766
+&device.id		usb 0x0017
++device.name		Packard Bell Carbon
+
+ vendor.id		usb 0x0766
 &device.id		usb 0x001b
 +device.name		Packard Bell Go
 
@@ -38765,11 +40080,11 @@
 
  vendor.id		usb 0x076b
 &device.id		usb 0x3021
-+device.name		CardMan 3121
++device.name		CardMan 3021 / 3121
 
  vendor.id		usb 0x076b
 &device.id		usb 0x3022
-+device.name		CardMan 3021
++device.name		CardMan 3121 (HID Technologies)
 
  vendor.id		usb 0x076b
 &device.id		usb 0x3610
@@ -38830,6 +40145,14 @@
  vendor.id		usb 0x076c
 +vendor.name		Partner Tech
 
+ vendor.id		usb 0x076c
+&device.id		usb 0x0204
++device.name		CD7220 Communications Port
+
+ vendor.id		usb 0x076c
+&device.id		usb 0x0302
++device.name		RP-600
+
  vendor.id		usb 0x076d
 +vendor.name		Denso Corp.
 
@@ -38872,7 +40195,15 @@
 +vendor.name		Volex, Inc.
 
  vendor.id		usb 0x0779
-+vendor.name		Fairchild Semiconductor
++vendor.name		ON Semiconductor (formerly Fairchild)
+
+ vendor.id		usb 0x0779
+&device.id		usb 0x0133
++device.name		FUSB307B
+
+ vendor.id		usb 0x0779
+&device.id		usb 0x0134
++device.name		FUSB308B
 
  vendor.id		usb 0x077a
 +vendor.name		Sankyo Seiki Mfg. Co., Ltd
@@ -38937,6 +40268,21 @@
  vendor.id		usb 0x077d
 &device.id		usb 0x627a
 +device.name		Radio SHARK
+
+ vendor.id		usb 0x077e
++vendor.name		Softing AG
+
+ vendor.id		usb 0x077e
+&device.id		usb 0x008a
++device.name		NetLink Compact MPI/Profibus adapter
+
+ vendor.id		usb 0x077e
+&device.id		usb 0x0160
++device.name		EDICblue
+
+ vendor.id		usb 0x077e
+&device.id		usb 0x0220
++device.name		VAS5054A
 
  vendor.id		usb 0x077f
 +vendor.name		Well Excellent & Most Corp.
@@ -39081,7 +40427,7 @@
 
  vendor.id		usb 0x0781
 &device.id		usb 0x557d
-+device.name		Cruzer Force (64GB)
++device.name		Cruzer Force
 
  vendor.id		usb 0x0781
 &device.id		usb 0x5580
@@ -39094,6 +40440,18 @@
  vendor.id		usb 0x0781
 &device.id		usb 0x5583
 +device.name		Ultra Fit
+
+ vendor.id		usb 0x0781
+&device.id		usb 0x5588
++device.name		Extreme Pro
+
+ vendor.id		usb 0x0781
+&device.id		usb 0x5589
++device.name		SD8SB8U512G[Extreme 500]
+
+ vendor.id		usb 0x0781
+&device.id		usb 0x558c
++device.name		Extreme Portable SSD
 
  vendor.id		usb 0x0781
 &device.id		usb 0x5590
@@ -39110,6 +40468,10 @@
  vendor.id		usb 0x0781
 &device.id		usb 0x6100
 +device.name		Ultra II SD Plus 2GB
+
+ vendor.id		usb 0x0781
+&device.id		usb 0x6500
++device.name		uSSD 5000
 
  vendor.id		usb 0x0781
 &device.id		usb 0x7100
@@ -39340,12 +40702,24 @@
 +device.name		SDDR-103 MobileMate SD+ Reader
 
  vendor.id		usb 0x0781
+&device.id		usb 0xb2b5
++device.name		SDDR-104 MobileMate SD+ Reader
+
+ vendor.id		usb 0x0781
 &device.id		usb 0xb4b5
 +device.name		SDDR-89 V4 ImageMate 12-in-1 Reader
 
  vendor.id		usb 0x0781
+&device.id		usb 0xb6b7
++device.name		SDDR-99 V4 ImageMate 5-in-1 Reader
+
+ vendor.id		usb 0x0781
 &device.id		usb 0xb6ba
 +device.name		CF SDDR-289
+
+ vendor.id		usb 0x0781
+&device.id		usb 0xcfc9
++device.name		SDDR-489 ImageMate Pro Reader
 
  vendor.id		usb 0x0782
 +vendor.name		Trackerball
@@ -39445,6 +40819,10 @@
  vendor.id		usb 0x0789
 &device.id		usb 0x00b3
 +device.name		DVD Multi-plus unit LDR-H443U2
+
+ vendor.id		usb 0x0789
+&device.id		usb 0x00cc
++device.name		LHD Device
 
  vendor.id		usb 0x0789
 &device.id		usb 0x0105
@@ -39704,11 +41082,11 @@
 
  vendor.id		usb 0x07a6
 &device.id		usb 0x8513
-+device.name		AN8513 Ethernet
++device.name		ADM8513 Pegasus II Ethernet
 
  vendor.id		usb 0x07a6
 &device.id		usb 0x8515
-+device.name		AN8515 Ethernet
++device.name		ADM8515 Pegasus II Ethernet
 
  vendor.id		usb 0x07aa
 +vendor.name		Corega K.K.
@@ -39819,6 +41197,10 @@
  vendor.id		usb 0x07ab
 &device.id		usb 0xfc03
 +device.name		USB2-IDE IDE bridge
+
+ vendor.id		usb 0x07ab
+&device.id		usb 0xfc77
++device.name		Quattro 3.0
 
  vendor.id		usb 0x07ab
 &device.id		usb 0xfcd6
@@ -39953,6 +41335,10 @@
 +device.name		Surfboard 5121 Cable Modem
 
  vendor.id		usb 0x07b2
+&device.id		usb 0x6002
++device.name		MTR7000 Cable Tuning Adapter
+
+ vendor.id		usb 0x07b2
 &device.id		usb 0x7030
 +device.name		WU830G 802.11bg Wireless Adapter [Envara WiND512]
 
@@ -40040,6 +41426,10 @@
 +device.name		OpticPro ST48 Scanner
 
  vendor.id		usb 0x07b3
+&device.id		usb 0x0807
++device.name		OpticFilm 7200 scanner
+
+ vendor.id		usb 0x07b3
 &device.id		usb 0x0900
 +device.name		OpticBook 3600 Scanner
 
@@ -40090,6 +41480,10 @@
  vendor.id		usb 0x07b3
 &device.id		usb 0x1301
 +device.name		OpticBook 4800 Scanner
+
+ vendor.id		usb 0x07b3
+&device.id		usb 0x130f
++device.name		Bookreader v200
 
  vendor.id		usb 0x07b4
 +vendor.name		Olympus Optical Co., Ltd
@@ -40189,6 +41583,10 @@
  vendor.id		usb 0x07b4
 &device.id		usb 0x0280
 +device.name		m:robe 100
+
+ vendor.id		usb 0x07b4
+&device.id		usb 0x0295
++device.name		Digital Voice Recorder VN-541PC
 
  vendor.id		usb 0x07b5
 +vendor.name		Mega World International, Ltd
@@ -40443,6 +41841,10 @@
  vendor.id		usb 0x07be
 +vendor.name		Veridicom
 
+ vendor.id		usb 0x07be
+&device.id		usb 0x1935
++device.name		Elektron Music Machines
+
  vendor.id		usb 0x07c0
 +vendor.name		Code Mercenaries Hard- und Software GmbH
 
@@ -40669,6 +42071,10 @@
  vendor.id		usb 0x07ca
 &device.id		usb 0x1830
 +device.name		AVerTV Volar Video Capture (H830)
+
+ vendor.id		usb 0x07ca
+&device.id		usb 0x1871
++device.name		TD310 DVB-T/T2/C dongle
 
  vendor.id		usb 0x07ca
 &device.id		usb 0x3835
@@ -40963,6 +42369,21 @@
 &device.id		usb 0x0001
 +device.name		USBuart Serial Port
 
+ vendor.id		usb 0x07ce
++vendor.name		Nidec Copal
+
+ vendor.id		usb 0x07ce
+&device.id		usb 0xc007
++device.name		DPB-4000
+
+ vendor.id		usb 0x07ce
+&device.id		usb 0xc009
++device.name		DPB-6000
+
+ vendor.id		usb 0x07ce
+&device.id		usb 0xc010
++device.name		CPB-7000
+
  vendor.id		usb 0x07cf
 +vendor.name		Casio Computer Co., Ltd
 
@@ -41045,6 +42466,10 @@
  vendor.id		usb 0x07cf
 &device.id		usb 0x6802
 +device.name		MIDI Keyboard
+
+ vendor.id		usb 0x07cf
+&device.id		usb 0x6803
++device.name		CTK-3500 (MIDI keyboard)
 
  vendor.id		usb 0x07d0
 +vendor.name		Dazzle
@@ -41464,12 +42889,24 @@
 &device.id		usb 0x0002
 +device.name		MOTU Audio for 64 bit
 
+ vendor.id		usb 0x07fd
+&device.id		usb 0x0004
++device.name		MicroBook
+
+ vendor.id		usb 0x07fd
+&device.id		usb 0x0008
++device.name		M Series
+
  vendor.id		usb 0x07ff
 +vendor.name		Unknown
 
  vendor.id		usb 0x07ff
 &device.id		usb 0x00ff
 +device.name		Portable Hard Drive
+
+ vendor.id		usb 0x07ff
+&device.id		usb 0xffff
++device.name		Mad Catz Gamepad
 
  vendor.id		usb 0x0801
 +vendor.name		MagTek
@@ -41647,6 +43084,13 @@
  vendor.id		usb 0x081e
 &device.id		usb 0xdf00
 +device.name		Handheld
+
+ vendor.id		usb 0x081f
++vendor.name		Manta
+
+ vendor.id		usb 0x081f
+&device.id		usb 0xe401
++device.name		MM812
 
  vendor.id		usb 0x0822
 +vendor.name		Reudo Corp.
@@ -41948,6 +43392,10 @@
 +device.name		6500 Document Camera
 
  vendor.id		usb 0x0839
+&device.id		usb 0x103f
++device.name		Digimax S500
+
+ vendor.id		usb 0x0839
 &device.id		usb 0x1058
 +device.name		S730 Camera
 
@@ -42210,6 +43658,10 @@
 +device.name		WPN111 802.11g Wireless Adapter [Atheros AR5523]
 
  vendor.id		usb 0x0846
+&device.id		usb 0x68e1
++device.name		LB1120-100NAS
+
+ vendor.id		usb 0x0846
 &device.id		usb 0x6a00
 +device.name		WG111v2 54 Mbps Wireless [RealTek RTL8187L]
 
@@ -42284,6 +43736,10 @@
  vendor.id		usb 0x0846
 &device.id		usb 0x9052
 +device.name		A6100 AC600 DB Wireless Adapter [Realtek RTL8811AU]
+
+ vendor.id		usb 0x0846
+&device.id		usb 0x9054
++device.name		Nighthawk A7000 802.11ac Wireless Adapter AC1900 [Realtek 8814AU]
 
  vendor.id		usb 0x0846
 &device.id		usb 0xa001
@@ -42373,6 +43829,14 @@
  vendor.id		usb 0x0853
 &device.id		usb 0x0100
 +device.name		HHKB Professional
+
+ vendor.id		usb 0x0853
+&device.id		usb 0x0119
++device.name		RealForce 105UB
+
+ vendor.id		usb 0x0853
+&device.id		usb 0x0200
++device.name		RealForce Compact Keyboard
 
  vendor.id		usb 0x0854
 +vendor.name		ActiveWire, Inc.
@@ -44193,6 +45657,10 @@
 +vendor.name		Philips Speech Processing
 
  vendor.id		usb 0x0911
+&device.id		usb 0x0c1c
++device.name		SpeechMike III
+
+ vendor.id		usb 0x0911
 &device.id		usb 0x149a
 +device.name		SpeechMike II Pro Plus LFH5276
 
@@ -44404,6 +45872,10 @@
 +device.name		Edge 800
 
  vendor.id		usb 0x091e
+&device.id		usb 0x2518
++device.name		eTrex 10
+
+ vendor.id		usb 0x091e
 &device.id		usb 0x2519
 +device.name		eTrex 30
 
@@ -44420,12 +45892,28 @@
 +device.name		Nuvi 2505LM
 
  vendor.id		usb 0x091e
+&device.id		usb 0x2613
++device.name		Edge 200 TWN
+
+ vendor.id		usb 0x091e
 &device.id		usb 0x26a1
 +device.name		Nuvi 55
 
  vendor.id		usb 0x091e
+&device.id		usb 0x2802
++device.name		fenix 3
+
+ vendor.id		usb 0x091e
+&device.id		usb 0x28db
++device.name		Drive 5
+
+ vendor.id		usb 0x091e
 &device.id		usb 0x47fb
 +device.name		nuviCam
+
+ vendor.id		usb 0x091e
+&device.id		usb 0x4cdb
++device.name		Fenix 6
 
  vendor.id		usb 0x0920
 +vendor.name		Echelon Co.
@@ -44453,6 +45941,10 @@
 +device.name		LabelWriter 310
 
  vendor.id		usb 0x0922
+&device.id		usb 0x0013
++device.name		LabelManager 400
+
+ vendor.id		usb 0x0922
 &device.id		usb 0x0019
 +device.name		LabelWriter 400
 
@@ -44465,12 +45957,24 @@
 +device.name		LabelWriter 450
 
  vendor.id		usb 0x0922
+&device.id		usb 0x0400
++device.name		LabelWriter SE450
+
+ vendor.id		usb 0x0922
 &device.id		usb 0x1001
 +device.name		LabelManager PnP
 
  vendor.id		usb 0x0922
+&device.id		usb 0x8003
++device.name		M10 Digital Postal Scale
+
+ vendor.id		usb 0x0922
 &device.id		usb 0x8004
 +device.name		M25 Digital Postal Scale
+
+ vendor.id		usb 0x0922
+&device.id		usb 0x8009
++device.name		S250 Digital Postal Scale
 
  vendor.id		usb 0x0923
 +vendor.name		IC Media Corp.
@@ -44542,6 +46046,14 @@
 +device.name		Wii Classic Controller Adapter
 
  vendor.id		usb 0x0925
+&device.id		usb 0x1031
++device.name		WiseGroup Ltd, Gameport Controller
+
+ vendor.id		usb 0x0925
+&device.id		usb 0x1700
++device.name		PS/SS/N64 Joypad
+
+ vendor.id		usb 0x0925
 &device.id		usb 0x3881
 +device.name		Saleae Logic
 
@@ -44583,6 +46095,10 @@
 
  vendor.id		usb 0x092b
 +vendor.name		Sena Technologies, Inc.
+
+ vendor.id		usb 0x092b
+&device.id		usb 0x4210
++device.name		20S - Bluetooth Motorcycle headset & universal intercom
 
  vendor.id		usb 0x092f
 +vendor.name		Northern Embedded Science/CAVNEX
@@ -44692,7 +46208,7 @@
 
  vendor.id		usb 0x0930
 &device.id		usb 0x0708
-+device.name		Pocket PC e350 Series
++device.name		Pocket PC e350 Series
 
  vendor.id		usb 0x0930
 &device.id		usb 0x0709
@@ -44769,6 +46285,10 @@
  vendor.id		usb 0x0930
 &device.id		usb 0x1400
 +device.name		Memory Stick 2GB
+
+ vendor.id		usb 0x0930
+&device.id		usb 0x140b
++device.name		Memory Stick 64GB
 
  vendor.id		usb 0x0930
 &device.id		usb 0x642f
@@ -44934,6 +46454,10 @@
 &device.id		usb 0x6545
 +device.name		Kingston DataTraveler 102/2.0 / HEMA Flash Drive 2 GB / PNY Attache 4GB Stick
 
+ vendor.id		usb 0x0930
+&device.id		usb 0xa002
++device.name		SunplusIT SATA bridge
+
  vendor.id		usb 0x0931
 +vendor.name		Harmonic Data Systems, Ltd
 
@@ -45015,6 +46539,10 @@
  vendor.id		usb 0x0939
 &device.id		usb 0x0b15
 +device.name		Toshiba Stor.E Alu 2
+
+ vendor.id		usb 0x0939
+&device.id		usb 0x0b16
++device.name		Toshiba StorE HDD
 
  vendor.id		usb 0x093a
 +vendor.name		Pixart Imaging, Inc.
@@ -45103,6 +46631,14 @@
 &device.id		usb 0x2624
 +device.name		Webcam
 
+ vendor.id		usb 0x093a
+&device.id		usb 0x2628
++device.name		Webcam Genius iLook 300
+
+ vendor.id		usb 0x093a
+&device.id		usb 0x2700
++device.name		GE 1.3 MP MiniCam Pro
+
  vendor.id		usb 0x093b
 +vendor.name		Plextor Corp.
 
@@ -45113,6 +46649,10 @@
  vendor.id		usb 0x093b
 &device.id		usb 0x0011
 +device.name		PlexWriter 40/12/40U
+
+ vendor.id		usb 0x093b
+&device.id		usb 0x0012
++device.name		PlexWriter 48/24/48U
 
  vendor.id		usb 0x093b
 &device.id		usb 0x0041
@@ -45272,6 +46812,10 @@
 +device.name		KNU101TX 100baseTX Ethernet
 
  vendor.id		usb 0x0951
+&device.id		usb 0x1539
++device.name		Iron Key D300 (Virtual CD-ROM and USB Stick)
+
+ vendor.id		usb 0x0951
 &device.id		usb 0x1600
 +device.name		DataTraveler II Pen Drive
 
@@ -45369,11 +46913,11 @@
 
  vendor.id		usb 0x0951
 &device.id		usb 0x1665
-+device.name		Digital DataTraveler SE9 64GB
++device.name		Digital DataTraveler SE9
 
  vendor.id		usb 0x0951
 &device.id		usb 0x1666
-+device.name		DataTraveler 100 G3/G4/SE9 G2
++device.name		DataTraveler 100 G3/G4/SE9 G2/50
 
  vendor.id		usb 0x0951
 &device.id		usb 0x1689
@@ -45388,14 +46932,42 @@
 +device.name		DT Elite 3.0
 
  vendor.id		usb 0x0951
+&device.id		usb 0x16a4
++device.name		HyperX 7.1 Audio
+
+ vendor.id		usb 0x0951
 &device.id		usb 0x16b3
 +device.name		HyperX Savage
+
+ vendor.id		usb 0x0951
+&device.id		usb 0x16d2
++device.name		HX-KB4BL1-US [HYPERX Alloy FPS Pro]
+
+ vendor.id		usb 0x0951
+&device.id		usb 0x16d4
++device.name		HyperX SavageEXO [0382]
+
+ vendor.id		usb 0x0951
+&device.id		usb 0x16d5
++device.name		DataTraveler Elite G2
+
+ vendor.id		usb 0x0951
+&device.id		usb 0x16df
++device.name		HyperX QuadCast
+
+ vendor.id		usb 0x0951
+&device.id		usb 0x16e4
++device.name		HyperX Pulsefire Raid
 
  vendor.id		usb 0x0954
 +vendor.name		RPM Systems Corp.
 
  vendor.id		usb 0x0955
 +vendor.name		NVIDIA Corp.
+
+ vendor.id		usb 0x0955
+&device.id		usb 0x7005
++device.name		Bootloader
 
  vendor.id		usb 0x0955
 &device.id		usb 0x7018
@@ -45426,12 +46998,20 @@
 +device.name		SHIELD Controller
 
  vendor.id		usb 0x0955
+&device.id		usb 0x7321
++device.name		Switch [Tegra Erista] recovery mode
+
+ vendor.id		usb 0x0955
 &device.id		usb 0x7721
-+device.name		T210 [Tegra Erista]
++device.name		T210 [TX1 Tegra Erista] recovery mode
 
  vendor.id		usb 0x0955
 &device.id		usb 0x7820
 +device.name		T20 [Tegra 2] recovery mode
+
+ vendor.id		usb 0x0955
+&device.id		usb 0x7c18
++device.name		T186 [TX2 Tegra Parker] recovery mode
 
  vendor.id		usb 0x0955
 &device.id		usb 0xb400
@@ -45496,6 +47076,10 @@
 +device.name		Test and Measurement Device (IVI)
 
  vendor.id		usb 0x0957
+&device.id		usb 0x1f01
++device.name		N5181A MXG Analog Signal Generator
+
+ vendor.id		usb 0x0957
 &device.id		usb 0x2918
 +device.name		U2702A oscilloscope
 
@@ -45554,6 +47138,10 @@
 +device.name		ePass2000
 
  vendor.id		usb 0x096e
+&device.id		usb 0x0006
++device.name		HID Dongle (for OEMs - manufacturer string is "OEM")
+
+ vendor.id		usb 0x096e
 &device.id		usb 0x0120
 +device.name		Microcosm Ltd Dinkey
 
@@ -45568,6 +47156,14 @@
  vendor.id		usb 0x096e
 &device.id		usb 0x0401
 +device.name		ePass3000
+
+ vendor.id		usb 0x096e
+&device.id		usb 0x0405
++device.name		Zzkey Dongle
+
+ vendor.id		usb 0x096e
+&device.id		usb 0x0608
++device.name		SC Reader KP382
 
  vendor.id		usb 0x096e
 &device.id		usb 0x0702
@@ -45689,6 +47285,10 @@
 &device.id		usb 0x0200
 +device.name		Hard Drive Storage (TPP)
 
+ vendor.id		usb 0x0984
+&device.id		usb 0x1407
++device.name		Secure Key 3.0
+
  vendor.id		usb 0x0985
 +vendor.name		cab Produkttechnik GmbH & Co KG
 
@@ -45737,8 +47337,16 @@
 +device.name		Sanwa Supply Inc. Small Keyboard
 
  vendor.id		usb 0x099a
+&device.id		usb 0x2620
++device.name		Graphics tablet [Polostar PT1001, Zeniq PT1001, Leogics PT1001]
+
+ vendor.id		usb 0x099a
 &device.id		usb 0x610c
 +device.name		EL-610 Super Mini Electron luminescent Keyboard
+
+ vendor.id		usb 0x099a
+&device.id		usb 0x6330
++device.name		SANWA Supply Inc. Slim Keyboard
 
  vendor.id		usb 0x099a
 &device.id		usb 0x713a
@@ -45792,6 +47400,17 @@
 
  vendor.id		usb 0x09ae
 +vendor.name		Tripp Lite
+
+ vendor.id		usb 0x09ae
+&device.id		usb 0x0002
++device.name		Any Device (see discussion)
+
+ vendor.id		usb 0x09b0
++vendor.name		Fargo
+
+ vendor.id		usb 0x09b0
+&device.id		usb 0x2400
++device.name		HDP5000
 
  vendor.id		usb 0x09b2
 +vendor.name		Franklin Electronic Publishers, Inc.
@@ -46010,6 +47629,10 @@
 &device.id		usb 0x1996
 +device.name		FLIR ONE Camera
 
+ vendor.id		usb 0x09cb
+&device.id		usb 0x4007
++device.name		Breach
+
  vendor.id		usb 0x09cc
 +vendor.name		Workbit Corp.
 
@@ -46045,17 +47668,21 @@
 
  vendor.id		usb 0x09d3
 &device.id		usb 0x000b
-+device.name		Bluetooth Adapter class 1 [BlueLight]
++device.name		Bluetooth Adapter class 2
 
  vendor.id		usb 0x09d7
-+vendor.name		NovAtel Inc.
++vendor.name		Hexagon NovAtel Inc.
 
  vendor.id		usb 0x09d7
 &device.id		usb 0x0100
-+device.name		NovAtel FlexPack GPS receiver
++device.name		GPS/GNSS/SPAN sensor
 
  vendor.id		usb 0x09d8
-+vendor.name		ELATEC
++vendor.name		ELATEC GmbH
+
+ vendor.id		usb 0x09d8
+&device.id		usb 0x0320
++device.name		TWN3 Multi125
 
  vendor.id		usb 0x09d8
 &device.id		usb 0x0406
@@ -46108,8 +47735,20 @@
 +device.name		Wireless Mouse (Battery Free)
 
  vendor.id		usb 0x09da
+&device.id		usb 0x09da
++device.name		Bloody V8 Mouse
+
+ vendor.id		usb 0x09da
 &device.id		usb 0x1068
 +device.name		Bloody A90 Mouse
+
+ vendor.id		usb 0x09da
+&device.id		usb 0x112c
++device.name		Bloody V5 Mouse
+
+ vendor.id		usb 0x09da
+&device.id		usb 0x3a60
++device.name		Bloody V8M Core 2 Mouse
 
  vendor.id		usb 0x09da
 &device.id		usb 0x8090
@@ -46126,6 +47765,10 @@
  vendor.id		usb 0x09da
 &device.id		usb 0x9090
 +device.name		XL-730K / XL-750BK / XL-755BK Mice
+
+ vendor.id		usb 0x09da
+&device.id		usb 0xf613
++device.name		Bloody V7M Mouse
 
  vendor.id		usb 0x09db
 +vendor.name		Measurement Computing Corp.
@@ -46181,6 +47824,10 @@
 
  vendor.id		usb 0x09e8
 +vendor.name		AKAI  Professional M.I. Corp.
+
+ vendor.id		usb 0x09e8
+&device.id		usb 0x0045
++device.name		MPK Mini Mk II MIDI Controller
 
  vendor.id		usb 0x09e8
 &device.id		usb 0x0062
@@ -46707,6 +48354,10 @@
  vendor.id		usb 0x0a4a
 +vendor.name		Ploytec GmbH
 
+ vendor.id		usb 0x0a4a
+&device.id		usb 0xa400
++device.name		AUDIO JUNCTION 2.0
+
  vendor.id		usb 0x0a4b
 +vendor.name		Fujitsu Media Devices, Ltd
 
@@ -46890,6 +48541,10 @@
  vendor.id		usb 0x0a5c
 &device.id		usb 0x0201
 +device.name		iLine10(tm) Network Adapter
+
+ vendor.id		usb 0x0a5c
+&device.id		usb 0x0bdc
++device.name		802.11a/b/g/n/ac Wireless Adapter
 
  vendor.id		usb 0x0a5c
 &device.id		usb 0x2000
@@ -47104,6 +48759,10 @@
 +device.name		BCM20702A0 Bluetooth 4.0
 
  vendor.id		usb 0x0a5c
+&device.id		usb 0x21ec
++device.name		BCM20702A0 Bluetooth 4.0
+
+ vendor.id		usb 0x0a5c
 &device.id		usb 0x21f1
 +device.name		HP Portable Bumble Bee
 
@@ -47198,8 +48857,20 @@
 +device.name		LP2844 Printer
 
  vendor.id		usb 0x0a5f
+&device.id		usb 0x0050
++device.name		P120i / WM120i
+
+ vendor.id		usb 0x0a5f
+&device.id		usb 0x0080
++device.name		GK420d Label Printer
+
+ vendor.id		usb 0x0a5f
 &device.id		usb 0x0081
 +device.name		GK420t Label Printer
+
+ vendor.id		usb 0x0a5f
+&device.id		usb 0x0084
++device.name		GX420d Desktop Label Printer
 
  vendor.id		usb 0x0a5f
 &device.id		usb 0x008b
@@ -47212,6 +48883,10 @@
  vendor.id		usb 0x0a5f
 &device.id		usb 0x00d1
 +device.name		Zebra GC420d Label Printer
+
+ vendor.id		usb 0x0a5f
+&device.id		usb 0x0110
++device.name		ZD500 Desktop Label Printer
 
  vendor.id		usb 0x0a5f
 &device.id		usb 0x930a
@@ -47325,6 +49000,10 @@
  vendor.id		usb 0x0a82
 &device.id		usb 0x4600
 +device.name		TravelScan 460/464
+
+ vendor.id		usb 0x0a82
+&device.id		usb 0x6605
++device.name		ScanShell 800N
 
  vendor.id		usb 0x0a83
 +vendor.name		NextComm, Inc.
@@ -47995,6 +49674,10 @@
 +device.name		Webcam
 
  vendor.id		usb 0x0ac8
+&device.id		usb 0xc412
++device.name		Lenovo IdeaCentre Web Camera
+
+ vendor.id		usb 0x0ac8
 &device.id		usb 0xc429
 +device.name		Lenovo ThinkCentre Web Camera
 
@@ -48502,6 +50185,10 @@
 +device.name		WL-167G v3 802.11n Adapter [Realtek RTL8188SU]
 
  vendor.id		usb 0x0b05
+&device.id		usb 0x179c
++device.name		Bluetooth Adapter
+
+ vendor.id		usb 0x0b05
 &device.id		usb 0x179d
 +device.name		USB-N53 802.11abgn Network Adapter [Ralink RT3572]
 
@@ -48528,6 +50215,10 @@
  vendor.id		usb 0x0b05
 &device.id		usb 0x17ba
 +device.name		N10 Nano 802.11n Network Adapter [Realtek RTL8192CU]
+
+ vendor.id		usb 0x0b05
+&device.id		usb 0x17c2
++device.name		ROG Spitfire
 
  vendor.id		usb 0x0b05
 &device.id		usb 0x17c7
@@ -48566,6 +50257,10 @@
 +device.name		USB-AC55 802.11a/b/g/n/ac Wireless Adapter [MediaTek MT7612U]
 
  vendor.id		usb 0x0b05
+&device.id		usb 0x17f5
++device.name		Xonar U5 sound card
+
+ vendor.id		usb 0x0b05
 &device.id		usb 0x180a
 +device.name		Broadcom BCM20702 Single-Chip Bluetooth 4.0 + LE
 
@@ -48576,6 +50271,10 @@
  vendor.id		usb 0x0b05
 &device.id		usb 0x1825
 +device.name		Qualcomm Bluetooth 4.1
+
+ vendor.id		usb 0x0b05
+&device.id		usb 0x18f0
++device.name		Realtek 8188EUS [USB-N10 Nano]
 
  vendor.id		usb 0x0b05
 &device.id		usb 0x4c80
@@ -48698,6 +50397,22 @@
 +vendor.name		GN Netcom
 
  vendor.id		usb 0x0b0e
+&device.id		usb 0x0305
++device.name		Jabra EVOLVE Link MS
+
+ vendor.id		usb 0x0b0e
+&device.id		usb 0x0311
++device.name		Jabra EVOLVE 65
+
+ vendor.id		usb 0x0b0e
+&device.id		usb 0x0312
++device.name		enc060:Buttons Volume up/down/mute + phone [Jabra]
+
+ vendor.id		usb 0x0b0e
+&device.id		usb 0x0343
++device.name		Jabra UC VOICE 150a
+
+ vendor.id		usb 0x0b0e
 &device.id		usb 0x0348
 +device.name		Jabra UC VOICE 550a MS
 
@@ -48706,12 +50421,24 @@
 +device.name		Jabra UC Voice 750 MS
 
  vendor.id		usb 0x0b0e
+&device.id		usb 0x034d
++device.name		Jabra UC VOICE 750
+
+ vendor.id		usb 0x0b0e
 &device.id		usb 0x0410
 +device.name		Jabra SPEAK 410
 
  vendor.id		usb 0x0b0e
 &device.id		usb 0x0420
 +device.name		Jabra SPEAK 510
+
+ vendor.id		usb 0x0b0e
+&device.id		usb 0x0422
++device.name		Jabra SPEAK 510 USB
+
+ vendor.id		usb 0x0b0e
+&device.id		usb 0x0933
++device.name		Jabra Freeway
 
  vendor.id		usb 0x0b0e
 &device.id		usb 0x094d
@@ -48738,6 +50465,14 @@
 +device.name		GN 2000 Stereo Corded Headset
 
  vendor.id		usb 0x0b0e
+&device.id		usb 0x2456
++device.name		Jabra SPEAK 810
+
+ vendor.id		usb 0x0b0e
+&device.id		usb 0x245e
++device.name		Jabra Link 370
+
+ vendor.id		usb 0x0b0e
 &device.id		usb 0x620c
 +device.name		Jabra BT620s
 
@@ -48745,8 +50480,20 @@
 &device.id		usb 0x9330
 +device.name		Jabra GN9330 Headset
 
+ vendor.id		usb 0x0b0e
+&device.id		usb 0xa346
++device.name		Jabra Engage 75 Stereo
+
+ vendor.id		usb 0x0b0e
+&device.id		usb 0xa50a
++device.name		Alienware Wireless Gaming Headset AW988
+
  vendor.id		usb 0x0b0f
 +vendor.name		AVID Technology
+
+ vendor.id		usb 0x0b0f
+&device.id		usb 0x0400
++device.name		DNxID
 
  vendor.id		usb 0x0b10
 +vendor.name		Pcally
@@ -48813,6 +50560,18 @@
  vendor.id		usb 0x0b33
 &device.id		usb 0x0700
 +device.name		RollerMouse Pro
+
+ vendor.id		usb 0x0b33
+&device.id		usb 0x08a0
++device.name		Perfit Mouse
+
+ vendor.id		usb 0x0b33
+&device.id		usb 0x1000
++device.name		RollerMouse Red
+
+ vendor.id		usb 0x0b33
+&device.id		usb 0x1010
++device.name		Vidamic Technomouse IQ
 
  vendor.id		usb 0x0b37
 +vendor.name		Hitachi ULSI Systems Co., Ltd
@@ -49064,6 +50823,10 @@
 &device.id		usb 0x110a
 +device.name		Graphtec CC200-20
 
+ vendor.id		usb 0x0b4d
+&device.id		usb 0x1123
++device.name		Electronic Cutting Tool [Silhouette Portrait]
+
  vendor.id		usb 0x0b4e
 +vendor.name		Musical Electronics, Ltd
 
@@ -49313,6 +51076,10 @@
 +device.name		AX88179 Gigabit Ethernet
 
  vendor.id		usb 0x0b95
+&device.id		usb 0x6802
++device.name		AX68002 KVM Switch SoC
+
+ vendor.id		usb 0x0b95
 &device.id		usb 0x7720
 +device.name		AX88772
 
@@ -49486,6 +51253,10 @@
  vendor.id		usb 0x0bb4
 &device.id		usb 0x00cf
 +device.name		SPV C500 Smart Phone
+
+ vendor.id		usb 0x0bb4
+&device.id		usb 0x0306
++device.name		Vive Hub Bluetooth 4.1 (Broadcom BCM920703)
 
  vendor.id		usb 0x0bb4
 &device.id		usb 0x0a01
@@ -50161,7 +51932,7 @@
 
  vendor.id		usb 0x0bb4
 &device.id		usb 0x0c01
-+device.name		Dream / ADP1 / G1 / Magic / Tattoo
++device.name		Dream / ADP1 / G1 / Magic / Tattoo / FP1
 
  vendor.id		usb 0x0bb4
 &device.id		usb 0x0c02
@@ -50224,6 +51995,10 @@
 +device.name		Android Phone [Evo Shift 4G]
 
  vendor.id		usb 0x0bb4
+&device.id		usb 0x0cab
++device.name		Desire / Desire HD / Hero / Thunderbolt (HTC Sync Mode)
+
+ vendor.id		usb 0x0bb4
 &device.id		usb 0x0cae
 +device.name		T-Mobile MyTouch 4G Slide [Doubleshot]
 
@@ -50252,6 +52027,10 @@
 +device.name		Remote NDIS based Device
 
  vendor.id		usb 0x0bb4
+&device.id		usb 0x0ff0
++device.name		One Mini (M4)
+
+ vendor.id		usb 0x0bb4
 &device.id		usb 0x0ff8
 +device.name		Desire HD (Tethering Mode)
 
@@ -50269,11 +52048,23 @@
 
  vendor.id		usb 0x0bb4
 &device.id		usb 0x2008
-+device.name		Android Phone via MTP [Wiko Cink Peax 2]
++device.name		Android Phone via MTP [MT65xx]
 
  vendor.id		usb 0x0bb4
 &device.id		usb 0x200b
 +device.name		Android Phone via PTP [Wiko Cink Peax 2]
+
+ vendor.id		usb 0x0bb4
+&device.id		usb 0x2134
++device.name		Vive Hub (SMSC USB2137B)
+
+ vendor.id		usb 0x0bb4
+&device.id		usb 0x2744
++device.name		Vive Hub (HTC CB USB2)
+
+ vendor.id		usb 0x0bb4
+&device.id		usb 0x2c87
++device.name		Vive
 
  vendor.id		usb 0x0bb5
 +vendor.name		Murata Manufacturing Co., Ltd
@@ -50340,6 +52131,10 @@
 +device.name		Expansion Portable
 
  vendor.id		usb 0x0bc2
+&device.id		usb 0x231c
++device.name		Expansion Portable
+
+ vendor.id		usb 0x0bc2
 &device.id		usb 0x2320
 +device.name		USB 3.0 bridge [Portable Expansion Drive]
 
@@ -50372,6 +52167,10 @@
 +device.name		SRD00F2 Expansion Desktop Drive (STBV)
 
  vendor.id		usb 0x0bc2
+&device.id		usb 0x331a
++device.name		Desktop HDD 5TB (ST5000DM000)
+
+ vendor.id		usb 0x0bc2
 &device.id		usb 0x3320
 +device.name		SRD00F2 [Expansion Desktop Drive]
 
@@ -50380,8 +52179,16 @@
 +device.name		SRD0NF2 [Expansion Desktop Drive]
 
  vendor.id		usb 0x0bc2
+&device.id		usb 0x3323
++device.name		Seagate RSS LLC
+
+ vendor.id		usb 0x0bc2
 &device.id		usb 0x3332
 +device.name		Expansion
+
+ vendor.id		usb 0x0bc2
+&device.id		usb 0x3343
++device.name		desktop drive stgy8000400
 
  vendor.id		usb 0x0bc2
 &device.id		usb 0x5020
@@ -50432,6 +52239,10 @@
 +device.name		Maxtor D3 Station 5TB
 
  vendor.id		usb 0x0bc2
+&device.id		usb 0x61b5
++device.name		Maxtor HX-M201TCB [M3 Portable 2TB]
+
+ vendor.id		usb 0x0bc2
 &device.id		usb 0x61b6
 +device.name		Maxtor HX-M101TCB/GM [M3 Portable 1TB]
 
@@ -50450,6 +52261,10 @@
  vendor.id		usb 0x0bc2
 &device.id		usb 0xa0a4
 +device.name		Backup Plus Desktop Drive
+
+ vendor.id		usb 0x0bc2
+&device.id		usb 0xaa14
++device.name		STJ4000400 [Seagate Basic Portable Drive 4TB]
 
  vendor.id		usb 0x0bc2
 &device.id		usb 0xab00
@@ -50476,6 +52291,14 @@
 +device.name		Backup Plus Slim Portable Drive 1 TB
 
  vendor.id		usb 0x0bc2
+&device.id		usb 0xab28
++device.name		Seagate Backup Plus Portable 5TB SRD00F1
+
+ vendor.id		usb 0x0bc2
+&device.id		usb 0xab2d
++device.name		SRD00F1 [Backup Plus Ultra Slim]
+
+ vendor.id		usb 0x0bc2
 &device.id		usb 0xab31
 +device.name		Backup Plus Desktop Drive (5TB)
 
@@ -50485,7 +52308,15 @@
 
  vendor.id		usb 0x0bc2
 &device.id		usb 0xab38
++device.name		Backup Plus Hub (Mass Storage)
+
+ vendor.id		usb 0x0bc2
+&device.id		usb 0xab44
 +device.name		Backup Plus Hub
+
+ vendor.id		usb 0x0bc2
+&device.id		usb 0xac20
++device.name		Backup Plus Slim 2TB
 
  vendor.id		usb 0x0bc3
 +vendor.name		IPWireless, Inc.
@@ -50725,12 +52556,32 @@
 +device.name		Card Reader
 
  vendor.id		usb 0x0bda
+&device.id		usb 0x0316
++device.name		Card Reader
+
+ vendor.id		usb 0x0bda
 &device.id		usb 0x0326
 +device.name		Card reader
 
  vendor.id		usb 0x0bda
+&device.id		usb 0x0411
++device.name		Hub
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x0811
++device.name		Realtek 8812AU/8821AU 802.11ac WLAN Adapter [USB Wireless Dual-Band Adapter 2.4/5Ghz]
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x0821
++device.name		RTL8821A Bluetooth
+
+ vendor.id		usb 0x0bda
 &device.id		usb 0x1724
 +device.name		RTL8723AU 802.11n WLAN Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x1a2b
++device.name		RTL8188GU 802.11n WLAN Adapter (Driver CDROM Mode)
 
  vendor.id		usb 0x0bda
 &device.id		usb 0x2831
@@ -50749,6 +52600,14 @@
 +device.name		RTL 8153 USB 3.0 hub with gigabit ethernet
 
  vendor.id		usb 0x0bda
+&device.id		usb 0x5411
++device.name		RTS5411 Hub
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x568c
++device.name		Integrated Webcam HD
+
+ vendor.id		usb 0x0bda
 &device.id		usb 0x570c
 +device.name		Asus laptop camera
 
@@ -50765,12 +52624,28 @@
 +device.name		HP "Truevision HD" laptop camera
 
  vendor.id		usb 0x0bda
+&device.id		usb 0x5776
++device.name		HP Truevision HD integrated webcam
+
+ vendor.id		usb 0x0bda
 &device.id		usb 0x57b3
 +device.name		Acer 640 × 480 laptop camera
 
  vendor.id		usb 0x0bda
+&device.id		usb 0x57cc
++device.name		HD Webcam - Realtek Semiconductor
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x57cf
++device.name		HD WebCam
+
+ vendor.id		usb 0x0bda
 &device.id		usb 0x57da
 +device.name		Built-In Video Camera
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x58c2
++device.name		Integrated Webcam HD
 
  vendor.id		usb 0x0bda
 &device.id		usb 0x58c8
@@ -50853,6 +52728,10 @@
 +device.name		RTL8187SU 802.11g WLAN Adapter
 
  vendor.id		usb 0x0bda
+&device.id		usb 0x8723
++device.name		RTL8723A Bluetooth
+
+ vendor.id		usb 0x0bda
 &device.id		usb 0x8812
 +device.name		RTL8812AU 802.11a/b/g/n/ac 2T2R DB WLAN Adapter
 
@@ -50861,8 +52740,64 @@
 +device.name		RTL8814AU 802.11a/b/g/n/ac Wireless Adapter
 
  vendor.id		usb 0x0bda
+&device.id		usb 0x881a
++device.name		RTL8812AU-VS 802.11a/b/g/n/ac 2T2R DB WLAN Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x8821
++device.name		RTL8821A Bluetooth
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0x9210
++device.name		RTL9210 M.2 NVME Adapter
+
+ vendor.id		usb 0x0bda
 &device.id		usb 0xa811
 +device.name		RTL8811AU 802.11a/b/g/n/ac WLAN Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb009
++device.name		Realtek Bluetooth 4.2 Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb00a
++device.name		Realtek Bluetooth 4.2 Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb00b
++device.name		Realtek Bluetooth 4.2 Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb023
++device.name		RTL8822BE Bluetooth 4.2 Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb711
++device.name		RTL8188GU 802.11n WLAN Adapter (After Modeswitch)
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb720
++device.name		RTL8723BU 802.11b/g/n WLAN Adapter
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb723
++device.name		RTL8723B Bluetooth
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb728
++device.name		RTL8723B Bluetooth
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb72a
++device.name		RTL8723B Bluetooth
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xb812
++device.name		RTL88x2bu [AC1200 Techkey]
+
+ vendor.id		usb 0x0bda
+&device.id		usb 0xf179
++device.name		RTL8188FTV 802.11b/g/n 1T1R 2.4G WLAN Adapter
 
  vendor.id		usb 0x0bdb
 +vendor.name		Ericsson Business Mobile Networks BV
@@ -50913,7 +52848,7 @@
 
  vendor.id		usb 0x0bdb
 &device.id		usb 0x1926
-+device.name		H5321 gw Mobile Broadband Driver
++device.name		H5321 gw Mobile Broadband Module
 
  vendor.id		usb 0x0bdc
 +vendor.name		Y Media Corp.
@@ -50955,6 +52890,10 @@
 
  vendor.id		usb 0x0bf0
 +vendor.name		Pace Micro Technology PLC
+
+ vendor.id		usb 0x0bf0
+&device.id		usb 0xc010
++device.name		EHD100SD
 
  vendor.id		usb 0x0bf1
 +vendor.name		Intracom S.A.
@@ -51035,6 +52974,13 @@
 &device.id		usb 0x101f
 +device.name		Fujitsu Full HD Pro Webcam
 
+ vendor.id		usb 0x0bfb
++vendor.name		Grass Valley Group
+
+ vendor.id		usb 0x0bfb
+&device.id		usb 0x0200
++device.name		TURBO iDDR Front Panel
+
  vendor.id		usb 0x0bfd
 +vendor.name		Kvaser AB
 
@@ -51085,6 +53031,10 @@
 
  vendor.id		usb 0x0c0a
 +vendor.name		Highpoint Technologies, Inc.
+
+ vendor.id		usb 0x0c0a
+&device.id		usb 0x6124
++device.name		RocketStor 6124V
 
  vendor.id		usb 0x0c0b
 +vendor.name		Dura Micro, Inc. (Acomdata)
@@ -51150,7 +53100,7 @@
 
  vendor.id		usb 0x0c12
 &device.id		usb 0x0005
-+device.name		PSX Vibration Feedback Converter
++device.name		PSX Vibration Feedback Converter / Intec Wireless Controller for Xbox
 
  vendor.id		usb 0x0c12
 &device.id		usb 0x0030
@@ -51162,7 +53112,7 @@
 
  vendor.id		usb 0x0c12
 &device.id		usb 0x8801
-+device.name		Xbox Controller
++device.name		Nyko Xbox Controller
 
  vendor.id		usb 0x0c12
 &device.id		usb 0x8802
@@ -51227,6 +53177,13 @@
 
  vendor.id		usb 0x0c1c
 +vendor.name		Hang Zhou Silan Electronics Co., Ltd
+
+ vendor.id		usb 0x0c1f
++vendor.name		Magicard
+
+ vendor.id		usb 0x0c1f
+&device.id		usb 0x1800
++device.name		Tango 2E
 
  vendor.id		usb 0x0c22
 +vendor.name		Tally Printer Corp.
@@ -51307,8 +53264,16 @@
 &device.id		usb 0x0018
 +device.name		USB-Serial Controller [Icom Inc. OPC-478UC]
 
+ vendor.id		usb 0x0c26
+&device.id		usb 0x002b
++device.name		Icom Inc. IC-R30
+
  vendor.id		usb 0x0c27
 +vendor.name		RFIDeas, Inc
+
+ vendor.id		usb 0x0c27
+&device.id		usb 0x232a
++device.name		pcProx Plus RFID Reader (CDC serial)
 
  vendor.id		usb 0x0c27
 &device.id		usb 0x3bfa
@@ -51340,6 +53305,10 @@
  vendor.id		usb 0x0c2e
 &device.id		usb 0x0720
 +device.name		Metrologic MS7120 Barcode Scanner (bi-directional serial mode)
+
+ vendor.id		usb 0x0c2e
+&device.id		usb 0x0a64
++device.name		[Stratos 2700]
 
  vendor.id		usb 0x0c2e
 &device.id		usb 0x0b61
@@ -51389,6 +53358,13 @@
 
  vendor.id		usb 0x0c3e
 +vendor.name		Nextcell, Inc.
+
+ vendor.id		usb 0x0c40
++vendor.name		ELMCU
+
+ vendor.id		usb 0x0c40
+&device.id		usb 0x8000
++device.name		2.4GHz receiver
 
  vendor.id		usb 0x0c44
 +vendor.name		Motorola iDEN
@@ -51511,6 +53487,18 @@
  vendor.id		usb 0x0c45
 &device.id		usb 0x184c
 +device.name		VoIP Phone
+
+ vendor.id		usb 0x0c45
+&device.id		usb 0x1a90
++device.name		2M pixel Microscope Camera (with capture button) [Andonstar V160]
+
+ vendor.id		usb 0x0c45
+&device.id		usb 0x5004
++device.name		Redragon Mitra RGB Keyboard
+
+ vendor.id		usb 0x0c45
+&device.id		usb 0x5101
++device.name		2.4G Wireless Device [Rii MX3]
 
  vendor.id		usb 0x0c45
 &device.id		usb 0x6001
@@ -51901,12 +53889,20 @@
 +device.name		Sonix USB 2.0 Camera
 
  vendor.id		usb 0x0c45
+&device.id		usb 0x6321
++device.name		HP Integrated Webcam
+
+ vendor.id		usb 0x0c45
 &device.id		usb 0x6340
 +device.name		Camera
 
  vendor.id		usb 0x0c45
 &device.id		usb 0x6341
 +device.name		Defender G-Lens 2577 HD720p Camera
+
+ vendor.id		usb 0x0c45
+&device.id		usb 0x6366
++device.name		Webcam Vitade AF
 
  vendor.id		usb 0x0c45
 &device.id		usb 0x63e0
@@ -51961,6 +53957,10 @@
 +device.name		Integrated Webcam
 
  vendor.id		usb 0x0c45
+&device.id		usb 0x64ad
++device.name		Dell Laptop Integrated Webcam HD
+
+ vendor.id		usb 0x0c45
 &device.id		usb 0x64bd
 +device.name		Sony Visual Communication Camera
 
@@ -51977,12 +53977,28 @@
 +device.name		HP Webcam
 
  vendor.id		usb 0x0c45
+&device.id		usb 0x652f
++device.name		Backlit Gaming Keyboard
+
+ vendor.id		usb 0x0c45
 &device.id		usb 0x6705
 +device.name		Integrated HD Webcam
 
  vendor.id		usb 0x0c45
+&device.id		usb 0x670c
++device.name		Integrated Webcam HD
+
+ vendor.id		usb 0x0c45
 &device.id		usb 0x6710
 +device.name		Integrated Webcam
+
+ vendor.id		usb 0x0c45
+&device.id		usb 0x6712
++device.name		Integrated Webcam HD
+
+ vendor.id		usb 0x0c45
+&device.id		usb 0x671d
++device.name		Integrated_Webcam_HD
 
  vendor.id		usb 0x0c45
 &device.id		usb 0x7401
@@ -52473,6 +54489,10 @@
 &device.id		usb 0x1607
 +device.name		audio controller
 
+ vendor.id		usb 0x0c76
+&device.id		usb 0x5663
++device.name		Audio Device
+
  vendor.id		usb 0x0c77
 +vendor.name		Sipix Group, Ltd
 
@@ -52567,6 +54587,25 @@
  vendor.id		usb 0x0c9b
 +vendor.name		Jobin Yvon, Inc.
 
+ vendor.id		usb 0x0c9c
++vendor.name		Brand Innovators BV
+
+ vendor.id		usb 0x0c9c
+&device.id		usb 0x1511
++device.name		BI-1511 Laser Simulator
+
+ vendor.id		usb 0x0c9c
+&device.id		usb 0x1512
++device.name		BI-1512 Syncbus Monitor
+
+ vendor.id		usb 0x0c9c
+&device.id		usb 0x1514
++device.name		BI-1514 HPC
+
+ vendor.id		usb 0x0c9c
+&device.id		usb 0x1532
++device.name		BI-1532 GPC
+
  vendor.id		usb 0x0c9d
 +vendor.name		SemTek
 
@@ -52616,6 +54655,13 @@
  vendor.id		usb 0x0ca7
 +vendor.name		Information Systems Laboratories
 
+ vendor.id		usb 0x0caa
++vendor.name		Allied Telesis KK.
+
+ vendor.id		usb 0x0caa
+&device.id		usb 0x3001
++device.name		AT-VT-Kit3 Serial Adapter
+
  vendor.id		usb 0x0cad
 +vendor.name		Motorola CGISS
 
@@ -52641,7 +54687,7 @@
 
  vendor.id		usb 0x0cad
 &device.id		usb 0x9001
-+device.name		PowerPad Pocket PC Device
++device.name		PowerPad Pocket PC Device
 
  vendor.id		usb 0x0cae
 +vendor.name		Ascom Business Systems, Ltd
@@ -52906,6 +54952,10 @@
 +device.name		NOXON DAB/DAB+ Stick
 
  vendor.id		usb 0x0ccd
+&device.id		usb 0x00b9
++device.name		WDR DAB/DAB+ Stick
+
+ vendor.id		usb 0x0ccd
 &device.id		usb 0x00e0
 +device.name		NOXON DAB/DAB+ Stick V2
 
@@ -52920,6 +54970,10 @@
  vendor.id		usb 0x0ccd
 &device.id		usb 0x10a7
 +device.name		TerraTec G3
+
+ vendor.id		usb 0x0ccd
+&device.id		usb 0x10ad
++device.name		Cinergy H5 Rev. 2
 
  vendor.id		usb 0x0cd4
 +vendor.name		Bang Olufsen
@@ -53182,6 +55236,10 @@
 +device.name		AR5523 (no firmware)
 
  vendor.id		usb 0x0cf3
+&device.id		usb 0x0036
++device.name		AR9462 Bluetooth
+
+ vendor.id		usb 0x0cf3
 &device.id		usb 0x1001
 +device.name		Thomson TG121N [Atheros AR9001U-(2)NG]
 
@@ -53226,6 +55284,10 @@
 +device.name		Bluetooth (AR3011)
 
  vendor.id		usb 0x0cf3
+&device.id		usb 0x311d
++device.name		Bluetooth
+
+ vendor.id		usb 0x0cf3
 &device.id		usb 0x311f
 +device.name		AR3012 Bluetooth
 
@@ -53242,6 +55304,10 @@
 +device.name		AR9271 802.11n
 
  vendor.id		usb 0x0cf3
+&device.id		usb 0x9378
++device.name		QCA9377-7
+
+ vendor.id		usb 0x0cf3
 &device.id		usb 0xb002
 +device.name		Ubiquiti WiFiStation 802.11n [Atheros AR9271]
 
@@ -53252,6 +55318,10 @@
  vendor.id		usb 0x0cf3
 &device.id		usb 0xe006
 +device.name		Dell Wireless 1802 Bluetooth 4.0 LE
+
+ vendor.id		usb 0x0cf3
+&device.id		usb 0xe300
++device.name		QCA61x4 Bluetooth 4.0
 
  vendor.id		usb 0x0cf4
 +vendor.name		Fomtex Corp.
@@ -53371,8 +55441,32 @@
 +device.name		Photo Printer 63xPL/PS
 
  vendor.id		usb 0x0d16
+&device.id		usb 0x0007
++device.name		P510K
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0009
++device.name		P72x Series
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x000a
++device.name		P728L
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x000b
++device.name		P510L
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x000d
++device.name		P518A
+
+ vendor.id		usb 0x0d16
 &device.id		usb 0x000e
 +device.name		P910L
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0010
++device.name		M610
 
  vendor.id		usb 0x0d16
 &device.id		usb 0x0100
@@ -53395,8 +55489,56 @@
 +device.name		Photo Printer 64xPS
 
  vendor.id		usb 0x0d16
+&device.id		usb 0x010e
++device.name		P510S
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0110
++device.name		P110S
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0111
++device.name		P510Si
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0112
++device.name		P518S
+
+ vendor.id		usb 0x0d16
 &device.id		usb 0x0200
 +device.name		Photo Printer 64xDL
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0309
++device.name		CS-200e
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x030a
++device.name		CS-220e
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0501
++device.name		P75x Series
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0502
++device.name		P52x Series
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0503
++device.name		P310L
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x050a
++device.name		P310W
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x050f
++device.name		P530D
+
+ vendor.id		usb 0x0d16
+&device.id		usb 0x0800
++device.name		X610
 
  vendor.id		usb 0x0d17
 +vendor.name		NALTEC, Inc.
@@ -53413,6 +55555,13 @@
  vendor.id		usb 0x0d28
 &device.id		usb 0x0204
 +device.name		ARM mbed
+
+ vendor.id		usb 0x0d2f
++vendor.name		Andamiro
+
+ vendor.id		usb 0x0d2f
+&device.id		usb 0x0002
++device.name		Pump It Up Pad
 
  vendor.id		usb 0x0d32
 +vendor.name		Leo Hui Electric Wire & Cable Co., Ltd
@@ -53520,6 +55669,10 @@
 +device.name		Drive
 
  vendor.id		usb 0x0d49
+&device.id		usb 0x3005
++device.name		Personal Storage 3000LS
+
+ vendor.id		usb 0x0d49
 &device.id		usb 0x3010
 +device.name		3000LE Drive
 
@@ -53605,6 +55758,10 @@
 +device.name		USB-Temp2 Thermometer
 
  vendor.id		usb 0x0d50
+&device.id		usb 0x0030
++device.name		Multiplexer
+
+ vendor.id		usb 0x0d50
 &device.id		usb 0x0040
 +device.name		F4 foot switch
 
@@ -53625,6 +55782,13 @@
 
  vendor.id		usb 0x0d57
 +vendor.name		Solomon Microtech, Ltd
+
+ vendor.id		usb 0x0d59
++vendor.name		TRC Simulators b.v.
+
+ vendor.id		usb 0x0d59
+&device.id		usb 0x02a8
++device.name		Digital Clock
 
  vendor.id		usb 0x0d5c
 +vendor.name		SMC Networks, Inc.
@@ -53695,6 +55859,10 @@
  vendor.id		usb 0x0d62
 &device.id		usb 0x2106
 +device.name		Dell L20U Multimedia Keyboard
+
+ vendor.id		usb 0x0d62
+&device.id		usb 0x910e
++device.name		HP Business Slim Keyboard
 
  vendor.id		usb 0x0d62
 &device.id		usb 0xa100
@@ -53941,6 +56109,10 @@
  vendor.id		usb 0x0d8c
 &device.id		usb 0x0003
 +device.name		Sound Device
+
+ vendor.id		usb 0x0d8c
+&device.id		usb 0x0004
++device.name		CM6631A Audio Processor
 
  vendor.id		usb 0x0d8c
 &device.id		usb 0x0005
@@ -54336,6 +56508,10 @@
 +device.name		Interface
 
  vendor.id		usb 0x0da4
+&device.id		usb 0x0003
++device.name		FlowLink
+
+ vendor.id		usb 0x0da4
 &device.id		usb 0x0008
 +device.name		Loop
 
@@ -54506,6 +56682,10 @@
 &device.id		usb 0xb97a
 +device.name		Bluetooth EDR Device
 
+ vendor.id		usb 0x0db0
+&device.id		usb 0xffff
++device.name		Bluetooth Adapter in DFU mode
+
  vendor.id		usb 0x0db1
 +vendor.name		Wen Te Electronics Co., Ltd
 
@@ -54536,6 +56716,10 @@
  vendor.id		usb 0x0db5
 &device.id		usb 0x0160
 +device.name		NFC and Smartcard Module (NSM)
+
+ vendor.id		usb 0x0db5
+&device.id		usb 0x0164
++device.name		NFC and Smartcard Module (NSM)with 4 SAM slots
 
  vendor.id		usb 0x0db7
 +vendor.name		ELCON Systemtechnik
@@ -54656,6 +56840,10 @@
 &device.id		usb 0x020a
 +device.name		Oyen Digital MiniPro 2.5" hard drive enclosure
 
+ vendor.id		usb 0x0dc4
+&device.id		usb 0x0290
++device.name		Mass Storage Device [NT2 U3.1]
+
  vendor.id		usb 0x0dc5
 +vendor.name		SDK Co., Ltd
 
@@ -54703,6 +56891,10 @@
  vendor.id		usb 0x0dd4
 +vendor.name		Custom Engineering SPA
 
+ vendor.id		usb 0x0dd4
+&device.id		usb 0x0237
++device.name		K80 80mm Thermal Printer
+
  vendor.id		usb 0x0dd5
 +vendor.name		California Micro Devices
 
@@ -54711,6 +56903,10 @@
 
  vendor.id		usb 0x0dd8
 +vendor.name		Netac Technology Co., Ltd
+
+ vendor.id		usb 0x0dd8
+&device.id		usb 0x0562
++device.name		Netac Portable SSD Z6s
 
  vendor.id		usb 0x0dd8
 &device.id		usb 0x1060
@@ -54722,7 +56918,7 @@
 
  vendor.id		usb 0x0dd8
 &device.id		usb 0xf607
-+device.name		OnlyDisk U208 1G flash drive [U-SAFE]
++device.name		OnlyDisk U210 1G flash drive [U-SAFE]
 
  vendor.id		usb 0x0dd9
 +vendor.name		HighSpeed Surfing
@@ -55137,8 +57333,16 @@
 +device.name		Touchscreen
 
  vendor.id		usb 0x0dfc
+&device.id		usb 0x0003
++device.name		MultiTouch TouchScreen(Dualtouch)
+
+ vendor.id		usb 0x0dfc
 &device.id		usb 0x0101
 +device.name		5-point Touch Screen
+
+ vendor.id		usb 0x0dfc
+&device.id		usb 0xd107
++device.name		MultiTouch TouchScreen
 
  vendor.id		usb 0x0e03
 +vendor.name		Nippon Systemware Co., Ltd
@@ -55199,6 +57403,10 @@
 +device.name		Virtual Keyboard
 
  vendor.id		usb 0x0e0f
+&device.id		usb 0x000a
++device.name		Virtual Sensors
+
+ vendor.id		usb 0x0e0f
 &device.id		usb 0x8001
 +device.name		Root Hub
 
@@ -55225,6 +57433,9 @@
 
  vendor.id		usb 0x0e1b
 +vendor.name		Crewave
+
+ vendor.id		usb 0x0e1e
++vendor.name		Green Hills Software
 
  vendor.id		usb 0x0e20
 +vendor.name		Pegasus Technologies Ltd.
@@ -55464,8 +57675,16 @@
 +device.name		Gamester Controller
 
  vendor.id		usb 0x0e4c
+&device.id		usb 0x1103
++device.name		Gamester Reflex
+
+ vendor.id		usb 0x0e4c
 &device.id		usb 0x2390
-+device.name		Games Jtech Controller
++device.name		Jtech Controller
+
+ vendor.id		usb 0x0e4c
+&device.id		usb 0x3510
++device.name		Gamester for Xbox
 
  vendor.id		usb 0x0e4c
 &device.id		usb 0x7288
@@ -55589,6 +57808,10 @@
 +device.name		MA100 [USB-UART Bridge IC]
 
  vendor.id		usb 0x0e6a
+&device.id		usb 0x02c0
++device.name		Defender Gaming Keyboard
+
+ vendor.id		usb 0x0e6a
 &device.id		usb 0x030b
 +device.name		Truly Ergonomic Computer Keyboard (Device Firmware Update mode)
 
@@ -55620,8 +57843,116 @@
 +device.name		Edge wireless Controller
 
  vendor.id		usb 0x0e6f
+&device.id		usb 0x0008
++device.name		After Glow Pro Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0105
++device.name		Disney's High School Musical 3 Dance Pad for Xbox 360
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0113
++device.name		Afterglow AX.1 Gamepad
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x011f
++device.name		Rock Candy Wired Controller for Xbox 360
+
+ vendor.id		usb 0x0e6f
 &device.id		usb 0x0128
 +device.name		Wireless PS3 Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0131
++device.name		PDP EA Sports Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0133
++device.name		Wired Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0139
++device.name		Afterglow Prismatic Wired Controller for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x013a
++device.name		PDP Xbox One Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0146
++device.name		Rock Candy Wired Controller for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0147
++device.name		PDP Marvel Controller for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x015c
++device.name		PDP Arcade Stick for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0161
++device.name		Camo Wired Controller for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0162
++device.name		Xbox One Wired Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0163
++device.name		Legendary Collection Deliverer of Truth
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0164
++device.name		Battlefield 1 Wired Controller for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0165
++device.name		Titanfall 2 Wired Controller for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0201
++device.name		Pelican PL-3601
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0213
++device.name		Afterglow Gamepad for Xbox 360
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x021f
++device.name		Rock Candy Gamepad for Xbox 360
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0246
++device.name		Rock Candy Gamepad for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0301
++device.name		Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0346
++device.name		Rock Candy Wired Controller for Xbox One
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0401
++device.name		Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0413
++device.name		Afterglow AX.1 Gamepad for Xbox 360
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0x0501
++device.name		Wired Controller
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0xf501
++device.name		Hi-TEC Essentials Wired Gamepad
+
+ vendor.id		usb 0x0e6f
+&device.id		usb 0xf900
++device.name		Afterglow AX.1
 
  vendor.id		usb 0x0e70
 +vendor.name		Tokyo Electronic Industry Co., Ltd
@@ -55702,6 +58033,10 @@
 +vendor.name		MediaTek Inc.
 
  vendor.id		usb 0x0e8d
+&device.id		usb 0x0002
++device.name		phone (mass storage mode) [Doro Primo 413]
+
+ vendor.id		usb 0x0e8d
 &device.id		usb 0x0003
 +device.name		MT6227 phone
 
@@ -55711,7 +58046,7 @@
 
  vendor.id		usb 0x0e8d
 &device.id		usb 0x0023
-+device.name		S103
++device.name		S103 / Powertel M6200
 
  vendor.id		usb 0x0e8d
 &device.id		usb 0x00a5
@@ -55726,6 +58061,10 @@
 +device.name		Samsung SE-S084 Super WriteMaster Slim External DVD writer
 
  vendor.id		usb 0x0e8d
+&device.id		usb 0x1887
++device.name		Slim Portable DVD Writer
+
+ vendor.id		usb 0x0e8d
 &device.id		usb 0x1956
 +device.name		Samsung SE-506 Portable BluRay Disc Writer
 
@@ -55734,12 +58073,24 @@
 +device.name		MT65xx Preloader
 
  vendor.id		usb 0x0e8d
+&device.id		usb 0x2008
++device.name		Cyrus Technology CS 24
+
+ vendor.id		usb 0x0e8d
 &device.id		usb 0x3329
 +device.name		Qstarz BT-Q1000XT
 
  vendor.id		usb 0x0e8d
+&device.id		usb 0x7612
++device.name		MT7612U 802.11a/b/g/n/ac Wireless Adapter
+
+ vendor.id		usb 0x0e8d
 &device.id		usb 0x763e
 +device.name		MT7630e Bluetooth Adapter
+
+ vendor.id		usb 0x0e8d
+&device.id		usb 0x7668
++device.name		MT7668 2x2 Dual Band Dual Concurrent 802.11a/b/g/n/ac WiFi with MU-MIMO and Bluetooth 5.0 Radios
 
  vendor.id		usb 0x0e8f
 +vendor.name		GreenAsia Inc.
@@ -55771,6 +58122,10 @@
  vendor.id		usb 0x0e8f
 &device.id		usb 0x0201
 +device.name		SmartJoy Frag Xpad/PS2 adaptor
+
+ vendor.id		usb 0x0e8f
+&device.id		usb 0x3008
++device.name		Xbox Controller
 
  vendor.id		usb 0x0e8f
 &device.id		usb 0x300a
@@ -55847,6 +58202,10 @@
 +device.name		Transcend JetFlash 2.0 / Astone USB Drive / Intellegent Stick 2.0
 
  vendor.id		usb 0x0ea0
+&device.id		usb 0x2213
++device.name		WinDroid N287 AH7N2502.013317
+
+ vendor.id		usb 0x0ea0
 &device.id		usb 0x6803
 +device.name		OTI-6803 Flash Disk
 
@@ -55918,7 +58277,7 @@
 
  vendor.id		usb 0x0eb8
 &device.id		usb 0xf000
-+device.name		PS60 Scale
++device.name		BC60 Scale
 
  vendor.id		usb 0x0ebb
 +vendor.name		Thermo Fisher Scientific
@@ -56059,7 +58418,7 @@
 
  vendor.id		usb 0x0eef
 &device.id		usb 0x0001
-+device.name		eGalax TouchScreen
++device.name		Titan6001 Surface Acoustic Wave Touchscreen Controller [eGalax]
 
  vendor.id		usb 0x0eef
 &device.id		usb 0x0002
@@ -56070,8 +58429,20 @@
 +device.name		Touchscreen Controller
 
  vendor.id		usb 0x0eef
+&device.id		usb 0x7904
++device.name		Multitouch Capacitive Touchscreen eGalaxTouch EXC7904-21v00_T13 [IIyama Prolite T1932-MSC]
+
+ vendor.id		usb 0x0eef
 &device.id		usb 0xa802
 +device.name		eGalaxTouch EXC7920
+
+ vendor.id		usb 0x0eef
+&device.id		usb 0xb10e
++device.name		eGalaxTouch EXC3000
+
+ vendor.id		usb 0x0eef
+&device.id		usb 0xc000
++device.name		Multitouch Capacitive Touchscreen eGalaxTouch EXC3188-4643-08.00.00.00 Sirius_4643 PCAP3188UR Series [IIyama Prolite PLT1932MSC]
 
  vendor.id		usb 0x0ef0
 +vendor.name		Hitachi Cable, Ltd
@@ -56131,8 +58502,48 @@
 +vendor.name		Hori Co., Ltd
 
  vendor.id		usb 0x0f0d
+&device.id		usb 0x000a
++device.name		Dead or Alive 4 FightStick for Xbox 360
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x000c
++device.name		Horipad EX Turbo for Xbox 360
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x000d
++device.name		Fighting Stick EX2 for Xbox 360
+
+ vendor.id		usb 0x0f0d
 &device.id		usb 0x0011
 +device.name		Real Arcade Pro 3
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x0016
++device.name		Real Arcade Pro.EX for Xbox 360
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x001b
++device.name		Real Aracde Pro.VX
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x0063
++device.name		Real Arcade Pro Hayabusa for Xbox One
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x0067
++device.name		Horipad One
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x0078
++device.name		Real Arcade Pro V Kai for Xbox One / Xbox 360
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x0090
++device.name		Horipad Ultimate
+
+ vendor.id		usb 0x0f0d
+&device.id		usb 0x00c1
++device.name		HORIPAD for Nintendo Switch
 
  vendor.id		usb 0x0f0e
 +vendor.name		Energy Full Corp.
@@ -56296,6 +58707,10 @@
 +device.name		PS3 Guitar Controller Dongle
 
  vendor.id		usb 0x0f30
+&device.id		usb 0x010b
++device.name		Philips Recoil
+
+ vendor.id		usb 0x0f30
 &device.id		usb 0x0110
 +device.name		Dual Analog Rumble Pad
 
@@ -56304,8 +58719,16 @@
 +device.name		Colour Rumble Pad
 
  vendor.id		usb 0x0f30
+&device.id		usb 0x0202
++device.name		Joytech Advanced Controller
+
+ vendor.id		usb 0x0f30
 &device.id		usb 0x0208
 +device.name		Xbox & PC Gamepad
+
+ vendor.id		usb 0x0f30
+&device.id		usb 0x8888
++device.name		BigBen XBMiniPad Controller
 
  vendor.id		usb 0x0f31
 +vendor.name		Chrysalis Development
@@ -56321,6 +58744,10 @@
 
  vendor.id		usb 0x0f39
 +vendor.name		TG3 Electronics
+
+ vendor.id		usb 0x0f39
+&device.id		usb 0x0404
++device.name		Recreated ZX Spectrum Keyboard
 
  vendor.id		usb 0x0f39
 &device.id		usb 0x0876
@@ -56361,6 +58788,13 @@
  vendor.id		usb 0x0f44
 &device.id		usb 0xff12
 +device.name		Liberty
+
+ vendor.id		usb 0x0f49
++vendor.name		Evolis SA
+
+ vendor.id		usb 0x0f49
+&device.id		usb 0x0a00
++device.name		Zenius
 
  vendor.id		usb 0x0f4b
 +vendor.name		St. John Technology Co., Ltd
@@ -56505,7 +58939,7 @@
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0100
-+device.name		GameBoy Color Emulator
++device.name		IS-CGB-EMULATOR
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0201
@@ -56513,31 +58947,39 @@
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0202
-+device.name		GameBoy Advance Capture
++device.name		IS-AGB-CAPTURE
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0300
-+device.name		Gamecube DOL Viewer
++device.name		IS-DOL-VIEWER
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0400
-+device.name		NDS Emulator
++device.name		IS-NITRO-EMULATOR
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0401
-+device.name		NDS UIC
++device.name		IS-NITRO-UIC
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0402
-+device.name		NDS Writer
++device.name		IS-NITRO-WRITER
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0403
-+device.name		NDS Capture
++device.name		IS-NITRO-CAPTURE
 
  vendor.id		usb 0x0f6e
 &device.id		usb 0x0404
-+device.name		NDS Emulator (Lite)
++device.name		IS-NITRO-EMULATOR (DS Lite)
+
+ vendor.id		usb 0x0f6e
+&device.id		usb 0x0500
++device.name		IS-TWL-DEBUGGER
+
+ vendor.id		usb 0x0f6e
+&device.id		usb 0x0501
++device.name		IS-TWL-CAPTURE
 
  vendor.id		usb 0x0f73
 +vendor.name		DFI
@@ -56710,6 +59152,10 @@
 +device.name		Blackberry Playbook (Connect to Mac mode)
 
  vendor.id		usb 0x0fca
+&device.id		usb 0x8014
++device.name		Blackberry Handheld Z30
+
+ vendor.id		usb 0x0fca
 &device.id		usb 0x8020
 +device.name		Blackberry Playbook (CD-Rom mode)
 
@@ -56797,8 +59243,16 @@
 +device.name		D5803 [Xperia Z3 Compact] (MTP mode)
 
  vendor.id		usb 0x0fce
-&device.id		usb 0x0dde
-+device.name		Xperia Mini Pro Bootloader
+&device.id		usb 0x01e0
++device.name		F5122 [Xperia X dual] (MTP mode)
+
+ vendor.id		usb 0x0fce
+&device.id		usb 0x01e8
++device.name		F5321 [Xperia X Compact] (MTP mode)
+
+ vendor.id		usb 0x0fce
+&device.id		usb 0x01f9
++device.name		H8314 [Xperia XZ2 Compact]
 
  vendor.id		usb 0x0fce
 &device.id		usb 0x1010
@@ -56865,6 +59319,10 @@
 +device.name		D5503 (Xperia Z1 Compact)
 
  vendor.id		usb 0x0fce
+&device.id		usb 0x51e0
++device.name		F5122 [Xperia X dual] (developer mode)
+
+ vendor.id		usb 0x0fce
 &device.id		usb 0x614f
 +device.name		Xperia X12 (debug mode)
 
@@ -56889,12 +59347,36 @@
 +device.name		Xperia Ion [Tethering]
 
  vendor.id		usb 0x0fce
+&device.id		usb 0x71f4
++device.name		G8441 (Xperia XZ1 Compact) [Tethering]
+
+ vendor.id		usb 0x0fce
+&device.id		usb 0x71f9
++device.name		H8314 [Xperia XZ2 Compact] (Tethering)
+
+ vendor.id		usb 0x0fce
 &device.id		usb 0x8004
 +device.name		9000 Phone [Mass Storage]
 
  vendor.id		usb 0x0fce
+&device.id		usb 0x81f4
++device.name		G8441 (Xperia XZ1 Compact) [Tethering]
+
+ vendor.id		usb 0x0fce
 &device.id		usb 0xadde
 +device.name		C2005 (Xperia M dual) in service mode
+
+ vendor.id		usb 0x0fce
+&device.id		usb 0xc1e0
++device.name		F5122 [Xperia X dual] (MIDI mode)
+
+ vendor.id		usb 0x0fce
+&device.id		usb 0xc1e8
++device.name		F5321 [Xperia X Compact] (MIDI mode)
+
+ vendor.id		usb 0x0fce
+&device.id		usb 0xc1f9
++device.name		H8314 [Xperia XZ2 Compact] (MIDI)
 
  vendor.id		usb 0x0fce
 &device.id		usb 0xd008
@@ -56951,6 +59433,10 @@
  vendor.id		usb 0x0fce
 &device.id		usb 0xd076
 +device.name		W910i (Phone mode)
+
+ vendor.id		usb 0x0fce
+&device.id		usb 0xd079
++device.name		K530 Phone
 
  vendor.id		usb 0x0fce
 &device.id		usb 0xd089
@@ -57217,6 +59703,22 @@
 &device.id		usb 0x0037
 +device.name		Video Capture v2
 
+ vendor.id		usb 0x0fd9
+&device.id		usb 0x0060
++device.name		Stream Deck
+
+ vendor.id		usb 0x0fd9
+&device.id		usb 0x0063
++device.name		Stream Deck Mini
+
+ vendor.id		usb 0x0fd9
+&device.id		usb 0x006c
++device.name		Stream Deck XL
+
+ vendor.id		usb 0x0fd9
+&device.id		usb 0x006d
++device.name		Stream Deck original V2
+
  vendor.id		usb 0x0fda
 +vendor.name		Quantec Networks GmbH
 
@@ -57237,6 +59739,10 @@
  vendor.id		usb 0x0fde
 &device.id		usb 0xca05
 +device.name		CM160
+
+ vendor.id		usb 0x0fde
+&device.id		usb 0xca08
++device.name		WMR300 Professional Weather System
 
  vendor.id		usb 0x0fe0
 +vendor.name		Osterhout Design Group
@@ -57339,6 +59845,10 @@
 &device.id		usb 0x0021
 +device.name		Nord Stage 2
 
+ vendor.id		usb 0x0ffc
+&device.id		usb 0x002a
++device.name		Nord Piano 4
+
  vendor.id		usb 0x0ffd
 +vendor.name		EarlySense
 
@@ -57369,6 +59879,10 @@
  vendor.id		usb 0x1003
 &device.id		usb 0x0100
 +device.name		SD9/SD10
+
+ vendor.id		usb 0x1003
+&device.id		usb 0x8781
++device.name		Dock UD-01
 
  vendor.id		usb 0x1004
 +vendor.name		LG Electronics, Inc.
@@ -57439,7 +59953,7 @@
 
  vendor.id		usb 0x1004
 &device.id		usb 0x631c
-+device.name		G2/Optimus Android Phone [MTP mode]
++device.name		LM-X420xxx/G2/Optimus Android Phone (charge mode)
 
  vendor.id		usb 0x1004
 &device.id		usb 0x631d
@@ -57447,7 +59961,7 @@
 
  vendor.id		usb 0x1004
 &device.id		usb 0x631e
-+device.name		G2/Optimus Android Phone [Camera/PTP mode]
++device.name		LM-X420xxx/G2/Optimus Android Phone (PTP/camera mode)
 
  vendor.id		usb 0x1004
 &device.id		usb 0x631f
@@ -57459,11 +59973,15 @@
 
  vendor.id		usb 0x1004
 &device.id		usb 0x633e
-+device.name		G2/G3 Android Phone [MTP/PTP/Download mode]
++device.name		LM-X420xxx/G2/G3 Android Phone (MTP/download mode)
 
  vendor.id		usb 0x1004
 &device.id		usb 0x6344
-+device.name		G2 Android Phone [tethering mode]
++device.name		LM-X420xxx/G2 Android Phone (USB tethering mode)
+
+ vendor.id		usb 0x1004
+&device.id		usb 0x6348
++device.name		LM-X420xxx Android Phone (MIDI mode)
 
  vendor.id		usb 0x1004
 &device.id		usb 0x6356
@@ -57503,6 +60021,10 @@
  vendor.id		usb 0x1005
 &device.id		usb 0xb113
 +device.name		Handy Steno/AH123 / Handy Steno 2.0/HT203
+
+ vendor.id		usb 0x1005
+&device.id		usb 0xb155
++device.name		Disk Module
 
  vendor.id		usb 0x1005
 &device.id		usb 0xb223
@@ -57627,6 +60149,10 @@
  vendor.id		usb 0x1017
 +vendor.name		Speedy Industrial Supplies, Pte., Ltd
 
+ vendor.id		usb 0x1017
+&device.id		usb 0x9015
++device.name		M625 [Vendor: DELUX]
+
  vendor.id		usb 0x1019
 +vendor.name		Elitegroup Computer Systems (ECS)
 
@@ -57651,7 +60177,7 @@
 
  vendor.id		usb 0x1020
 &device.id		usb 0x0106
-+device.name		Wireless Optical Mouse
++device.name		Wireless Optical Mouse/Keyboard
 
  vendor.id		usb 0x1022
 +vendor.name		Shinko Shoji Co., Ltd
@@ -57704,6 +60230,10 @@
 &device.id		usb 0x6251
 +device.name		Q-Cam VGA
 
+ vendor.id		usb 0x102c
+&device.id		usb 0xff0c
++device.name		Joytech Wireless Advanced Controller
+
  vendor.id		usb 0x102d
 +vendor.name		Winic Corp.
 
@@ -57728,8 +60258,20 @@
 +device.name		Ideazon Zboard
 
  vendor.id		usb 0x1038
+&device.id		usb 0x1260
++device.name		Arctis 7 wireless adapter
+
+ vendor.id		usb 0x1038
 &device.id		usb 0x1361
 +device.name		Ideazon Sensei
+
+ vendor.id		usb 0x1038
+&device.id		usb 0x1410
++device.name		SRW-S1 [Simraceway Steering Wheel]
+
+ vendor.id		usb 0x1038
+&device.id		usb 0x1720
++device.name		Mouse
 
  vendor.id		usb 0x1039
 +vendor.name		devolo AG
@@ -57885,6 +60427,10 @@
 &device.id		usb 0x1003
 +device.name		Model-52 LED Light Source Power Supply and Driver
 
+ vendor.id		usb 0x104d
+&device.id		usb 0x3001
++device.name		ESP301 3 Axis Motion Controller
+
  vendor.id		usb 0x104f
 +vendor.name		WB Electronics
 
@@ -57969,31 +60515,31 @@
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0401
-+device.name		Yubikey 4 OTP
++device.name		Yubikey 4/5 OTP
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0402
-+device.name		Yubikey 4 U2F
++device.name		Yubikey 4/5 U2F
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0403
-+device.name		Yubikey 4 OTP+U2F
++device.name		Yubikey 4/5 OTP+U2F
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0404
-+device.name		Yubikey 4 CCID
++device.name		Yubikey 4/5 CCID
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0405
-+device.name		Yubikey 4 OTP+CCID
++device.name		Yubikey 4/5 OTP+CCID
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0406
-+device.name		Yubikey 4 U2F+CCID
++device.name		Yubikey 4/5 U2F+CCID
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0407
-+device.name		Yubikey 4 OTP+U2F+CCID
++device.name		Yubikey 4/5 OTP+U2F+CCID
 
  vendor.id		usb 0x1050
 &device.id		usb 0x0410
@@ -58254,6 +60800,10 @@
 +device.name		My Book Essential (WDBACW)
 
  vendor.id		usb 0x1058
+&device.id		usb 0x1170
++device.name		My Book Essential 3TB (WDBACW0030HBK)
+
+ vendor.id		usb 0x1058
 &device.id		usb 0x1230
 +device.name		My Book (WDBFJK)
 
@@ -58275,7 +60825,7 @@
 
  vendor.id		usb 0x1058
 &device.id		usb 0x25a1
-+device.name		Elements / My Passport (WD20NMVW)
++device.name		Elements / My Passport
 
  vendor.id		usb 0x1058
 &device.id		usb 0x25a2
@@ -58286,8 +60836,44 @@
 +device.name		Elements Desktop (WDBWLG)
 
  vendor.id		usb 0x1058
+&device.id		usb 0x25da
++device.name		My Book (WDBFJK)
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x25e1
++device.name		My Passport (WD20NMVW)
+
+ vendor.id		usb 0x1058
 &device.id		usb 0x25e2
 +device.name		My Passport (WD40NMZW)
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x25ee
++device.name		My Book 25EE
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x25f3
++device.name		My Passport SSD (WDBK3E)
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x25fa
++device.name		easystore Portable 5TB (WDBKUZ0050)
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x25fb
++device.name		easystore Desktop (WDBCKA)
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x2603
++device.name		My Passport Game Storage for PS4 4TB (WDBZGE0040)
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x2624
++device.name		easystore Portable 5TB (WDBKUZ0050)
+
+ vendor.id		usb 0x1058
+&device.id		usb 0x2626
++device.name		My Passport (WDBPKJ)
 
  vendor.id		usb 0x1058
 &device.id		usb 0x30a0
@@ -58839,6 +61425,10 @@
  vendor.id		usb 0x108c
 +vendor.name		Robert Bosch GmbH
 
+ vendor.id		usb 0x108c
+&device.id		usb 0x017e
++device.name		GTC 400 C
+
  vendor.id		usb 0x108e
 +vendor.name		Lotes Co., Ltd.
 
@@ -58859,8 +61449,20 @@
 +vendor.name		Hisense
 
  vendor.id		usb 0x109b
+&device.id		usb 0x9109
++device.name		CROSSCALL Trekker-M1 Core (MTP-Mode)
+
+ vendor.id		usb 0x109b
 &device.id		usb 0x9118
 +device.name		Medion P4013 Mobile
+
+ vendor.id		usb 0x109b
+&device.id		usb 0x9119
++device.name		CROSSCALL Trekker-M1 Core (PTP-Mode)
+
+ vendor.id		usb 0x109b
+&device.id		usb 0xf009
++device.name		CROSSCALL Trekker-M1 Core (CD-ROM-Mode)
 
  vendor.id		usb 0x109f
 +vendor.name		eSOL Co., Ltd
@@ -59440,6 +62042,14 @@
 +device.name		Ciaat Brava 21
 
  vendor.id		usb 0x10ce
+&device.id		usb 0x0039
++device.name		Sinfonia CHC-S2245
+
+ vendor.id		usb 0x10ce
+&device.id		usb 0x10ce
++device.name		Sinfonia CHC-S2245
+
+ vendor.id		usb 0x10ce
 &device.id		usb 0xea6a
 +device.name		MobiData EDGE USB Modem
 
@@ -59505,6 +62115,10 @@
  vendor.id		usb 0x10d5
 &device.id		usb 0x55a2
 +device.name		2Port KVMSwitcher
+
+ vendor.id		usb 0x10d5
+&device.id		usb 0x5a08
++device.name		Dual Bay Docking Station
 
  vendor.id		usb 0x10d6
 +vendor.name		Actions Semiconductor Co., Ltd
@@ -59600,6 +62214,117 @@
 &device.id		usb 0x0200
 +device.name		Audio Advantage Roadie
 
+ vendor.id		usb 0x10f5
+&device.id		usb 0x0231
++device.name		Ear Force P11 Headset
+
+ vendor.id		usb 0x10f5
+&device.id		usb 0x10f5
++device.name		EarForce PX21 Gaming Headset
+
+ vendor.id		usb 0x10f8
++vendor.name		Cesys GmbH
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0x3201
++device.name		CeboLC
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0x3202
++device.name		CeboStick
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0x3203
++device.name		CeboMSA64
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0x3204
++device.name		CeboDFN
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0x3205
++device.name		PSAA2304W_CASC
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc401
++device.name		USBV4F unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc402
++device.name		EFM01 unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc403
++device.name		MISS2 unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc404
++device.name		CID unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc405
++device.name		USBS6 unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc406
++device.name		OP_MISS2 unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc407
++device.name		NanoUsb uncofigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc481
++device.name		USBV4F
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc482
++device.name		EFM01
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc483
++device.name		MISS2
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc484
++device.name		CID
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc485
++device.name		USBS6
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc486
++device.name		OP_MISS2
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc487
++device.name		NanoUsb
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc501
++device.name		EFM02 unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc502
++device.name		EFM02/B unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc503
++device.name		EFM03 unconfigured
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc581
++device.name		EFM02
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc582
++device.name		EFM02/B
+
+ vendor.id		usb 0x10f8
+&device.id		usb 0xc583
++device.name		EFM03
+
  vendor.id		usb 0x10fb
 +vendor.name		Pictos Technologies, Inc.
 
@@ -59648,6 +62373,14 @@
 
  vendor.id		usb 0x110a
 +vendor.name		Moxa Technologies Co., Ltd.
+
+ vendor.id		usb 0x110a
+&device.id		usb 0x1110
++device.name		UPort 1110
+
+ vendor.id		usb 0x110a
+&device.id		usb 0x1150
++device.name		UPort 1150 1-Port RS-232/422/485
 
  vendor.id		usb 0x110a
 &device.id		usb 0x1250
@@ -59785,12 +62518,20 @@
 +device.name		iBuddy
 
  vendor.id		usb 0x1130
+&device.id		usb 0x0004
++device.name		iBuddy Twins
+
+ vendor.id		usb 0x1130
 &device.id		usb 0x0202
 +device.name		Rocket Launcher
 
  vendor.id		usb 0x1130
 &device.id		usb 0x6604
 +device.name		MCE IR-Receiver
+
+ vendor.id		usb 0x1130
+&device.id		usb 0x6606
++device.name		U+P Mouse
 
  vendor.id		usb 0x1130
 &device.id		usb 0x660c
@@ -60253,8 +62994,16 @@
 +device.name		Gobi 2000 Wireless Modem
 
  vendor.id		usb 0x1199
+&device.id		usb 0x9011
++device.name		MC8305 Modem
+
+ vendor.id		usb 0x1199
 &device.id		usb 0x9013
 +device.name		Sierra Wireless Gobi 3000 Modem device (MC8355)
+
+ vendor.id		usb 0x1199
+&device.id		usb 0x9041
++device.name		EM7305 Modem
 
  vendor.id		usb 0x1199
 &device.id		usb 0x9055
@@ -60263,6 +63012,14 @@
  vendor.id		usb 0x1199
 &device.id		usb 0x9057
 +device.name		Gobi 9x15 Multimode 3G/4G LTE Modem (IP passthrough mode)
+
+ vendor.id		usb 0x1199
+&device.id		usb 0x9071
++device.name		AirPrime MC7455 3G/4G LTE Modem
+
+ vendor.id		usb 0x1199
+&device.id		usb 0x9079
++device.name		EM7455
 
  vendor.id		usb 0x119a
 +vendor.name		ZHAN QI Technology Co., Ltd
@@ -60316,6 +63073,10 @@
 &device.id		usb 0x6208
 +device.name		PRO-28U
 
+ vendor.id		usb 0x11b0
+&device.id		usb 0x6298
++device.name		Kingston SNA-DC/U
+
  vendor.id		usb 0x11be
 +vendor.name		R&D International NV
 
@@ -60337,8 +63098,19 @@
 &device.id		usb 0x0521
 +device.name		IMT-0521 Smartcard Reader
 
+ vendor.id		usb 0x11c9
++vendor.name		Nacon
+
+ vendor.id		usb 0x11c9
+&device.id		usb 0x55f0
++device.name		GC-100XF
+
  vendor.id		usb 0x11ca
 +vendor.name		VeriFone Inc
+
+ vendor.id		usb 0x11ca
+&device.id		usb 0x0201
++device.name		MX870/MX880
 
  vendor.id		usb 0x11ca
 &device.id		usb 0x0207
@@ -60415,6 +63187,66 @@
 
  vendor.id		usb 0x1209
 &device.id		usb 0x0001
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0002
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0003
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0004
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0005
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0006
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0007
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0008
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0009
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x000a
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x000b
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x000c
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x000d
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x000e
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x000f
++device.name		pid.codes Test PID
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x0010
 +device.name		pid.codes Test PID
 
  vendor.id		usb 0x1209
@@ -60523,7 +63355,7 @@
 
  vendor.id		usb 0x1209
 &device.id		usb 0x2048
-+device.name		Housedillon.com MRF49XA Transciever
++device.name		Housedillon.com MRF49XA Transceiver
 
  vendor.id		usb 0x1209
 &device.id		usb 0x2100
@@ -60654,6 +63486,14 @@
 +device.name		LabConnect Digitalnetzteil
 
  vendor.id		usb 0x1209
+&device.id		usb 0x345b
++device.name		kinX Hub
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x345c
++device.name		kinX Keyboard Controller
+
+ vendor.id		usb 0x1209
 &device.id		usb 0x3690
 +device.name		Kigakudoh TouchMIDI32
 
@@ -60744,6 +63584,14 @@
  vendor.id		usb 0x1209
 &device.id		usb 0x5050
 +device.name		trebb ISO50
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x5070
++device.name		SoloHacker security key [SoloKey]
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x50b0
++device.name		boot for security key [SoloKey]
 
  vendor.id		usb 0x1209
 &device.id		usb 0x5222
@@ -60864,6 +63712,26 @@
  vendor.id		usb 0x1209
 &device.id		usb 0x7778
 +device.name		circuitvalley IO Board V3 Bootloader
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x7950
++device.name		PIC18F87J94 Bootloader [GenII]
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x7951
++device.name		PIC18F87J94 Application [GenII]
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x7952
++device.name		PIC18F87J94 Bootloader [GenIII/IV]
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x7953
++device.name		PIC18F87J94 Application [GenIII/IV]
+
+ vendor.id		usb 0x1209
+&device.id		usb 0x7954
++device.name		PIC18F87J94 Application [GenIII/IV]
 
  vendor.id		usb 0x1209
 &device.id		usb 0x7bd0
@@ -61262,6 +64130,10 @@
 +device.name		ManCave Made Quark One
 
  vendor.id		usb 0x1209
+&device.id		usb 0xdeed
++device.name		Kroneum Time Tracker
+
+ vendor.id		usb 0x1209
 &device.id		usb 0xdf00
 +device.name		D.F.Mac. @TripArts Music mi:muz:tuch
 
@@ -61407,6 +64279,10 @@
 +vendor.name		DigiTech
 
  vendor.id		usb 0x1210
+&device.id		usb 0x000d
++device.name		RP250 Guitar Multi-Effects Processor
+
+ vendor.id		usb 0x1210
 &device.id		usb 0x0016
 +device.name		RP500 Guitar Multi-Effects Processor
 
@@ -61424,6 +64300,41 @@
  vendor.id		usb 0x121e
 &device.id		usb 0x3403
 +device.name		Muzio JM250 Audio Player
+
+ vendor.id		usb 0x121f
++vendor.name		Panini S.p.A.
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0001
++device.name		VisionX without Firmware
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0002
++device.name		VisionX with Firmware
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0010
++device.name		I-Deal
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0020
++device.name		wI-Deal
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0021
++device.name		VisionX Page Scanner Extension
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0030
++device.name		VisionNext
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0040
++device.name		mI:Deal Check Scanner
+
+ vendor.id		usb 0x121f
+&device.id		usb 0x0041
++device.name		EverNext Check Scanner
 
  vendor.id		usb 0x1220
 +vendor.name		TC Electronic
@@ -61450,6 +64361,13 @@
  vendor.id		usb 0x1221
 &device.id		usb 0x3234
 +device.name		Disk (Thumb drive)
+
+ vendor.id		usb 0x1222
++vendor.name		TiPro
+
+ vendor.id		usb 0x1222
+&device.id		usb 0xfaca
++device.name		programmable keyboard
 
  vendor.id		usb 0x1223
 +vendor.name		SKYCABLE ENTERPRISE. CO., LTD.
@@ -61594,6 +64512,18 @@
 +device.name		Impulse 61
 
  vendor.id		usb 0x1235
+&device.id		usb 0x0032
++device.name		Launchkey 61
+
+ vendor.id		usb 0x1235
+&device.id		usb 0x0069
++device.name		Launchpad MK2
+
+ vendor.id		usb 0x1235
+&device.id		usb 0x0102
++device.name		LaunchKey Mini MK3
+
+ vendor.id		usb 0x1235
 &device.id		usb 0x4661
 +device.name		ReMOTE25
 
@@ -61642,12 +64572,32 @@
 +device.name		Focusrite Scarlett 2i2
 
  vendor.id		usb 0x1235
+&device.id		usb 0x8202
++device.name		Focusrite Scarlett 2i2 2nd Gen
+
+ vendor.id		usb 0x1235
 &device.id		usb 0x8203
 +device.name		Focusrite Scarlett 6i6
 
  vendor.id		usb 0x1235
 &device.id		usb 0x8204
 +device.name		Scarlett 18i8 2nd Gen
+
+ vendor.id		usb 0x1235
+&device.id		usb 0x8210
++device.name		Scarlett 2i2 Camera
+
+ vendor.id		usb 0x1235
+&device.id		usb 0x8211
++device.name		Scarlett Solo (3rd Gen.)
+
+ vendor.id		usb 0x1235
+&device.id		usb 0x8214
++device.name		Scarlett 18i8 3rd Gen
+
+ vendor.id		usb 0x1235
+&device.id		usb 0x8215
++device.name		Scarlett 18i20 3rd Gen
 
  vendor.id		usb 0x1241
 +vendor.name		Belkin
@@ -61687,6 +64637,13 @@
  vendor.id		usb 0x1241
 &device.id		usb 0xf767
 +device.name		Keyboard
+
+ vendor.id		usb 0x1243
++vendor.name		Holtek Semiconductor, Inc.
+
+ vendor.id		usb 0x1243
+&device.id		usb 0xe000
++device.name		Unique NFC/RFID reader (keyboard emulation)
 
  vendor.id		usb 0x124a
 +vendor.name		AirVast
@@ -61728,6 +64685,13 @@
 &device.id		usb 0x0010
 +device.name		Alta series CCD
 
+ vendor.id		usb 0x125d
++vendor.name		JMicron
+
+ vendor.id		usb 0x125d
+&device.id		usb 0x0580
++device.name		JM580
+
  vendor.id		usb 0x125f
 +vendor.name		A-DATA Technology Co., Ltd.
 
@@ -61746,6 +64710,10 @@
  vendor.id		usb 0x125f
 &device.id		usb 0xa22a
 +device.name		DashDrive Elite HE720 500GB
+
+ vendor.id		usb 0x125f
+&device.id		usb 0xa31a
++device.name		HV620 Portable HDD
 
  vendor.id		usb 0x125f
 &device.id		usb 0xa91a
@@ -61856,6 +64824,10 @@
  vendor.id		usb 0x1275
 &device.id		usb 0x0080
 +device.name		SkyEye Weather Satellite Receiver
+
+ vendor.id		usb 0x1275
+&device.id		usb 0x0090
++device.name		WeatherFax 2000 Demodulator
 
  vendor.id		usb 0x1278
 +vendor.name		Starlight Xpress
@@ -61995,6 +64967,10 @@
 +device.name		K30326 802.11bgn Wireless Module [Marvell 88W8786U]
 
  vendor.id		usb 0x1286
+&device.id		usb 0x204c
++device.name		Bluetooth and Wireless LAN Composite
+
+ vendor.id		usb 0x1286
 &device.id		usb 0x8001
 +device.name		BLOB boot loader firmware
 
@@ -62073,6 +65049,22 @@
 
  vendor.id		usb 0x12ab
 +vendor.name		Honey Bee Electronic International Ltd.
+
+ vendor.id		usb 0x12ab
+&device.id		usb 0x0004
++device.name		Dance Pad for Xbox 360
+
+ vendor.id		usb 0x12ab
+&device.id		usb 0x0301
++device.name		Afterglow Wired Controller for Xbox 360
+
+ vendor.id		usb 0x12ab
+&device.id		usb 0x0303
++device.name		Mortal Kombat Klassic FightStick for Xbox 360
+
+ vendor.id		usb 0x12ab
+&device.id		usb 0x8809
++device.name		Dance Dance Revolution Dance Pad
 
  vendor.id		usb 0x12b8
 +vendor.name		Zhejiang Xinya Electronic Technology Co., Ltd.
@@ -62189,7 +65181,23 @@
 
  vendor.id		usb 0x12d1
 &device.id		usb 0x1052
-+device.name		MT7-L09
++device.name		MT7-L09 / P7-L10 / Y330-U01
+
+ vendor.id		usb 0x12d1
+&device.id		usb 0x1053
++device.name		P7-L10 (PTP)
+
+ vendor.id		usb 0x12d1
+&device.id		usb 0x1054
++device.name		P7-L10 (PTP + debug)
+
+ vendor.id		usb 0x12d1
+&device.id		usb 0x1079
++device.name		GEM-703LT [Honor/MediaPad X2]
+
+ vendor.id		usb 0x12d1
+&device.id		usb 0x107e
++device.name		P10 smartphone
 
  vendor.id		usb 0x12d1
 &device.id		usb 0x1404
@@ -62253,7 +65261,7 @@
 
  vendor.id		usb 0x12d1
 &device.id		usb 0x14dc
-+device.name		E33372 LTE/UMTS/GSM HiLink Modem/Networkcard
++device.name		E3372 LTE/UMTS/GSM HiLink Modem/Networkcard
 
  vendor.id		usb 0x12d1
 &device.id		usb 0x14f1
@@ -62290,6 +65298,10 @@
  vendor.id		usb 0x12d1
 &device.id		usb 0x155a
 +device.name		R205 Mobile WiFi (CD-ROM mode)
+
+ vendor.id		usb 0x12d1
+&device.id		usb 0x1573
++device.name		ME909u-521 mPCIe LTE/GPS card
 
  vendor.id		usb 0x12d1
 &device.id		usb 0x1575
@@ -62336,11 +65348,22 @@
 +device.name		K5150 LTE modem (Mass Storage Mode)
 
  vendor.id		usb 0x12d1
+&device.id		usb 0x360e
++device.name		Y330-U01 (MTP Mode)
+
+ vendor.id		usb 0x12d1
 &device.id		usb 0x380b
 +device.name		WiMAX USB modem(s)
 
  vendor.id		usb 0x12d2
 +vendor.name		LINE TECH INDUSTRIAL CO., LTD.
+
+ vendor.id		usb 0x12d3
++vendor.name		LINAK
+
+ vendor.id		usb 0x12d3
+&device.id		usb 0x0002
++device.name		DeskLine CBD Control Box
 
  vendor.id		usb 0x12d6
 +vendor.name		EMS Dr. Thomas Wuensche
@@ -62411,6 +65434,9 @@
  vendor.id		usb 0x12ff
 &device.id		usb 0x0101
 +device.name		Advanced RC Servo Controller
+
+ vendor.id		usb 0x1306
++vendor.name		FM20 Barcode Scanner
 
  vendor.id		usb 0x1307
 +vendor.name		Transcend Information, Inc.
@@ -62500,12 +65526,20 @@
 +device.name		TXP-Series Slot (TXP5001, TXP5004)
 
  vendor.id		usb 0x1313
+&device.id		usb 0x8011
++device.name		BP1 Slit Beam Profiler
+
+ vendor.id		usb 0x1313
 &device.id		usb 0x8012
 +device.name		BC106 Camera Beam Profiler
 
  vendor.id		usb 0x1313
 &device.id		usb 0x8013
 +device.name		WFS10 Wavefront Sensor
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8016
++device.name		DMP40 Deformable Mirror
 
  vendor.id		usb 0x1313
 &device.id		usb 0x8017
@@ -62528,8 +65562,56 @@
 +device.name		PM320E Optical Power and Energy Meter
 
  vendor.id		usb 0x1313
+&device.id		usb 0x8025
++device.name		WFS20 Wavefront Sensor
+
+ vendor.id		usb 0x1313
 &device.id		usb 0x8030
 +device.name		ER100 Extinction Ratio Meter
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8039
++device.name		PAX1000 Rotating Waveplate Polarimeter
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8047
++device.name		CLD1000
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8048
++device.name		TED4000
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8049
++device.name		LDC4000
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x804a
++device.name		ITC4000
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8058
++device.name		LC-100
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8060
++device.name		DC3100
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8061
++device.name		DC4100
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8062
++device.name		DC2100
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8065
++device.name		CS2010
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8066
++device.name		DC4104
 
  vendor.id		usb 0x1313
 &device.id		usb 0x8070
@@ -62540,12 +65622,84 @@
 +device.name		PM100USB Power and Energy Meter Interface
 
  vendor.id		usb 0x1313
+&device.id		usb 0x8073
++device.name		PM106 Wireless Powermeter Photodiode Sensor
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8074
++device.name		PM160T Wireless Powermeter Thermal Sensor
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8075
++device.name		PM400 Handheld Optical Power/Energy Meter
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8076
++device.name		PM101 Serial PD Power Meter
+
+ vendor.id		usb 0x1313
 &device.id		usb 0x8078
 +device.name		PM100D Compact Power and Energy Meter Console
 
  vendor.id		usb 0x1313
 &device.id		usb 0x8080
 +device.name		CCS100 - Compact Spectrometer
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8081
++device.name		CCS100 Compact Spectrometer
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8083
++device.name		CCS125 Spectrometer
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8085
++device.name		CCS150 UV Spectrometer
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8087
++device.name		CCS175 NIR Spectrometer
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8089
++device.name		CCS200 Wide Range Spectrometer
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8090
++device.name		SPCM Single Photon Counter
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x80a0
++device.name		LC100 series smart line camera
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x80b0
++device.name		PM200 Handheld Power and Energy Meter
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x80c0
++device.name		DC2200
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x80c9
++device.name		MTD Series
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x80f0
++device.name		TSP01
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x80f1
++device.name		M2SET Dongle
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8180
++device.name		OCT Probe Controller (OCTH-1300)
+
+ vendor.id		usb 0x1313
+&device.id		usb 0x8181
++device.name		OCT Device
 
  vendor.id		usb 0x131d
 +vendor.name		Natural Point
@@ -62564,6 +65718,14 @@
 
  vendor.id		usb 0x1325
 +vendor.name		ams AG
+
+ vendor.id		usb 0x1325
+&device.id		usb 0x00d6
++device.name		I2C/SPI InterfaceBoard
+
+ vendor.id		usb 0x1325
+&device.id		usb 0x0c08
++device.name		Embedded Linux Sensor Bridge
 
  vendor.id		usb 0x1325
 &device.id		usb 0x4002
@@ -62750,7 +65912,7 @@
 
  vendor.id		usb 0x1343
 &device.id		usb 0x0006
-+device.name		CW-02
++device.name		CW-02 / OP900ii
 
  vendor.id		usb 0x1343
 &device.id		usb 0x0007
@@ -62758,7 +65920,15 @@
 
  vendor.id		usb 0x1343
 &device.id		usb 0x0008
-+device.name		CX2 / DNP DS620
++device.name		DNP DS620 (old)
+
+ vendor.id		usb 0x1343
+&device.id		usb 0x000a
++device.name		CX-02
+
+ vendor.id		usb 0x1343
+&device.id		usb 0x000b
++device.name		CX-02W
 
  vendor.id		usb 0x1345
 +vendor.name		Sino Lite Technology Corp.
@@ -62874,6 +66044,37 @@
 &device.id		usb 0x0504
 +device.name		DEMOJM
 
+ vendor.id		usb 0x1357
+&device.id		usb 0x1000
++device.name		Smart Control Touchpad
+
+ vendor.id		usb 0x135e
++vendor.name		Insta GmbH
+
+ vendor.id		usb 0x135e
+&device.id		usb 0x0021
++device.name		Berker KNX Data Interface
+
+ vendor.id		usb 0x135e
+&device.id		usb 0x0022
++device.name		Gira KNX Data Interface
+
+ vendor.id		usb 0x135e
+&device.id		usb 0x0023
++device.name		JUNG KNX Data Interface
+
+ vendor.id		usb 0x135e
+&device.id		usb 0x0024
++device.name		Merten/Schneider Electric KNX Data Interface
+
+ vendor.id		usb 0x135e
+&device.id		usb 0x0025
++device.name		Hager KNX Data Interface
+
+ vendor.id		usb 0x135e
+&device.id		usb 0x0026
++device.name		Feller KNX Data Interface
+
  vendor.id		usb 0x135f
 +vendor.name		Control Development Inc.
 
@@ -62903,6 +66104,10 @@
  vendor.id		usb 0x1366
 &device.id		usb 0x0101
 +device.name		J-Link PLUS
+
+ vendor.id		usb 0x1366
+&device.id		usb 0x1015
++device.name		J-Link
 
  vendor.id		usb 0x136b
 +vendor.name		STEC
@@ -62980,6 +66185,21 @@
  vendor.id		usb 0x137b
 &device.id		usb 0x0002
 +device.name		SCAPS USC-2 Scanner Controller
+
+ vendor.id		usb 0x137c
++vendor.name		YASKAWA ELECTRIC CORP.
+
+ vendor.id		usb 0x137c
+&device.id		usb 0x0220
++device.name		MP Series
+
+ vendor.id		usb 0x137c
+&device.id		usb 0x0250
++device.name		SIGMA Series
+
+ vendor.id		usb 0x137c
+&device.id		usb 0x0401
++device.name		AC Drive
 
  vendor.id		usb 0x1385
 +vendor.name		Netgear, Inc
@@ -63083,7 +66303,7 @@
 
  vendor.id		usb 0x1390
 &device.id		usb 0x0001
-+device.name		GO 520 T/GO 630/ONE XL (v9)
++device.name		GO 520 T / GO 630 / ONE / ONE XL
 
  vendor.id		usb 0x1390
 &device.id		usb 0x5454
@@ -63112,8 +66332,172 @@
 +device.name		Headset [PC 8]
 
  vendor.id		usb 0x1395
+&device.id		usb 0x0026
++device.name		SC230
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0027
++device.name		SC260
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0028
++device.name		SC230 CTRL
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0029
++device.name		SC260 CTRL
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x002a
++device.name		SC230 for Lync
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x002b
++device.name		SC260 for Lync
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x002d
++device.name		BTD-800
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x002e
++device.name		Presence
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0030
++device.name		CEHS-CI 02
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0031
++device.name		U320 Gaming
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0032
++device.name		SC30 for Lync
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0033
++device.name		SC60 for Lync
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0034
++device.name		SC30 Control
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0035
++device.name		SC60 Control
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0036
++device.name		SC630 for Lync
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0037
++device.name		SC660 for Lync
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0038
++device.name		SC630 CTRL
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0039
++device.name		SC660 CTRL
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x003f
++device.name		SP 20
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0040
++device.name		MB Pro 1/2
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0041
++device.name		SP 20 for Lync
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0042
++device.name		SP 10
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0043
++device.name		SP 10 for Lync
+
+ vendor.id		usb 0x1395
 &device.id		usb 0x0046
 +device.name		PXC 550
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x004a
++device.name		MOMENTUM M2 OEBT
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x004b
++device.name		MOMENTUM M2 AEBT
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x004f
++device.name		SC230 for MS II
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0050
++device.name		SC260 for MS II
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0051
++device.name		USB-ED CC 01
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0058
++device.name		USB-ED CC 01 for MS
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0059
++device.name		SC40 for MS
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x005a
++device.name		SC70 for MS
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x005b
++device.name		SC40 CTRL
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x005c
++device.name		SC70 CTRL
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0060
++device.name		SCx5 MS
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0061
++device.name		SCx5 CTRL
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0064
++device.name		MB 660 MS
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0065
++device.name		MB 660
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0066
++device.name		SP 20 D UC
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0067
++device.name		SP 20 D MS
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x006b
++device.name		SC5x5 MS
+
+ vendor.id		usb 0x1395
+&device.id		usb 0x0072
++device.name		Headset
 
  vendor.id		usb 0x1395
 &device.id		usb 0x3556
@@ -63121,6 +66505,10 @@
 
  vendor.id		usb 0x1397
 +vendor.name		BEHRINGER International GmbH
+
+ vendor.id		usb 0x1397
+&device.id		usb 0x0004
++device.name		FCA1616
 
  vendor.id		usb 0x1397
 &device.id		usb 0x00bc
@@ -63513,6 +66901,10 @@
 +device.name		Atheros AR3012 Bluetooth
 
  vendor.id		usb 0x13d3
+&device.id		usb 0x3526
++device.name		Bluetooth Radio
+
+ vendor.id		usb 0x13d3
 &device.id		usb 0x5070
 +device.name		Webcam
 
@@ -63545,6 +66937,18 @@
 +device.name		Integrated Webcam
 
  vendor.id		usb 0x13d3
+&device.id		usb 0x5615
++device.name		Lenovo EasyCamera
+
+ vendor.id		usb 0x13d3
+&device.id		usb 0x5670
++device.name		HP TrueVision HD
+
+ vendor.id		usb 0x13d3
+&device.id		usb 0x5682
++device.name		SunplusIT Integrated Camera
+
+ vendor.id		usb 0x13d3
 &device.id		usb 0x5702
 +device.name		UVC VGA Webcam
 
@@ -63557,12 +66961,20 @@
 +device.name		UVC VGA Webcam
 
  vendor.id		usb 0x13d3
+&device.id		usb 0x5a07
++device.name		VGA UVC WebCam
+
+ vendor.id		usb 0x13d3
 &device.id		usb 0x7020
 +device.name		DTV-DVB UDST7020BDA DVB-S Box(DVBS for MCE2005)
 
  vendor.id		usb 0x13d3
 &device.id		usb 0x7022
 +device.name		DTV-DVB UDST7022BDA DVB-S Box(Without HID)
+
+ vendor.id		usb 0x13d3
+&device.id		usb 0x784b
++device.name		XHC Camera
 
  vendor.id		usb 0x13d7
 +vendor.name		Guidance Software, Inc.
@@ -63627,6 +67039,10 @@
 +vendor.name		Initio Corporation
 
  vendor.id		usb 0x13fd
+&device.id		usb 0x0550
++device.name		INIC-1530 PATA Bridge
+
+ vendor.id		usb 0x13fd
 &device.id		usb 0x0840
 +device.name		INIC-1618L SATA
 
@@ -63671,8 +67087,16 @@
 +device.name		Samsung Writemaster external DVD writer
 
  vendor.id		usb 0x13fd
+&device.id		usb 0x3920
++device.name		INIC-3619PN SATA Bridge
+
+ vendor.id		usb 0x13fd
 &device.id		usb 0x3940
 +device.name		external DVD burner ECD819-SU3
+
+ vendor.id		usb 0x13fd
+&device.id		usb 0x3960
++device.name		INIC-3639
 
  vendor.id		usb 0x13fd
 &device.id		usb 0x3e40
@@ -63722,6 +67146,10 @@
 +device.name		Verbatim STORE N GO 4GB
 
  vendor.id		usb 0x13fe
+&device.id		usb 0x3200
++device.name		flash drive (2GB, EMTEC)
+
+ vendor.id		usb 0x13fe
 &device.id		usb 0x3600
 +device.name		flash drive (4GB, EMTEC)
 
@@ -63730,12 +67158,20 @@
 +device.name		Rage XT Flash Drive
 
  vendor.id		usb 0x13fe
+&device.id		usb 0x3d00
++device.name		Flash Drive
+
+ vendor.id		usb 0x13fe
 &device.id		usb 0x3e00
 +device.name		Flash Drive
 
  vendor.id		usb 0x13fe
 &device.id		usb 0x4100
 +device.name		Flash drive
+
+ vendor.id		usb 0x13fe
+&device.id		usb 0x4200
++device.name		Platinum USB drive mini
 
  vendor.id		usb 0x13fe
 &device.id		usb 0x5000
@@ -63748,6 +67184,14 @@
  vendor.id		usb 0x13fe
 &device.id		usb 0x5200
 +device.name		DataTraveler R3.0
+
+ vendor.id		usb 0x13fe
+&device.id		usb 0x5500
++device.name		Flash drive
+
+ vendor.id		usb 0x13fe
+&device.id		usb 0x6300
++device.name		SP Mobile C31 (64GB)
 
  vendor.id		usb 0x1400
 +vendor.name		Axxion Group Corp.
@@ -63766,6 +67210,13 @@
 &device.id		usb 0x0003
 +device.name		Digital Photo Frame (DPF-1104)
 
+ vendor.id		usb 0x1404
++vendor.name		Fundamental Software, Inc.
+
+ vendor.id		usb 0x1404
+&device.id		usb 0xcddc
++device.name		Dongle
+
  vendor.id		usb 0x1409
 +vendor.name		IDS Imaging Development Systems GmbH
 
@@ -63776,6 +67227,10 @@
  vendor.id		usb 0x1409
 &device.id		usb 0x1485
 +device.name		uEye UI1485
+
+ vendor.id		usb 0x1409
+&device.id		usb 0x3240
++device.name		uEye UI3240
 
  vendor.id		usb 0x140e
 +vendor.name		Telechips, Inc.
@@ -64012,8 +67467,20 @@
 +device.name		Guitar Hero4 hub
 
  vendor.id		usb 0x1430
+&device.id		usb 0x4748
++device.name		Guitar Hero X-plorer
+
+ vendor.id		usb 0x1430
 &device.id		usb 0x474b
 +device.name		Guitar Hero MIDI interface
+
+ vendor.id		usb 0x1430
+&device.id		usb 0x8888
++device.name		TX6500+ Dance Pad
+
+ vendor.id		usb 0x1430
+&device.id		usb 0xf801
++device.name		Controller
 
  vendor.id		usb 0x1431
 +vendor.name		Pertech Resources, Inc.
@@ -64127,6 +67594,10 @@
 &device.id		usb 0x8b01
 +device.name		DS620
 
+ vendor.id		usb 0x1452
+&device.id		usb 0x9001
++device.name		DS820
+
  vendor.id		usb 0x1453
 +vendor.name		Radio Shack
 
@@ -64223,6 +67694,22 @@
 &device.id		usb 0x0176
 +device.name		Isla Keyboard
 
+ vendor.id		usb 0x145f
+&device.id		usb 0x019f
++device.name		17676 Webcam
+
+ vendor.id		usb 0x145f
+&device.id		usb 0x01e5
++device.name		Keyboard [GXT 830]
+
+ vendor.id		usb 0x145f
+&device.id		usb 0x0212
++device.name		Panora Widescreen Graphic Tablet
+
+ vendor.id		usb 0x145f
+&device.id		usb 0x023f
++device.name		Mouse [GXT 168]
+
  vendor.id		usb 0x1460
 +vendor.name		Tatung Co.
 
@@ -64243,6 +67730,17 @@
  vendor.id		usb 0x1462
 &device.id		usb 0x8807
 +device.name		DIGIVOX mini III [af9015]
+
+ vendor.id		usb 0x146b
++vendor.name		BigBen Interactive
+
+ vendor.id		usb 0x146b
+&device.id		usb 0x0601
++device.name		Controller for Xbox 360
+
+ vendor.id		usb 0x146b
+&device.id		usb 0x0902
++device.name		Wired Mini PS3 Game Controller
 
  vendor.id		usb 0x1472
 +vendor.name		Huawei-3Com
@@ -64510,6 +68008,10 @@
 +vendor.name		Imagination Technologies
 
  vendor.id		usb 0x149a
+&device.id		usb 0x069b
++device.name		PURE Digital Evoke-1XT Tri-band
+
+ vendor.id		usb 0x149a
 &device.id		usb 0x2107
 +device.name		DBX1 DSP core
 
@@ -64551,6 +68053,10 @@
 
  vendor.id		usb 0x14b0
 +vendor.name		StarTech.com Ltd.
+
+ vendor.id		usb 0x14b0
+&device.id		usb 0x3410
++device.name		Serial Adapter ICUSB2321X [TUSB3410I]
 
  vendor.id		usb 0x14b2
 +vendor.name		Ralink Technology, Corp.
@@ -64668,6 +68174,10 @@
 +device.name		SDXC Reader
 
  vendor.id		usb 0x14cd
+&device.id		usb 0x168a
++device.name		Elecom Co., Ltd MR-K013 Multicard Reader
+
+ vendor.id		usb 0x14cd
 &device.id		usb 0x6116
 +device.name		M6116 SATA Bridge
 
@@ -64745,8 +68255,44 @@
 +vendor.name		Shure Inc.
 
  vendor.id		usb 0x14ed
+&device.id		usb 0x1000
++device.name		MV5
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x1002
++device.name		MV51
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x1003
++device.name		MVi
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x1004
++device.name		SHA900
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x1005
++device.name		KSE1500
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x1011
++device.name		MV88+
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x1100
++device.name		ANIUSB-MATRIX
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x1101
++device.name		P300
+
+ vendor.id		usb 0x14ed
 &device.id		usb 0x29b6
 +device.name		X2u Adapter
+
+ vendor.id		usb 0x14ed
+&device.id		usb 0x3000
++device.name		RMCE-USB
 
  vendor.id		usb 0x14f7
 +vendor.name		TechniSat Digital GmbH
@@ -64776,6 +68322,16 @@
 
  vendor.id		usb 0x1501
 +vendor.name		Pine-Tum Enterprise Co., Ltd.
+
+ vendor.id		usb 0x1504
++vendor.name		Bixolon CO LTD
+
+ vendor.id		usb 0x1504
+&device.id		usb 0x001f
++device.name		SRP-350II Thermal Receipt Printer
+
+ vendor.id		usb 0x1508
++vendor.name		Fibocom
 
  vendor.id		usb 0x1509
 +vendor.name		First International Computer, Inc.
@@ -65112,12 +68668,24 @@
 +device.name		JMS551 - Sharkoon SATA QuickPort Duo
 
  vendor.id		usb 0x152d
+&device.id		usb 0x0562
++device.name		JMS567 SATA 6Gb/s bridge
+
+ vendor.id		usb 0x152d
 &device.id		usb 0x0567
 +device.name		JMS567 SATA 6Gb/s bridge
 
  vendor.id		usb 0x152d
+&device.id		usb 0x0576
++device.name		Gen1 SATA 6Gb/s Bridge
+
+ vendor.id		usb 0x152d
 &device.id		usb 0x0578
-+device.name		JMS567 SATA 6Gb/s bridge
++device.name		JMS578 SATA 6Gb/s
+
+ vendor.id		usb 0x152d
+&device.id		usb 0x0583
++device.name		JMS583Gen 2 to PCIe Gen3x2 Bridge
 
  vendor.id		usb 0x152d
 &device.id		usb 0x0770
@@ -65126,6 +68694,10 @@
  vendor.id		usb 0x152d
 &device.id		usb 0x1561
 +device.name		JMS561U two ports SATA 6Gb/s bridge
+
+ vendor.id		usb 0x152d
+&device.id		usb 0x1576
++device.name		External Disk 3.0
 
  vendor.id		usb 0x152d
 &device.id		usb 0x2329
@@ -65183,12 +68755,28 @@
 &device.id		usb 0x3569
 +device.name		JMS566 SATA 3Gb/s bridge
 
+ vendor.id		usb 0x152d
+&device.id		usb 0x578e
++device.name		JMS578 SATA 6Gb/s bridge
+
+ vendor.id		usb 0x152d
+&device.id		usb 0x8561
++device.name		salcar docking station two disks
+
  vendor.id		usb 0x152e
 +vendor.name		LG (HLDS)
 
  vendor.id		usb 0x152e
+&device.id		usb 0x1640
++device.name		INIC-1605 SATA Bridge
+
+ vendor.id		usb 0x152e
 &device.id		usb 0x2507
 +device.name		PL-2507 IDE Controller
+
+ vendor.id		usb 0x152e
+&device.id		usb 0x2571
++device.name		GP08NU6W DVD-RW
 
  vendor.id		usb 0x152e
 &device.id		usb 0xe001
@@ -65202,16 +68790,52 @@
 +device.name		RZ01-020300 Optical Mouse [Diamondback]
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0002
++device.name		Diamondback Optical Mouse
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0003
 +device.name		Krait Mouse
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0005
++device.name		Boomslang CE
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0007
 +device.name		DeathAdder Mouse
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0009
++device.name		Gaming Mouse [Tempest Habu]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x000a
++device.name		Mamba (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x000c
++device.name		Lachesis
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x000d
++device.name		DiamondBack 3G
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x000e
++device.name		Megalodon
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x000f
++device.name		Mamba (Wireless)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0012
++device.name		Gaming Mouse [Salmosa]
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0013
-+device.name		Orochi mouse
++device.name		Orochi 2011
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0015
@@ -65219,31 +68843,135 @@
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0016
-+device.name		DeathAdder Mouse
++device.name		DeathAdder 3.5G
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0017
 +device.name		RZ01-0035 Laser Gaming Mouse [Imperator]
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0019
++device.name		Marauder
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x001a
++device.name		Spectre
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x001b
++device.name		Gaming Headset
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x001c
 +device.name		RZ01-0036 Optical Gaming Mouse [Abyssus]
 
  vendor.id		usb 0x1532
+&device.id		usb 0x001e
++device.name		Lachesis (5600 DPI)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x001f
++device.name		Naga Epic (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0020
++device.name		Abyssus 1800
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0021
++device.name		Naga Epic Dock (Wireless, Bluetooth)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0022
++device.name		Gaming Mouse [TRON]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0023
++device.name		Gaming Keyboard [TRON]
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0024
-+device.name		Mamba
++device.name		Mamba 2012 (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0025
++device.name		Mamba 2012 (Wireless)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0029
++device.name		DeathAdder Black Edition
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x002a
++device.name		Gaming Mouse [Star Wars: The Old Republic]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x002b
++device.name		Gaming Keyboard [Star Wars: The Old Republic]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x002c
++device.name		Gaming Headset [Star Wars: The Old Republic]
 
  vendor.id		usb 0x1532
 &device.id		usb 0x002e
-+device.name		RZ01-0058 Gaming Mouse [Naga]
++device.name		RZ01-0058 Gaming Mouse [Naga 2012]
 
  vendor.id		usb 0x1532
 &device.id		usb 0x002f
 +device.name		Imperator 2012
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0031
++device.name		Gaming Mouse Dock [Star Wars: The Old Republic]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0032
++device.name		Ouroboros 2012 (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0033
++device.name		Ouroboros 2012 (Wireless)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0034
++device.name		Taipan
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0035
++device.name		Krait 2013 Essential
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0036
-+device.name		RZ01-0075, Gaming Mouse [Naga Hex]
++device.name		RZ01-0075, Gaming Mouse [Naga Hex (Red)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0037
++device.name		DeathAdder 2013
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0038
++device.name		DeathAdder 1800
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0039
++device.name		Orochi 2013
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x003e
++device.name		Naga Epic Chroma (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x003f
++device.name		Naga Epic Chroma (Wireless)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0040
++device.name		Naga 2014
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0041
++device.name		Naga Hex
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0042
@@ -65267,7 +68995,167 @@
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0048
-+device.name		Orochi (Wired)
++device.name		Orochi 2015 (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x004a
++device.name		RZ03-0133 Gaming Lapboard, Keyboard Mouse Combo, Dongle [Turret Dongle]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x004c
++device.name		Diamondback Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x004d
++device.name		DeathAdder 2000 (Cynosa Pro Bundle)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x004f
++device.name		RZ01-0145, Gaming Mouse [DeathAdder 2000 (Alternate)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0050
++device.name		Naga Hex V2
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0053
++device.name		Naga Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0054
++device.name		DeathAdder 3500
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0056
++device.name		Orochi 2015 (Wireless)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0059
++device.name		RZ01-0212 Gaming Mouse [Lancehead (Wired)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x005a
++device.name		RZ01-0212 Gaming Mouse [Lancehead (Wireless)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x005b
++device.name		Abyssus V2
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x005c
++device.name		DeathAdder Elite
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x005e
++device.name		Abyssus 2000
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x005f
++device.name		DeathAdder 2000
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0060
++device.name		RZ01-0213 Gaming Mouse [Lancehead Tournament Edition]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0062
++device.name		Atheris
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0064
++device.name		Basilisk
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0065
++device.name		RZ01-0265, Gaming Mouse [Basilisk Essential]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0067
++device.name		Naga Trinity
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0068
++device.name		Gaming Mouse Mat [Firefly Hyperflux]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0069
++device.name		Gaming Mouse [Mamba Hyperflux]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x006a
++device.name		Abyssus Elite (D.Va Edition)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x006b
++device.name		Abyssus Essential
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x006c
++device.name		Mamba Elite (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x006e
++device.name		DeathAdder Essential
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x006f
++device.name		RZ01-0257 Gaming Mouse [Lancehead Wireless (2019, Wireless, Receiver)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0070
++device.name		RZ01-0257 Gaming Mouse [Lancehead Wireless (2019, Wired)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0071
++device.name		RZ01-0254 Gaming Mouse [DeathAdder Essential White Edition]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0072
++device.name		Mamba 2018 (Wireless)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0073
++device.name		Mamba 2018 (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0078
++device.name		Viper (wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x007a
++device.name		RC30-0305 Gaming Mouse [Viper Ultimate (Wired)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x007b
++device.name		RC30-0305 Gaming Mouse Dongle [Viper Ultimate (Wireless)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x007e
++device.name		RC30-030502 Mouse Dock
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0083
++device.name		RC30-0315, Gaming Mouse [Basilisk X HyperSpeed]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0084
++device.name		RZ01-0321 Gaming Mouse [DeathAdder V2]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0085
++device.name		RZ01-0316 Gaming Mouse [Basilisk V2]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0086
++device.name		Gaming Mouse [Basilisk Ultimate, Wired]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0088
++device.name		Gaming Mouse [Basilisk Ultimate, Wireless, Receiver]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x008a
++device.name		RZ01-0325, Gaming Mouse [Viper Mini]
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0101
@@ -65278,20 +69166,64 @@
 +device.name		Tarantula Keyboard
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0103
++device.name		Gaming Keyboard [Reclusa]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0105
++device.name		Gaming Keyboard [ProType]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0106
++device.name		Gaming Keyboard [ProType]
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0109
 +device.name		Lycosa Keyboard
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x010b
++device.name		Gaming Keyboard [Arctosa]
 
  vendor.id		usb 0x1532
 &device.id		usb 0x010d
 +device.name		BlackWidow Ultimate 2012
 
  vendor.id		usb 0x1532
+&device.id		usb 0x010e
++device.name		BlackWidow Classic (Alternate)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x010f
++device.name		Anansi
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0110
++device.name		Cyclosa
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0111
++device.name		Nostromo
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0113
 +device.name		RZ07-0074 Gaming Keypad [Orbweaver]
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0114
++device.name		DeathStalker Ultimate
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0116
++device.name		Blade Pro (2015)
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0118
-+device.name		RZ03-0080, Gaming Keyboard [Deathstalker]
++device.name		RZ03-0080, Gaming Keyboard [Deathstalker Essential]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0119
++device.name		Gaming Keyboard [Lycosa]
 
  vendor.id		usb 0x1532
 &device.id		usb 0x011a
@@ -65302,44 +69234,420 @@
 +device.name		BlackWidow Classic
 
  vendor.id		usb 0x1532
+&device.id		usb 0x011c
++device.name		BlackWidow Tournament Edition Stealth
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x011d
++device.name		Blade 2013
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x011e
++device.name		Gaming Keyboard Dock [Edge Keyboard Dock]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x011f
++device.name		Deathstalker Essential 2014
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0200
++device.name		Gaming Keyboard [Reclusa]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0201
++device.name		Tartarus
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0202
++device.name		DeathStalker Expert
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0203
 +device.name		BlackWidow Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0204
++device.name		DeathStalker Chroma
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0205
 +device.name		Blade Stealth
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0207
++device.name		Orbweaver Chroma keypad
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0208
-+device.name		Tartarus
++device.name		Tartarus Chroma
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0209
 +device.name		BlackWidow Tournament Edition Chroma
 
  vendor.id		usb 0x1532
+&device.id		usb 0x020d
++device.name		Cynosa Pro keyboard (Cynosa Pro Bundle)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x020f
++device.name		Blade QHD
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0210
++device.name		Blade Pro (Late 2016)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0211
++device.name		BlackWidow Chroma (Overwatch)
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0214
 +device.name		BlackWidow Ultimate 2016
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0215
++device.name		Core
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0216
 +device.name		BlackWidow X Chroma
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0217
++device.name		BlackWidow X Ultimate
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x021a
 +device.name		BlackWidow X Tournament Edition Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x021b
++device.name		Gaming Keyboard [BlackWidow X Tournament Edition]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x021e
++device.name		Ornata Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x021f
++device.name		Ornata
 
  vendor.id		usb 0x1532
 &device.id		usb 0x0220
 +device.name		Blade Stealth (2016)
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0221
++device.name		RZ03-0203 Gaming Keyboard [BlackWidow Chroma V2]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0224
++device.name		Blade (Late 2016)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0225
++device.name		Blade Pro (2017)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0226
++device.name		Huntsman Elite
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0227
++device.name		Huntsman
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0228
++device.name		BlackWidow Elite
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x022a
++device.name		Cynosa Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x022b
++device.name		Tartarus V2
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x022c
++device.name		Cynosa Chroma Pro
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x022d
++device.name		Blade Stealth (Mid 2017)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x022f
++device.name		Blade Pro FullHD (2017)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0232
++device.name		Blade Stealth (Late 2017)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0233
++device.name		Blade 15 (2018)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0234
++device.name		Blade Pro 17 (2019)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0235
++device.name		BlackWidow Lite (2018)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0237
++device.name		BlackWidow Essential
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0239
++device.name		Blade Stealth (2019)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x023a
++device.name		Blade 15 (2019) Advanced
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x023b
++device.name		Blade 15 (2018) Base Model
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x023f
++device.name		RZ03-0274 Gaming Keyboard [Cynosa Lite]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0240
++device.name		Blade 15 (2018) Mercury
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0241
++device.name		BlackWidow (2019)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0243
++device.name		Huntsman Tournament Edition
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0244
++device.name		RZ07-0311 Gaming Keypad [Tartarus Pro]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0245
++device.name		Blade 15 (Mid 2019) Mercury
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0246
++device.name		Blade 15 (Mid 2019) Base Model
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x024a
++device.name		Blade Stealth (Late 2019)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x024b
++device.name		Gaming Laptop [Blade 15 Advanced (Late 2019)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x024c
++device.name		Gaming Laptop [Blade Pro (Late 2019)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x024d
++device.name		Blade 15 Studio Edition (2019)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0253
++device.name		RZ09-0330, Gaming Laptop [Blade 15 Advanced (Early 2020)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0255
++device.name		RZ09-0328, Gaming Laptop [Blade 15 Base Model (2020)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0256
++device.name		RZ09--0329, Gaming Laptop [Blade Pro 17 Full HD (2020)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x025d
++device.name		RZ03-0338, Gaming Keyboard [Ornata V2]
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0300
 +device.name		RZ06-0063 Motion Sensing Controllers [Hydra]
 
  vendor.id		usb 0x1532
+&device.id		usb 0x0401
++device.name		Gaming Arcade Stick [Panthera]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0501
++device.name		Kraken 7.1
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0502
++device.name		Gaming Headset [Kraken USB]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0504
++device.name		Kraken 7.1 Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0506
++device.name		Kraken 7.1 (Alternate Version)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0510
++device.name		Kraken 7.1 V2
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0511
++device.name		RZ19-0229 Gaming Microphone
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0514
++device.name		Electra V2 USB
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0517
++device.name		Nommo Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0518
++device.name		Nommo Pro
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x051a
++device.name		Nari Ultimate
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x051c
++device.name		Nari (Wireless)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x051d
++device.name		Nari (Wired)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x051e
++device.name		RC30-026902, Gaming Headset [Nari Essential, Wireless, Receiver]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x051f
++device.name		RC30-026901, Gaming Headset [Nari Essential, Wired]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0520
++device.name		Kraken Tournament Edition
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0521
++device.name		Kraken Kitty Edition
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0527
++device.name		RZ04-0318 Gaming Headset [Kraken Ultimate]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0904
++device.name		R201-0282 Gaming Keyboard, Mouse Combination [Turret For Xbox One]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0a00
++device.name		Atrox Arcade Stick for Xbox One
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0a02
++device.name		ManO'War
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0a03
++device.name		Wildcat
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0a15
++device.name		RZ06-0199, Gaming Controller [Wolverine Tournament Edition]
+
+ vendor.id		usb 0x1532
 &device.id		usb 0x0c00
-+device.name		Firefly
++device.name		RZ02-0135 Hard Gaming Mouse Mat [Firefly]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0c01
++device.name		Goliathus
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0c02
++device.name		Goliathus Extended
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0c04
++device.name		Firefly V2
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0e03
++device.name		Gaming Webcam [Kiyo]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0f03
++device.name		Tiamat 7.1 V2
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0f07
++device.name		Chroma Mug Holder
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0f08
++device.name		Base Station Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0f09
++device.name		Chroma HDK
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0f0d
++device.name		Laptop Stand Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0f13
++device.name		Lian Li O11 Dynamic Razer Edition
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x0f1a
++device.name		Core X Chroma
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x1000
++device.name		Gaming Controller [Raiju]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x1004
++device.name		Gaming Controller [Raiju Ultimate Wired]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x1007
++device.name		Gaming Controller [Raiju 2 Tournament Edition (USB)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x1008
++device.name		Gaming Flightstick [Panthera Evo]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x1009
++device.name		Gaming Controller [Raiju 2 Ultimate Edition (BT)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x100a
++device.name		Gaming Controller [Raiju 2 Tournament Edition (BT)]
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x110d
++device.name		Bootloader (Alternate)
+
+ vendor.id		usb 0x1532
+&device.id		usb 0x800e
++device.name		Bootloader
 
  vendor.id		usb 0x153b
 +vendor.name		TerraTec Electronic GmbH
@@ -65397,6 +69705,10 @@
 +vendor.name		PNY
 
  vendor.id		usb 0x154b
+&device.id		usb 0x000f
++device.name		Flash Drive
+
+ vendor.id		usb 0x154b
 &device.id		usb 0x0010
 +device.name		USB 2.0 Flash Drive
 
@@ -65427,6 +69739,14 @@
  vendor.id		usb 0x154b
 &device.id		usb 0x007a
 +device.name		Classic Attache Flash Drive
+
+ vendor.id		usb 0x154b
+&device.id		usb 0x5408
++device.name		2.5in drive enclosure
+
+ vendor.id		usb 0x154b
+&device.id		usb 0x6000
++device.name		Flash Drive
 
  vendor.id		usb 0x154b
 &device.id		usb 0x6545
@@ -65585,8 +69905,16 @@
 +device.name		USB2CAN Application for ColdFire DEMOJM board
 
  vendor.id		usb 0x15a2
+&device.id		usb 0x0041
++device.name		i.MX51 SystemOnChip in RecoveryMode
+
+ vendor.id		usb 0x15a2
 &device.id		usb 0x0042
 +device.name		OSBDM - Debug Port
+
+ vendor.id		usb 0x15a2
+&device.id		usb 0x004e
++device.name		i.MX53 SystemOnChip in RecoveryMode
 
  vendor.id		usb 0x15a2
 &device.id		usb 0x004f
@@ -65603,6 +69931,18 @@
  vendor.id		usb 0x15a2
 &device.id		usb 0x0061
 +device.name		i.MX 6Solo/6DualLite SystemOnChip in RecoveryMode
+
+ vendor.id		usb 0x15a2
+&device.id		usb 0x006a
++device.name		Vybrid series SystemOnChip in RecoveryMode
+
+ vendor.id		usb 0x15a2
+&device.id		usb 0x0076
++device.name		i.MX 7Solo/7Dual SystemOnChip in RecoveryMode
+
+ vendor.id		usb 0x15a2
+&device.id		usb 0x0080
++device.name		i.MX 6ULL SystemOnChip in RecoveryMode
 
  vendor.id		usb 0x15a4
 +vendor.name		Afatech Technologies, Inc.
@@ -65681,6 +70021,10 @@
  vendor.id		usb 0x15ba
 &device.id		usb 0x002b
 +device.name		ARM-USB-OCD-H JTAG+RS232
+
+ vendor.id		usb 0x15ba
+&device.id		usb 0x003c
++device.name		TERES Keyboard+Touchpad
 
  vendor.id		usb 0x15c0
 +vendor.name		XL Imaging
@@ -65882,8 +70226,24 @@
 +device.name		Mixtrack
 
  vendor.id		usb 0x15e4
+&device.id		usb 0x003c
++device.name		DJ2GO2 Touch
+
+ vendor.id		usb 0x15e4
 &device.id		usb 0x0140
 +device.name		ION VCR 2 PC / Video 2 PC
+
+ vendor.id		usb 0x15e4
+&device.id		usb 0x3f00
++device.name		Power A Mini Pro Elite
+
+ vendor.id		usb 0x15e4
+&device.id		usb 0x3f0a
++device.name		Airflo Wired Controller for Xbox 360
+
+ vendor.id		usb 0x15e4
+&device.id		usb 0x3f10
++device.name		Batarang controller for Xbox 360
 
  vendor.id		usb 0x15e8
 +vendor.name		SohoWare
@@ -65926,11 +70286,19 @@
 +device.name		HanfTek UMT-010 USB2.0 DVB-T (warm)
 
  vendor.id		usb 0x15f4
+&device.id		usb 0x0131
++device.name		Astrometa DVB-T/T2/C FM & DAB receiver [RTL2832P]
+
+ vendor.id		usb 0x15f4
 &device.id		usb 0x0135
 +device.name		Astrometa T2hybrid
 
  vendor.id		usb 0x1604
 +vendor.name		Tascam
+
+ vendor.id		usb 0x1604
+&device.id		usb 0x10c0
++device.name		Dell Integrated Hub
 
  vendor.id		usb 0x1604
 &device.id		usb 0x8000
@@ -65962,6 +70330,26 @@
  vendor.id		usb 0x1605
 &device.id		usb 0x0001
 +device.name		DIO-32 (No Firmware Yet)
+
+ vendor.id		usb 0x1605
+&device.id		usb 0x0002
++device.name		USB-DIO-48 (No Firmware Yet)
+
+ vendor.id		usb 0x1605
+&device.id		usb 0x0003
++device.name		USB-DIO-96 (No Firmware Yet)
+
+ vendor.id		usb 0x1605
+&device.id		usb 0x0004
++device.name		USB-DIO-32I (No Firmware Yet)
+
+ vendor.id		usb 0x1605
+&device.id		usb 0x0005
++device.name		USB-DIO24 (based on -CTR6) (No Firmware Yet)
+
+ vendor.id		usb 0x1605
+&device.id		usb 0x0006
++device.name		USB-DIO24-CTR6 (No Firmware Yet)
 
  vendor.id		usb 0x1606
 +vendor.name		Umax
@@ -66421,6 +70809,21 @@
 &device.id		usb 0xc019
 +device.name		RT2573
 
+ vendor.id		usb 0x1633
++vendor.name		AIM GmbH
+
+ vendor.id		usb 0x1633
+&device.id		usb 0x4510
++device.name		ASC1553
+
+ vendor.id		usb 0x1633
+&device.id		usb 0x4520
++device.name		ASC429
+
+ vendor.id		usb 0x1633
+&device.id		usb 0x4560
++device.name		ASC-FDX
+
  vendor.id		usb 0x1645
 +vendor.name		Entrega [hex]
 
@@ -66715,6 +71118,13 @@
 &device.id		usb 0x2002
 +device.name		Cheetah SPI Host Adapter
 
+ vendor.id		usb 0x167b
++vendor.name		Pure Digital Technologies, Inc.
+
+ vendor.id		usb 0x167b
+&device.id		usb 0x2009
++device.name		Flip Ultra U1120
+
  vendor.id		usb 0x1680
 +vendor.name		Golden Bridge Electech Inc.
 
@@ -66763,7 +71173,19 @@
 
  vendor.id		usb 0x1686
 &device.id		usb 0x0045
-+device.name		H4 Digital Recorder
++device.name		Handy Recorder stereo mix
+
+ vendor.id		usb 0x1686
+&device.id		usb 0x01c0
++device.name		Zoom Handy Recorder card reader
+
+ vendor.id		usb 0x1686
+&device.id		usb 0x01c5
++device.name		Zoom Handy Recorder multi track
+
+ vendor.id		usb 0x1686
+&device.id		usb 0x03d5
++device.name		LiveTrak L-12
 
  vendor.id		usb 0x1687
 +vendor.name		Kingmax Digital Inc.
@@ -66789,6 +71211,14 @@
  vendor.id		usb 0x1689
 &device.id		usb 0xfd00
 +device.name		Onza Tournament Edition controller
+
+ vendor.id		usb 0x1689
+&device.id		usb 0xfd01
++device.name		Onza Classic Edition
+
+ vendor.id		usb 0x1689
+&device.id		usb 0xfe00
++device.name		Sabertooth Elite
 
  vendor.id		usb 0x168c
 +vendor.name		Atheros Communications
@@ -67108,12 +71538,20 @@
 +device.name		Teensyduino Flight Sim Controls
 
  vendor.id		usb 0x16c0
+&device.id		usb 0x05b5
++device.name		BU0836
+
+ vendor.id		usb 0x16c0
 &device.id		usb 0x05dc
 +device.name		shared ID for use with libusb
 
  vendor.id		usb 0x16c0
 &device.id		usb 0x05dd
 +device.name		BlackcatUSB2
+
+ vendor.id		usb 0x16c0
+&device.id		usb 0x05de
++device.name		Flashcat
 
  vendor.id		usb 0x16c0
 &device.id		usb 0x05df
@@ -67174,6 +71612,10 @@
  vendor.id		usb 0x16c0
 &device.id		usb 0x08cd
 +device.name		Alpermann+Velte SAM7X MT Boot Loader
+
+ vendor.id		usb 0x16c0
+&device.id		usb 0x09ce
++device.name		LINKUSB
 
  vendor.id		usb 0x16c0
 &device.id		usb 0x0a32
@@ -67249,12 +71691,32 @@
 +device.name		EasyLogic Board
 
  vendor.id		usb 0x16d0
+&device.id		usb 0x05f0
++device.name		Superior Freedom Programmable IR Remote
+
+ vendor.id		usb 0x16d0
 &device.id		usb 0x06cc
 +device.name		Trinamic TMCM-3110
 
  vendor.id		usb 0x16d0
+&device.id		usb 0x06f0
++device.name		Axium AX-R4C Controller
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x06f1
++device.name		Axium AX-R1D Controller
+
+ vendor.id		usb 0x16d0
 &device.id		usb 0x06f9
 +device.name		Gabotronics Xminilab
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0726
++device.name		Autonomic M400 Amplifier
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0727
++device.name		Autonomic M800 Amplifier
 
  vendor.id		usb 0x16d0
 &device.id		usb 0x0753
@@ -67269,20 +71731,76 @@
 +device.name		AB-1.x UAC2 [Audio Widget]
 
  vendor.id		usb 0x16d0
+&device.id		usb 0x07cc
++device.name		Xylanta Ltd, Saint3 Device
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x07f8
++device.name		Axium AX-R4D Controller
+
+ vendor.id		usb 0x16d0
 &device.id		usb 0x080a
 +device.name		S2E1 Interface
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0830
++device.name		DMXControl Projects e.V., Nodle U1
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0831
++device.name		DMXControl Projects e.V., Desklamp
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0832
++device.name		DMXControl Projects e.V., Nodle U2
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0833
++device.name		DMXControl Projects e.V., Nodle R4S
 
  vendor.id		usb 0x16d0
 &device.id		usb 0x0870
 +device.name		Kaufmann Automotive GmbH, RKS+CAN Interface
 
  vendor.id		usb 0x16d0
+&device.id		usb 0x09f2
++device.name		Axium AX-1250 Amplifier
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x09f4
++device.name		Axium AX-Mini4 Amplifier
+
+ vendor.id		usb 0x16d0
 &device.id		usb 0x0b03
 +device.name		AIS Receiver [dAISy]
 
  vendor.id		usb 0x16d0
+&device.id		usb 0x0b7d
++device.name		Autonomic M801 Amplifier
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0b7e
++device.name		Autonomic M401 Amplifier
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0b7f
++device.name		Autonomic M120e Amplifier
+
+ vendor.id		usb 0x16d0
 &device.id		usb 0x0bd4
 +device.name		codesrc SCSI2SD
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0c9b
++device.name		Fermium LABS srl/LabTrek srl Hall Effect Apparatus
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0d3c
++device.name		InputStick BT4.0
+
+ vendor.id		usb 0x16d0
+&device.id		usb 0x0e1e
++device.name		AtomMiner
 
  vendor.id		usb 0x16d1
 +vendor.name		Suprema Inc.
@@ -67405,7 +71923,7 @@
 +vendor.name		King Billion Electronics Co., Ltd.
 
  vendor.id		usb 0x16f0
-+vendor.name		GN ReSound A/S
++vendor.name		GN Hearing A/S
 
  vendor.id		usb 0x16f0
 &device.id		usb 0x0001
@@ -67415,8 +71933,19 @@
 &device.id		usb 0x0003
 +device.name		Airlink Wireless Programming Interface
 
+ vendor.id		usb 0x16f0
+&device.id		usb 0x0004
++device.name		Accessory Programming Interface
+
  vendor.id		usb 0x16f5
 +vendor.name		Futurelogic Inc.
+
+ vendor.id		usb 0x1702
++vendor.name		FDI-MATELEC
+
+ vendor.id		usb 0x1702
+&device.id		usb 0x0002
++device.name		Encodeur
 
  vendor.id		usb 0x1706
 +vendor.name		BlueView Technologies, Inc.
@@ -67528,7 +72057,7 @@
 +vendor.name		CANON IMAGING SYSTEM TECHNOLOGIES INC.
 
  vendor.id		usb 0x1737
-+vendor.name		Linksys
++vendor.name		802.11g Adapter [Linksys WUSB54GC v3]
 
  vendor.id		usb 0x1737
 &device.id		usb 0x0039
@@ -67657,6 +72186,10 @@
 +device.name		Transcend ESD400 Portable SSD (USB 3.0)
 
  vendor.id		usb 0x174c
+&device.id		usb 0x1151
++device.name		ASM1151W
+
+ vendor.id		usb 0x174c
 &device.id		usb 0x1153
 +device.name		ASM1153 SATA 3Gb/s bridge
 
@@ -67682,7 +72215,7 @@
 
  vendor.id		usb 0x174c
 &device.id		usb 0x55aa
-+device.name		Name: ASM1051E SATA 6Gb/s bridge, ASM1053E SATA 6Gb/s bridge, ASM1153 SATA 3Gb/s bridge, ASM1153E SATA 6Gb/s bridge
++device.name		ASM1051E SATA 6Gb/s bridge, ASM1053E SATA 6Gb/s bridge, ASM1153 SATA 3Gb/s bridge, ASM1153E SATA 6Gb/s bridge
 
  vendor.id		usb 0x174f
 +vendor.name		Syntek
@@ -67696,12 +72229,28 @@
 +device.name		HP Webcam
 
  vendor.id		usb 0x174f
+&device.id		usb 0x1122
++device.name		HP Webcam
+
+ vendor.id		usb 0x174f
+&device.id		usb 0x1169
++device.name		Lenovo EasyCamera
+
+ vendor.id		usb 0x174f
 &device.id		usb 0x1403
 +device.name		Integrated Webcam
 
  vendor.id		usb 0x174f
 &device.id		usb 0x1404
 +device.name		USB Camera device, 1.3 MPixel Web Cam
+
+ vendor.id		usb 0x174f
+&device.id		usb 0x1758
++device.name		XYZ printing cameraR2
+
+ vendor.id		usb 0x174f
+&device.id		usb 0x1759
++device.name		XYZ printing cameraL2
 
  vendor.id		usb 0x174f
 &device.id		usb 0x5212
@@ -67787,6 +72336,13 @@
 &device.id		usb 0x0b05
 +device.name		802.11n Network Adapter (wrong ID - swapped vendor and device)
 
+ vendor.id		usb 0x1770
++vendor.name		MSI
+
+ vendor.id		usb 0x1770
+&device.id		usb 0xff00
++device.name		steel series rgb keyboard
+
  vendor.id		usb 0x1772
 +vendor.name		System Level Solutions, Inc.
 
@@ -67796,6 +72352,13 @@
  vendor.id		usb 0x1776
 &device.id		usb 0x501c
 +device.name		300K CMOS Camera
+
+ vendor.id		usb 0x1777
++vendor.name		Microscan Systems, Inc.
+
+ vendor.id		usb 0x1777
+&device.id		usb 0x0003
++device.name		MicroHAWK ID-20
 
  vendor.id		usb 0x177f
 +vendor.name		Sweex
@@ -67820,6 +72383,22 @@
 +vendor.name		Multiple Vendors
 
  vendor.id		usb 0x1781
+&device.id		usb 0x07df
++device.name		Axium AX-800DAV Amplifier
+
+ vendor.id		usb 0x1781
+&device.id		usb 0x07e1
++device.name		Axium AX-KPC Keypad
+
+ vendor.id		usb 0x1781
+&device.id		usb 0x07e2
++device.name		Axium AX-KPD Keypad
+
+ vendor.id		usb 0x1781
+&device.id		usb 0x07e3
++device.name		Axium AX-400DA Amplifier
+
+ vendor.id		usb 0x1781
 &device.id		usb 0x083e
 +device.name		MetaGeek Wi-Spy
 
@@ -67830,6 +72409,10 @@
  vendor.id		usb 0x1781
 &device.id		usb 0x0938
 +device.name		Iguanaworks USB IR Transceiver
+
+ vendor.id		usb 0x1781
+&device.id		usb 0x0941
++device.name		qNimble Quark
 
  vendor.id		usb 0x1781
 &device.id		usb 0x0a96
@@ -67872,6 +72455,10 @@
 +device.name		raphnet.net MultiDB9joy
 
  vendor.id		usb 0x1781
+&device.id		usb 0x0bad
++device.name		Mantracourt Load Cell
+
+ vendor.id		usb 0x1781
 &device.id		usb 0x0c30
 +device.name		Telldus TellStick
 
@@ -67895,8 +72482,16 @@
 &device.id		usb 0x1ef1
 +device.name		E1701 Modular Controller Card
 
+ vendor.id		usb 0x1781
+&device.id		usb 0x1ef2
++device.name		E1803 Compact Controller Card
+
  vendor.id		usb 0x1782
 +vendor.name		Spreadtrum Communications Inc.
+
+ vendor.id		usb 0x1782
+&device.id		usb 0x3d00
++device.name		F200n mobile phone
 
  vendor.id		usb 0x1784
 +vendor.name		TopSeed Technology Corp.
@@ -67934,6 +72529,13 @@
 
  vendor.id		usb 0x1788
 +vendor.name		ShenZhen Litkconn Technology Co., Ltd.
+
+ vendor.id		usb 0x178e
++vendor.name		ASUSTek Computer, Inc. (wrong ID)
+
+ vendor.id		usb 0x178e
+&device.id		usb 0x0b05
++device.name		CrossLink cable 2GB (wrong ID - swapped vendor and device)
 
  vendor.id		usb 0x1796
 +vendor.name		Printrex, Inc.
@@ -67983,6 +72585,14 @@
 +device.name		Meteorite condenser microphone
 
  vendor.id		usb 0x17a0
+&device.id		usb 0x0130
++device.name		Go Mic Direct
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0x0132
++device.name		Go Mic Mobile wireless receiver
+
+ vendor.id		usb 0x17a0
 &device.id		usb 0x0200
 +device.name		StudioDock monitors (internal hub)
 
@@ -67993,6 +72603,18 @@
  vendor.id		usb 0x17a0
 &device.id		usb 0x0210
 +device.name		StudioGT monitors
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0x0211
++device.name		StudioGT monitors [CM6400]
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0x0240
++device.name		Go Mic Connect
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0x0241
++device.name		G-Track Pro microphone
 
  vendor.id		usb 0x17a0
 &device.id		usb 0x0301
@@ -68017,6 +72639,22 @@
  vendor.id		usb 0x17a0
 &device.id		usb 0x0310
 +device.name		Meteor condenser microphone
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0x0311
++device.name		Satellite condenser microphone
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0x1616
++device.name		RXD1 wireless receiver
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0xb241
++device.name		G-Track Pro firmware update
+
+ vendor.id		usb 0x17a0
+&device.id		usb 0xb311
++device.name		Satellite firmware update
 
  vendor.id		usb 0x17a4
 +vendor.name		Concept2
@@ -68045,6 +72683,22 @@
  vendor.id		usb 0x17a8
 &device.id		usb 0x0005
 +device.name		M-Bus Master MultiPort 250D
+
+ vendor.id		usb 0x17a8
+&device.id		usb 0x0010
++device.name		444MHz Radio Mesh Frontend
+
+ vendor.id		usb 0x17a8
+&device.id		usb 0x0011
++device.name		444MHz RF sniffer
+
+ vendor.id		usb 0x17a8
+&device.id		usb 0x0012
++device.name		870MHz Radio Mesh Frontend
+
+ vendor.id		usb 0x17a8
+&device.id		usb 0x0013
++device.name		870MHz RF sniffer
 
  vendor.id		usb 0x17b3
 +vendor.name		Grey Innovation
@@ -68094,6 +72748,10 @@
 +device.name		Audio 2 DJ
 
  vendor.id		usb 0x17cc
+&device.id		usb 0x041d
++device.name		Traktor Audio 2
+
+ vendor.id		usb 0x17cc
 &device.id		usb 0x0808
 +device.name		Maschine Controller
 
@@ -68108,6 +72766,14 @@
  vendor.id		usb 0x17cc
 &device.id		usb 0x0d8d
 +device.name		Guitarrig Mobile
+
+ vendor.id		usb 0x17cc
+&device.id		usb 0x1001
++device.name		Komplete Audio 6
+
+ vendor.id		usb 0x17cc
+&device.id		usb 0x1110
++device.name		Maschine Mikro
 
  vendor.id		usb 0x17cc
 &device.id		usb 0x1915
@@ -68162,6 +72828,18 @@
 +device.name		USB VGA Adaptor
 
  vendor.id		usb 0x17e9
+&device.id		usb 0x0198
++device.name		DisplayLink
+
+ vendor.id		usb 0x17e9
+&device.id		usb 0x019e
++device.name		Overfly FY-1016A
+
+ vendor.id		usb 0x17e9
+&device.id		usb 0x028f
++device.name		HIS Multi-View II
+
+ vendor.id		usb 0x17e9
 &device.id		usb 0x030b
 +device.name		HP T100
 
@@ -68202,8 +72880,20 @@
 +device.name		HP Port Replicator (Composite Device)
 
  vendor.id		usb 0x17e9
+&device.id		usb 0x430f
++device.name		Kensington Dock (Composite Device)
+
+ vendor.id		usb 0x17e9
 &device.id		usb 0x4312
 +device.name		S2340T
+
+ vendor.id		usb 0x17e9
+&device.id		usb 0x436e
++device.name		Dell D3100 Docking Station
+
+ vendor.id		usb 0x17e9
+&device.id		usb 0xff10
++device.name		I1659FWUX {AOC Powered Monitor]
 
  vendor.id		usb 0x17eb
 +vendor.name		Cornice, Inc.
@@ -68213,7 +72903,7 @@
 
  vendor.id		usb 0x17ef
 &device.id		usb 0x1000
-+device.name		Hub
++device.name		ThinkPad X6 UltraBase
 
  vendor.id		usb 0x17ef
 &device.id		usb 0x1003
@@ -68224,6 +72914,10 @@
 +device.name		Integrated Webcam
 
  vendor.id		usb 0x17ef
+&device.id		usb 0x1005
++device.name		ThinkPad X200 Ultrabase (42X4963 )
+
+ vendor.id		usb 0x17ef
 &device.id		usb 0x1008
 +device.name		Hub
 
@@ -68232,8 +72926,56 @@
 +device.name		ThinkPad Mini Dock Plus Series 3
 
  vendor.id		usb 0x17ef
+&device.id		usb 0x100f
++device.name		ThinkPad Ultra Dock Hub
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x1010
++device.name		ThinkPad Ultra Dock Hub
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x1020
++device.name		ThinkPad Dock Hub
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x1021
++device.name		ThinkPad Dock Hub [Cypress HX2VL]
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x3049
++device.name		ThinkPad OneLink integrated audio
+
+ vendor.id		usb 0x17ef
 &device.id		usb 0x304b
 +device.name		AX88179 Gigabit Ethernet [ThinkPad OneLink GigaLAN]
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x304f
++device.name		RTL8153 Gigabit Ethernet [ThinkPad OneLink Pro Dock]
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x3060
++device.name		ThinkPad Dock
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x3062
++device.name		ThinkPad Dock Ethernet [Realtek RTL8153B]
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x3063
++device.name		ThinkPad Dock Audio
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x3066
++device.name		ThinkPad Thunderbolt 3 Dock MCU
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x3069
++device.name		ThinkPad TBT3 LAN
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x306a
++device.name		ThinkPad Thunderbolt 3 Dock Audio
 
  vendor.id		usb 0x17ef
 &device.id		usb 0x3815
@@ -68241,7 +72983,7 @@
 
  vendor.id		usb 0x17ef
 &device.id		usb 0x4802
-+device.name		Lenovo Vc0323+MI1310_SOC Camera
++device.name		Vc0323+MI1310_SOC Camera
 
  vendor.id		usb 0x17ef
 &device.id		usb 0x4807
@@ -68312,16 +73054,68 @@
 +device.name		ThinkPad Keyboard with TrackPoint
 
  vendor.id		usb 0x17ef
+&device.id		usb 0x600e
++device.name		Optical Mouse
+
+ vendor.id		usb 0x17ef
 &device.id		usb 0x6014
 +device.name		Mini Wireless Keyboard N5901
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x6019
++device.name		M-U0025-O Mouse
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x6022
++device.name		Ultraslim Plus Wireless Keyboard and Mouse
 
  vendor.id		usb 0x17ef
 &device.id		usb 0x6025
 +device.name		ThinkPad Travel Mouse
 
  vendor.id		usb 0x17ef
+&device.id		usb 0x602d
++device.name		Black Silk Keyboard
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x6032
++device.name		Wireless Dongle for Keyboard and Mouse
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x6044
++device.name		ThinkPad Laser Mouse
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x6047
++device.name		ThinkPad Compact Keyboard with TrackPoint
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x604b
++device.name		Precision Wireless Mouse
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x608d
++device.name		Optical Mouse
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x609b
++device.name		Professional Wireless Keyboard and Mouse Combo
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x609c
++device.name		Professional Wireless Keyboard
+
+ vendor.id		usb 0x17ef
 &device.id		usb 0x7203
 +device.name		Ethernet adapter [U2L 100P-Y1]
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7205
++device.name		Thinkpad LAN
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7217
++device.name		VGA adapter
 
  vendor.id		usb 0x17ef
 &device.id		usb 0x7423
@@ -68351,6 +73145,90 @@
 &device.id		usb 0x749b
 +device.name		A789 (PTP mode, with debug)
 
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7604
++device.name		A760 (Mass Storage mode)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7605
++device.name		A760 (Mass Storage mode, with debug)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x760a
++device.name		A760 (MTP mode)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x760b
++device.name		A760 (MTP mode, with debug)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x760c
++device.name		A760 (PTP mode)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x760d
++device.name		A760 (PTP mode, with debug)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x76fc
++device.name		B8000-H (Yoga Tablet 10) (mass storage)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x76fd
++device.name		B8000-H (Yoga Tablet 10) (debug , mass storage)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x76fe
++device.name		B8000-H (Yoga Tablet 10) (MTP)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x76ff
++device.name		B8000-H (Yoga Tablet 10) (debug , MTP)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7702
++device.name		B8000-H (Yoga Tablet 10) (PTP)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7703
++device.name		B8000-H (Yoga Tablet 10) (debug , PTP)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7704
++device.name		B8000-H (Yoga Tablet 10) (USB tether)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7705
++device.name		B8000-H (Yoga Tablet 10) (debug , USB tether)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7706
++device.name		B8000-H (Yoga Tablet 10) (zerocd)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x7707
++device.name		B8000-H (Yoga Tablet 10) (debug , zerocd)
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0x785f
++device.name		TAB 2 A7-10 Tablet
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0xb000
++device.name		Virtual Keyboard and Mouse
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0xb001
++device.name		Ethernet
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0xb003
++device.name		Virtual Keyboard and Mouse / Mass Storage
+
+ vendor.id		usb 0x17ef
+&device.id		usb 0xf003
++device.name		MEDION LIFETAB X10605 MTP mode
+
  vendor.id		usb 0x17f4
 +vendor.name		WaveSense
 
@@ -68362,11 +73240,15 @@
 +vendor.name		K.K. Rocky
 
  vendor.id		usb 0x17f6
-+vendor.name		Unicomp, Inc
++vendor.name		Unicomp, Inc.
 
  vendor.id		usb 0x17f6
 &device.id		usb 0x0709
 +device.name		Model M Keyboard
+
+ vendor.id		usb 0x17f6
+&device.id		usb 0x0822
++device.name		Ruffian 6 Keyboard v3 [Model M]
 
  vendor.id		usb 0x1809
 +vendor.name		Advantech
@@ -68409,8 +73291,23 @@
  vendor.id		usb 0x1849
 +vendor.name		ASRock Incorporation
 
+ vendor.id		usb 0x184f
++vendor.name		K2L GmbH
+
+ vendor.id		usb 0x184f
+&device.id		usb 0x0012
++device.name		MOCCA compact
+
  vendor.id		usb 0x1852
 +vendor.name		GYROCOM C&C Co., LTD
+
+ vendor.id		usb 0x1852
+&device.id		usb 0x7022
++device.name		Fiio E10
+
+ vendor.id		usb 0x1852
+&device.id		usb 0x7921
++device.name		Audiotrak ProDigy CUBE
 
  vendor.id		usb 0x1852
 &device.id		usb 0x7922
@@ -68479,6 +73376,14 @@
  vendor.id		usb 0x187c
 &device.id		usb 0x0511
 +device.name		AlienFX Mobile lighting
+
+ vendor.id		usb 0x187c
+&device.id		usb 0x0513
++device.name		Gaming Desktop [Aurora R4]
+
+ vendor.id		usb 0x187c
+&device.id		usb 0x0550
++device.name		LED controller
 
  vendor.id		usb 0x187c
 &device.id		usb 0x0600
@@ -68582,11 +73487,19 @@
 +device.name		Flash Drive (Store'n'Go)
 
  vendor.id		usb 0x18a5
+&device.id		usb 0x0245
++device.name		Store'n'Stay
+
+ vendor.id		usb 0x18a5
 &device.id		usb 0x0302
 +device.name		Flash Drive
 
  vendor.id		usb 0x18a5
 &device.id		usb 0x0304
++device.name		Store 'n' Go
+
+ vendor.id		usb 0x18a5
+&device.id		usb 0x0408
 +device.name		Store 'n' Go
 
  vendor.id		usb 0x18a5
@@ -68676,11 +73589,27 @@
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x2d00
-+device.name		Android-powered device in accessory mode
++device.name		Android Open Accessory device (accessory)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x2d01
-+device.name		Android-powered device in accessory mode with ADB support
++device.name		Android Open Accessory device (accessory + ADB)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x2d02
++device.name		Android Open Accessory device (audio)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x2d03
++device.name		Android Open Accessory device (audio + ADB)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x2d04
++device.name		Android Open Accessory device (accessory + audio)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x2d05
++device.name		Android Open Accessory device (accessory + audio + ADB)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4e11
@@ -68736,31 +73665,47 @@
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4ee0
-+device.name		Nexus 4 (bootloader)
++device.name		Nexus/Pixel Device (fastboot)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4ee1
-+device.name		Nexus Device (MTP)
++device.name		Nexus/Pixel Device (MTP)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4ee2
-+device.name		Nexus Device (debug)
++device.name		Nexus/Pixel Device (MTP + debug)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4ee3
-+device.name		Nexus 4/5/7/10 (tether)
++device.name		Nexus/Pixel Device (tether)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4ee4
-+device.name		Nexus 4/5/7/10 (debug + tether)
++device.name		Nexus/Pixel Device (tether+ debug)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4ee5
-+device.name		Nexus 4 (PTP)
++device.name		Nexus/Pixel Device (PTP)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x4ee6
-+device.name		Nexus 4/5 (PTP + debug)
++device.name		Nexus/Pixel Device (PTP + debug)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x4ee7
++device.name		Nexus/Pixel Device (charging + debug)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x4ee8
++device.name		Nexus/Pixel Device (MIDI)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x4ee9
++device.name		Nexus/Pixel Device (MIDI + debug)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0x5033
++device.name		Pixel earbuds
 
  vendor.id		usb 0x18d1
 &device.id		usb 0x7102
@@ -68777,6 +73722,10 @@
  vendor.id		usb 0x18d1
 &device.id		usb 0xd002
 +device.name		Nexus 4 (debug)
+
+ vendor.id		usb 0x18d1
+&device.id		usb 0xd00d
++device.name		Xiaomi Mi/Redmi 2 (fastboot)
 
  vendor.id		usb 0x18d1
 &device.id		usb 0xd109
@@ -68874,12 +73823,43 @@
 &device.id		usb 0x3366
 +device.name		Bresser Biolux NV
 
+ vendor.id		usb 0x18ec
+&device.id		usb 0x5850
++device.name		CVBS / S-Video Capture Device [UVC]
+
+ vendor.id		usb 0x18ef
++vendor.name		ELV Elektronik AG
+
+ vendor.id		usb 0x18ef
+&device.id		usb 0xe014
++device.name		FS20PCE
+
+ vendor.id		usb 0x18ef
+&device.id		usb 0xe015
++device.name		FS20PCS
+
+ vendor.id		usb 0x18ef
+&device.id		usb 0xe01a
++device.name		Bedien-Anzeige-Terminal
+
  vendor.id		usb 0x18f8
 +vendor.name		[Maxxter]
 
  vendor.id		usb 0x18f8
+&device.id		usb 0x0f97
++device.name		Optical Gaming Mouse [Xtrem]
+
+ vendor.id		usb 0x18f8
 &device.id		usb 0x0f99
 +device.name		Optical gaming mouse
+
+ vendor.id		usb 0x18f8
+&device.id		usb 0x1142
++device.name		Optical gaming mouse
+
+ vendor.id		usb 0x18f8
+&device.id		usb 0x1486
++device.name		X5s ZEUS Macro Pro Gaming Mouse
 
  vendor.id		usb 0x18fb
 +vendor.name		Scriptel Corporation
@@ -68962,8 +73942,32 @@
 +vendor.name		GEMBIRD
 
  vendor.id		usb 0x1908
+&device.id		usb 0x0102
++device.name		Digital Photo Frame
+
+ vendor.id		usb 0x1908
+&device.id		usb 0x0226
++device.name		MicroSD Card Reader/Writer
+
+ vendor.id		usb 0x1908
+&device.id		usb 0x1315
++device.name		Digital Photo Frame
+
+ vendor.id		usb 0x1908
 &device.id		usb 0x1320
-+device.name		PhotoFrame PF-15-1
++device.name		DM8261 Flashdisc
+
+ vendor.id		usb 0x1908
+&device.id		usb 0x2070
++device.name		Honk HK-5002 USB Speaker
+
+ vendor.id		usb 0x1908
+&device.id		usb 0x2220
++device.name		Buildwin Media-Player
+
+ vendor.id		usb 0x1908
+&device.id		usb 0x2311
++device.name		Generic UVC 1.00 camera [AppoTech AX2311]
 
  vendor.id		usb 0x190d
 +vendor.name		Motorola GSG
@@ -68977,6 +73981,10 @@
  vendor.id		usb 0x1915
 &device.id		usb 0x000c
 +device.name		Wireless Desktop nRF24L01 CX-1766
+
+ vendor.id		usb 0x1915
+&device.id		usb 0x0101
++device.name		HP Prime Wireless Kit [FOK65AA] (Flash mode)
 
  vendor.id		usb 0x1915
 &device.id		usb 0x2233
@@ -68993,6 +74001,10 @@
  vendor.id		usb 0x1915
 &device.id		usb 0x2236
 +device.name		Linksys WUSB11 v3.0 802.11b Adapter [Intersil PRISM 3]
+
+ vendor.id		usb 0x1915
+&device.id		usb 0x7777
++device.name		Bitcraze Crazyradio (PA) dongle
 
  vendor.id		usb 0x191c
 +vendor.name		Innovative Technology LTD
@@ -69124,8 +74136,19 @@
 +device.name		1950 HID Touchscreen
 
  vendor.id		usb 0x1926
+&device.id		usb 0x0dbf
++device.name		HID Touchscreen
+
+ vendor.id		usb 0x1926
 &device.id		usb 0x0dc2
 +device.name		HID Touchscreen
+
+ vendor.id		usb 0x1928
++vendor.name		Proceq SA
+
+ vendor.id		usb 0x1928
+&device.id		usb 0x0400
++device.name		Equotip Piccolo
 
  vendor.id		usb 0x192f
 +vendor.name		Avago Technologies, Pte.
@@ -69141,6 +74164,10 @@
  vendor.id		usb 0x192f
 &device.id		usb 0x0616
 +device.name		ADNS-5700 Optical Mouse Controller (5-button)
+
+ vendor.id		usb 0x192f
+&device.id		usb 0x0916
++device.name		ADNS-2710 Optical Mouse Controller
 
  vendor.id		usb 0x1930
 +vendor.name		Shenzhen Xianhe Technology Co., Ltd.
@@ -69163,12 +74190,23 @@
 &device.id		usb 0x5168
 +device.name		F71610A or F71612A Consumer Infrared Receiver/Transceiver
 
+ vendor.id		usb 0x1935
++vendor.name		Elektron Music Machines
+
+ vendor.id		usb 0x1935
+&device.id		usb 0x000d
++device.name		Elektron Digitakt
+
  vendor.id		usb 0x1938
 +vendor.name		Meinberg Funkuhren GmbH & Co. KG
 
  vendor.id		usb 0x1938
 &device.id		usb 0x0501
 +device.name		TCR51USB IRIG Time Code Reader
+
+ vendor.id		usb 0x1938
+&device.id		usb 0x0502
++device.name		TCR600USB IRIG Time Code Reader
 
  vendor.id		usb 0x1941
 +vendor.name		Dream Link
@@ -69197,6 +74235,10 @@
 +device.name		Model 2257 4 Channel Capture Card
 
  vendor.id		usb 0x1943
+&device.id		usb 0x2263
++device.name		Model 2263 UVC HD Audio/Video Codec Card
+
+ vendor.id		usb 0x1943
 &device.id		usb 0xa250
 +device.name		Model 2250 MPEG and JPEG Capture Card (cold)
 
@@ -69217,11 +74259,27 @@
 
  vendor.id		usb 0x1949
 &device.id		usb 0x0006
-+device.name		Kindle Fire
++device.name		Amazon Kindle Fire
 
  vendor.id		usb 0x1949
 &device.id		usb 0x0008
 +device.name		Amazon Kindle Fire HD 8.9"
+
+ vendor.id		usb 0x1949
+&device.id		usb 0x000a
++device.name		Amazon Kindle Fire 2nd generation (2012)
+
+ vendor.id		usb 0x1949
+&device.id		usb 0x0331
++device.name		Kindle Fire HD 8 (2018)
+
+ vendor.id		usb 0x1949
+&device.id		usb 0x0417
++device.name		Amazon Zukey; clone of Yubikey 4 OTP+U2F
+
+ vendor.id		usb 0x1949
+&device.id		usb 0x0800
++device.name		Fire Phone
 
  vendor.id		usb 0x194f
 +vendor.name		PreSonus Audio Electronics, Inc.
@@ -69237,6 +74295,10 @@
  vendor.id		usb 0x194f
 &device.id		usb 0x0103
 +device.name		AudioBox 1818 VSL
+
+ vendor.id		usb 0x194f
+&device.id		usb 0x0201
++device.name		FaderPort
 
  vendor.id		usb 0x194f
 &device.id		usb 0x0301
@@ -69259,6 +74321,10 @@
 +vendor.name		Itron Technology iONE
 
  vendor.id		usb 0x195d
+&device.id		usb 0x2030
++device.name		Func KB-460 Gaming Keyboard
+
+ vendor.id		usb 0x195d
 &device.id		usb 0x7002
 +device.name		Libra-Q11 IR remote
 
@@ -69274,12 +74340,31 @@
 &device.id		usb 0x7779
 +device.name		Scorpius-P20MT
 
+ vendor.id		usb 0x1963
++vendor.name		IK Multimedia
+
+ vendor.id		usb 0x1963
+&device.id		usb 0x0005
++device.name		iRig KEYS
+
+ vendor.id		usb 0x1963
+&device.id		usb 0x0046
++device.name		UNO Synth
+
  vendor.id		usb 0x1965
 +vendor.name		Uniden Corporation
 
  vendor.id		usb 0x1965
 &device.id		usb 0x0016
 +device.name		HomePatrol-1
+
+ vendor.id		usb 0x1965
+&device.id		usb 0x0018
++device.name		UBC125XLT
+
+ vendor.id		usb 0x1965
+&device.id		usb 0x001a
++device.name		BCD436HP Scanner
 
  vendor.id		usb 0x1967
 +vendor.name		CASIO HITACHI Mobile Communications Co., Ltd.
@@ -69294,6 +74379,21 @@
 &device.id		usb 0x0000
 +device.name		Z Mate 16GB
 
+ vendor.id		usb 0x1973
++vendor.name		Spectralink Corporation
+
+ vendor.id		usb 0x1973
+&device.id		usb 0x0002
++device.name		Pivot recovery
+
+ vendor.id		usb 0x1973
+&device.id		usb 0x0003
++device.name		Pivot Media Transfer Protocol
+
+ vendor.id		usb 0x1973
+&device.id		usb 0x0004
++device.name		Pivot Media Transfer Protocol
+
  vendor.id		usb 0x1975
 +vendor.name		Dongguan Guneetal Wire & Cable Co., Ltd.
 
@@ -69301,8 +74401,12 @@
 +vendor.name		Chipsbrand Microelectronics (HK) Co., Ltd.
 
  vendor.id		usb 0x1976
+&device.id		usb 0x1307
++device.name		microSD Card Reader
+
+ vendor.id		usb 0x1976
 &device.id		usb 0x6025
-+device.name		Flash Drive 512 MB
++device.name		CBM2090 Flash Drive
 
  vendor.id		usb 0x1977
 +vendor.name		T-Logic
@@ -69317,6 +74421,13 @@
  vendor.id		usb 0x197d
 &device.id		usb 0x0222
 +device.name		BCL 508i
+
+ vendor.id		usb 0x1980
++vendor.name		Storage Appliance Corporation
+
+ vendor.id		usb 0x1980
+&device.id		usb 0x0808
++device.name		Clickfree C2 Slimline (527SE)
 
  vendor.id		usb 0x1989
 +vendor.name		Nuconn Technology Corp.
@@ -69361,6 +74472,17 @@
 &device.id		usb 0x3012
 +device.name		e-ImageData Corp. ScanPro
 
+ vendor.id		usb 0x1997
++vendor.name		Shenzhen Riitek Technology Co., Ltd
+
+ vendor.id		usb 0x1997
+&device.id		usb 0x0409
++device.name		wireless mini keyboard with touchpad
+
+ vendor.id		usb 0x1997
+&device.id		usb 0x2433
++device.name		wireless mini keyboard with touchpad
+
  vendor.id		usb 0x199b
 +vendor.name		MicroStrain, Inc.
 
@@ -69375,8 +74497,31 @@
 &device.id		usb 0x8101
 +device.name		DFx 21BU04 Camera
 
+ vendor.id		usb 0x199e
+&device.id		usb 0x8457
++device.name		DFK AFU130-L53 camera
+
  vendor.id		usb 0x199f
 +vendor.name		Benica Corporation
+
+ vendor.id		usb 0x19a5
++vendor.name		HARRIS Corp.
+
+ vendor.id		usb 0x19a5
+&device.id		usb 0x0004
++device.name		Remote NDIS Network Device
+
+ vendor.id		usb 0x19a5
+&device.id		usb 0x0012
++device.name		RF-7800S Secure Personal Radio
+
+ vendor.id		usb 0x19a5
+&device.id		usb 0x0401
++device.name		Mass Storage Device
+
+ vendor.id		usb 0x19a5
+&device.id		usb 0x0402
++device.name		Falcon III RF-7800V family RNDIS
 
  vendor.id		usb 0x19a8
 +vendor.name		Biforst Technology Inc.
@@ -69435,6 +74580,10 @@
 +vendor.name		Data Robotics
 
  vendor.id		usb 0x19b9
+&device.id		usb 0x4b10
++device.name		Drobo
+
+ vendor.id		usb 0x19b9
 &device.id		usb 0x8d20
 +device.name		Drobo Elite
 
@@ -69455,6 +74604,13 @@
  vendor.id		usb 0x19cf
 +vendor.name		Parrot SA
 
+ vendor.id		usb 0x19cf
+&device.id		usb 0x0001
++device.name		MiniKit Slim handsfree car kit in firmware update mode
+
+ vendor.id		usb 0x19d1
++vendor.name		BYD
+
  vendor.id		usb 0x19d2
 +vendor.name		ZTE WCDMA Technologies MSM
 
@@ -69471,8 +74627,20 @@
 +device.name		TU25 WiMAX Adapter [Beceem BCS200]
 
  vendor.id		usb 0x19d2
+&device.id		usb 0x0017
++device.name		MF669
+
+ vendor.id		usb 0x19d2
 &device.id		usb 0x0031
 +device.name		MF110/MF627/MF636
+
+ vendor.id		usb 0x19d2
+&device.id		usb 0x0037
++device.name		ONDA MC503HSA
+
+ vendor.id		usb 0x19d2
+&device.id		usb 0x0039
++device.name		MF100
 
  vendor.id		usb 0x19d2
 &device.id		usb 0x0063
@@ -69495,6 +74663,10 @@
 +device.name		K4505-Z
 
  vendor.id		usb 0x19d2
+&device.id		usb 0x0117
++device.name		MF667
+
+ vendor.id		usb 0x19d2
 &device.id		usb 0x0146
 +device.name		MF 195E (HSPA+ Modem)
 
@@ -69513,6 +74685,18 @@
  vendor.id		usb 0x19d2
 &device.id		usb 0x0326
 +device.name		LTE4G O2 ZTE MF821D LTE/UMTS/GSM Modem/Networkcard
+
+ vendor.id		usb 0x19d2
+&device.id		usb 0x0501
++device.name		Lever Cell Phone Model Z936L
+
+ vendor.id		usb 0x19d2
+&device.id		usb 0x1001
++device.name		K3805-Z vodafone WCDMA/GSM Modem - storage mode (made by ZTE)
+
+ vendor.id		usb 0x19d2
+&device.id		usb 0x1002
++device.name		K3805-Z vodafone WCDMA/GSM Modem/Networkcard (made by ZTE)
 
  vendor.id		usb 0x19d2
 &device.id		usb 0x1008
@@ -69541,6 +74725,10 @@
  vendor.id		usb 0x19d2
 &device.id		usb 0x1218
 +device.name		MF652
+
+ vendor.id		usb 0x19d2
+&device.id		usb 0x1270
++device.name		MF667
 
  vendor.id		usb 0x19d2
 &device.id		usb 0x2000
@@ -69581,8 +74769,15 @@
 +vendor.name		Gampaq Co.Ltd
 
  vendor.id		usb 0x19fa
+&device.id		usb 0x0607
++device.name		GAME CONTROLLER
+
+ vendor.id		usb 0x19fa
 &device.id		usb 0x0703
 +device.name		Steering Wheel
+
+ vendor.id		usb 0x19fd
++vendor.name		MTI Instruments Inc.
 
  vendor.id		usb 0x19ff
 +vendor.name		Dynex
@@ -69596,8 +74791,16 @@
 +device.name		Rocketfish Wireless 2.4G Laser Mouse
 
  vendor.id		usb 0x19ff
+&device.id		usb 0x0220
++device.name		RF-HDWEBLT RocketFish HD WebCam
+
+ vendor.id		usb 0x19ff
 &device.id		usb 0x0238
 +device.name		DX-WRM1401 Mouse
+
+ vendor.id		usb 0x19ff
+&device.id		usb 0x0239
++device.name		Bluetooth 4.0 Adapter [Broadcom, 1.12, BCM20702A0]
 
  vendor.id		usb 0x1a08
 +vendor.name		Bellwood International, Inc.
@@ -69635,6 +74838,18 @@
  vendor.id		usb 0x1a2c
 &device.id		usb 0x0024
 +device.name		Multimedia Keyboard
+
+ vendor.id		usb 0x1a2c
+&device.id		usb 0x2124
++device.name		Keyboard
+
+ vendor.id		usb 0x1a2c
+&device.id		usb 0x2d23
++device.name		Keyboard
+
+ vendor.id		usb 0x1a2c
+&device.id		usb 0x427c
++device.name		Backlit Keyboard [Cougar Vantar]
 
  vendor.id		usb 0x1a32
 +vendor.name		Quanta Microsystems, Inc.
@@ -69690,6 +74905,25 @@
 &device.id		usb 0x3410
 +device.name		CoPilot System Cable
 
+ vendor.id		usb 0x1a61
+&device.id		usb 0x3650
++device.name		FreeStyle Libre
+
+ vendor.id		usb 0x1a61
+&device.id		usb 0x3850
++device.name		FreeStyle Optium/Precision Neo
+
+ vendor.id		usb 0x1a61
+&device.id		usb 0x3950
++device.name		FreeStyle Libre 2
+
+ vendor.id		usb 0x1a64
++vendor.name		Mastervolt
+
+ vendor.id		usb 0x1a64
+&device.id		usb 0x0000
++device.name		MasterBus Link
+
  vendor.id		usb 0x1a6a
 +vendor.name		Spansion Inc.
 
@@ -69717,8 +74951,20 @@
 +device.name		Contour
 
  vendor.id		usb 0x1a79
+&device.id		usb 0x6210
++device.name		Contour Next Link 2.4 glucometer
+
+ vendor.id		usb 0x1a79
+&device.id		usb 0x6300
++device.name		Contour next link
+
+ vendor.id		usb 0x1a79
 &device.id		usb 0x7410
 +device.name		Contour Next
+
+ vendor.id		usb 0x1a79
+&device.id		usb 0x7800
++device.name		Contour Plus One
 
  vendor.id		usb 0x1a7b
 +vendor.name		Lumberg Connect  GmbH & Co. KG
@@ -69738,8 +74984,35 @@
 &device.id		usb 0x0191
 +device.name		VerticalMouse 4
 
+ vendor.id		usb 0x1a7c
+&device.id		usb 0x0195
++device.name		VerticalMouse C Wireless
+
+ vendor.id		usb 0x1a7e
++vendor.name		Meltec Systementwicklung
+
+ vendor.id		usb 0x1a7e
+&device.id		usb 0x1001
++device.name		UFT75, UT150, UT60
+
+ vendor.id		usb 0x1a7e
+&device.id		usb 0x1003
++device.name		Thermostick
+
  vendor.id		usb 0x1a81
 +vendor.name		Holtek Semiconductor, Inc.
+
+ vendor.id		usb 0x1a81
+&device.id		usb 0x1004
++device.name		Wireless Dongle 2.4 GHZ HT82D40REW
+
+ vendor.id		usb 0x1a81
+&device.id		usb 0x1701
++device.name		Wireless dongle
+
+ vendor.id		usb 0x1a81
+&device.id		usb 0x2004
++device.name		Keyboard
 
  vendor.id		usb 0x1a81
 &device.id		usb 0x2203
@@ -69752,6 +75025,10 @@
  vendor.id		usb 0x1a81
 &device.id		usb 0x2205
 +device.name		Laser Mouse
+
+ vendor.id		usb 0x1a81
+&device.id		usb 0x4001
++device.name		Keyboard
 
  vendor.id		usb 0x1a86
 +vendor.name		QinHeng Electronics
@@ -69770,7 +75047,7 @@
 
  vendor.id		usb 0x1a86
 &device.id		usb 0x7523
-+device.name		HL-340 USB-Serial adapter
++device.name		CH340 serial converter
 
  vendor.id		usb 0x1a86
 &device.id		usb 0x752d
@@ -69817,6 +75094,25 @@
  vendor.id		usb 0x1aa6
 +vendor.name		eFortune Technology Corp.
 
+ vendor.id		usb 0x1aab
++vendor.name		Silvercreations Software AG
+
+ vendor.id		usb 0x1aab
+&device.id		usb 0x7736
++device.name		sceye (Gen 2)
+
+ vendor.id		usb 0x1aab
+&device.id		usb 0x7737
++device.name		sceye (Gen 3)
+
+ vendor.id		usb 0x1aab
+&device.id		usb 0x7738
++device.name		sceye (Gen 4, 3 Mpix)
+
+ vendor.id		usb 0x1aab
+&device.id		usb 0x7750
++device.name		sceyeS (Gen 5, 5 MPix)
+
  vendor.id		usb 0x1aad
 +vendor.name		KeeTouch
 
@@ -69828,8 +75124,27 @@
 +vendor.name		Rigol Technologies
 
  vendor.id		usb 0x1ab1
+&device.id		usb 0x04b0
++device.name		DS6000 SERIES
+
+ vendor.id		usb 0x1ab1
+&device.id		usb 0x04be
++device.name		DS4000 SERIES
+
+ vendor.id		usb 0x1ab1
+&device.id		usb 0x04ce
++device.name		DS1xx4Z/MSO1xxZ series
+
+ vendor.id		usb 0x1ab1
 &device.id		usb 0x0588
 +device.name		DS1000 SERIES
+
+ vendor.id		usb 0x1ab2
++vendor.name		Allied Vision
+
+ vendor.id		usb 0x1ab2
+&device.id		usb 0x0001
++device.name		Vision device
 
  vendor.id		usb 0x1acb
 +vendor.name		Salcomp Plc
@@ -69852,7 +75167,15 @@
 +device.name		KM290-HRS
 
  vendor.id		usb 0x1adb
-+vendor.name		SEL C662 Serial Cable
++vendor.name		Schweitzer Engineering Laboratories, Inc
+
+ vendor.id		usb 0x1adb
+&device.id		usb 0x0001
++device.name		C662 Serial Cable
+
+ vendor.id		usb 0x1adb
+&device.id		usb 0x0003
++device.name		CDC Ethernet Gadget
 
  vendor.id		usb 0x1ae4
 +vendor.name		ic-design Reinhard Gottinger GmbH
@@ -69863,6 +75186,10 @@
  vendor.id		usb 0x1ae7
 &device.id		usb 0x0381
 +device.name		VS-DVB-T 380U (af9015 based)
+
+ vendor.id		usb 0x1ae7
+&device.id		usb 0x0525
++device.name		X-Tensions ISDN TA XC-525 [HFC-S USB]
 
  vendor.id		usb 0x1ae7
 &device.id		usb 0x2001
@@ -69884,6 +75211,13 @@
 
  vendor.id		usb 0x1af1
 +vendor.name		Connect One Ltd.
+
+ vendor.id		usb 0x1af3
++vendor.name		Kingsis Technology Corporation
+
+ vendor.id		usb 0x1af3
+&device.id		usb 0x0001
++device.name		ZOWIE Gaming mouse
 
  vendor.id		usb 0x1afe
 +vendor.name		A. Eberle GmbH & Co. KG
@@ -70214,6 +75548,13 @@
 &device.id		usb 0x1080
 +device.name		WRITECHIP II CCID
 
+ vendor.id		usb 0x1b12
++vendor.name		Eventide
+
+ vendor.id		usb 0x1b12
+&device.id		usb 0x0011
++device.name		ModFactor
+
  vendor.id		usb 0x1b1c
 +vendor.name		Corsair
 
@@ -70234,6 +75575,26 @@
 +device.name		Link Cooling Node
 
  vendor.id		usb 0x1b1c
+&device.id		usb 0x0c06
++device.name		RM-Series C-Link Adapter
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x0c0a
++device.name		Hydro Series H115i Liquid CPU Cooler
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x0c0b
++device.name		Lighting Node Pro
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x0c0c
++device.name		Lighting Node Loader
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x0c22
++device.name		iCUE H150i RGB PRO XT Liquid CPU Cooler
+
+ vendor.id		usb 0x1b1c
 &device.id		usb 0x1a01
 +device.name		Flash Voyager GT
 
@@ -70252,6 +75613,14 @@
  vendor.id		usb 0x1b1c
 &device.id		usb 0x1a0b
 +device.name		Flash Voyager LS
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1a0e
++device.name		Voyager GTX
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1a14
++device.name		Voyager Vega
 
  vendor.id		usb 0x1b1c
 &device.id		usb 0x1a15
@@ -70290,12 +75659,71 @@
 +device.name		Vengeance K70RGB keyboard
 
  vendor.id		usb 0x1b1c
+&device.id		usb 0x1b20
++device.name		STRAFE RGB Gaming Keyboard
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1b2d
++device.name		K95 RGB Platinum Keyboard [RGP0056]
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1b2e
++device.name		Corsair Corsair Gaming M65 Pro RGB Mouse
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1b2f
++device.name		Sabre RGB [CH-9303011-XX]
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1b3d
++device.name		Corsair Corsair Gaming K55 RGB Keyboard
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1b5e
++device.name		Harpoon Wireless Mouse
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1b65
++device.name		Harpoon Wireless Dongle
+
+ vendor.id		usb 0x1b1c
 &device.id		usb 0x1c00
 +device.name		Controller for Corsair Link
 
  vendor.id		usb 0x1b1c
+&device.id		usb 0x1c02
++device.name		AX1500i Power Supply
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1c05
++device.name		HX750i Power Supply
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1c07
++device.name		HX1000i Power Supply
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1c08
++device.name		HX1200i Power Supply
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1c0b
++device.name		RM750i Power Supply
+
+ vendor.id		usb 0x1b1c
 &device.id		usb 0x1c0c
 +device.name		RM850i Power Supply
+
+ vendor.id		usb 0x1b1c
+&device.id		usb 0x1c1a
++device.name		Corsair CORSAIR Lighting Node CORE
+
+ vendor.id		usb 0x1b1e
++vendor.name		General Imaging / General Electric
+
+ vendor.id		usb 0x1b1e
+&device.id		usb 0x1003
++device.name		A1250
 
  vendor.id		usb 0x1b1f
 +vendor.name		eQ-3 Entwicklung GmbH
@@ -70304,11 +75732,22 @@
 &device.id		usb 0xc00f
 +device.name		HM-CFG-USB/HM-CFG-USB-2 [HomeMatic Configuration adapter]
 
+ vendor.id		usb 0x1b1f
+&device.id		usb 0xc020
++device.name		HmIP-RFUSB
+
  vendor.id		usb 0x1b20
 +vendor.name		MStar Semiconductor, Inc.
 
  vendor.id		usb 0x1b22
 +vendor.name		WiLinx Corp.
+
+ vendor.id		usb 0x1b24
++vendor.name		Telegent Systems, Inc.
+
+ vendor.id		usb 0x1b24
+&device.id		usb 0x4001
++device.name		TLG2300 Hybrid TV Device
 
  vendor.id		usb 0x1b26
 +vendor.name		Cellex Power Products, Inc.
@@ -70439,6 +75878,10 @@
 &device.id		usb 0x2002
 +device.name		808 Camera #9 (web-cam mode)
 
+ vendor.id		usb 0x1b3f
+&device.id		usb 0x2003
++device.name		GPD6000 [Digital MP3 Player]
+
  vendor.id		usb 0x1b47
 +vendor.name		Energizer Holdings, Inc.
 
@@ -70553,6 +75996,10 @@
 +vendor.name		Fushicai
 
  vendor.id		usb 0x1b71
+&device.id		usb 0x0050
++device.name		Encore ENUTV-4 Analog TV Tuner
+
+ vendor.id		usb 0x1b71
 &device.id		usb 0x3002
 +device.name		USBTV007 Video Grabber [EasyCAP]
 
@@ -70622,6 +76069,14 @@
  vendor.id		usb 0x1b80
 &device.id		usb 0xe297
 +device.name		Conceptronic DVB-T CTVDIGRCU V3.0
+
+ vendor.id		usb 0x1b80
+&device.id		usb 0xe302
++device.name		CVBS / S-Video Capture Device [Pinnacle Dazzle / UB315-E]
+
+ vendor.id		usb 0x1b80
+&device.id		usb 0xe34c
++device.name		UB435-Q ATSC TV Stick
 
  vendor.id		usb 0x1b80
 &device.id		usb 0xe383
@@ -70699,6 +76154,10 @@
 &device.id		usb 0x0001
 +device.name		InSight USB Link
 
+ vendor.id		usb 0x1ba4
+&device.id		usb 0x0002
++device.name		EM358 Virtual COM Port
+
  vendor.id		usb 0x1ba6
 +vendor.name		Abilis Systems
 
@@ -70710,11 +76169,159 @@
 
  vendor.id		usb 0x1bad
 &device.id		usb 0x0002
-+device.name		Guitar for Xbox 360
++device.name		Rock Band Guitar for Xbox 360
 
  vendor.id		usb 0x1bad
 &device.id		usb 0x0003
-+device.name		Drum Kit for Xbox 360
++device.name		Rock Band Drum Kit for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0x0130
++device.name		Ion Drum Rocker for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0x028e
++device.name		Controller
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0x3330
++device.name		Rock Band 3 Keyboard wii interface
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf016
++device.name		Controller
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf018
++device.name		Street Fighter IV SE FightStick for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf019
++device.name		BrawlStick for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf021
++device.name		Ghost Recon Future Soldier Gamepad for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf023
++device.name		MLG Pro Circuit Controller for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf025
++device.name		Call of Duty Controller for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf027
++device.name		FPS Pro Controller for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf028
++device.name		Street Fighter IV FightPad for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf02e
++device.name		FightPad
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf030
++device.name		MC2 MicroCON Racing Wheel for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf036
++device.name		MicroCON Gamepad Pro for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf038
++device.name		Street Fighter IV FightStick TE for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf039
++device.name		Marvel VS Capcom 2 Tournament Stick for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf03a
++device.name		Street Fighter X Tekken FightStick Pro for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf03d
++device.name		Street Fighter IV Arcade Stick TE for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf03e
++device.name		MLG Arcade FightStick TE for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf03f
++device.name		Soulcalibur FightStick for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf042
++device.name		Arcade FightStick TE S+ for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf080
++device.name		FightStick TE2 for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf501
++device.name		Horipad EX2 Turbo for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf502
++device.name		Real Arcade Pro.VX SA for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf503
++device.name		Fighting Stick VX for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf504
++device.name		Real Arcade Pro.EX
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf505
++device.name		Fighting Stick EX2B for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf506
++device.name		Real Arcade Pro.EX Premium VLX for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf900
++device.name		Controller
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf901
++device.name		GameStop Controller
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf903
++device.name		Tron Controller for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf904
++device.name		PDP Versus Fighting Pad for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf906
++device.name		Mortal Kombat FightStick for Xbox 360
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xf907
++device.name		Afterglow Gamepad
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xfa01
++device.name		Gamepad
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xfd00
++device.name		Razer Onza Tournament Edition
+
+ vendor.id		usb 0x1bad
+&device.id		usb 0xfd01
++device.name		Razer Onza Classic Edition
 
  vendor.id		usb 0x1bae
 +vendor.name		Vuzix Corporation
@@ -70727,12 +76334,86 @@
 +vendor.name		T & A Mobile Phones
 
  vendor.id		usb 0x1bbb
+&device.id		usb 0x0003
++device.name		Alcatel one touch 4030D modem connection
+
+ vendor.id		usb 0x1bbb
+&device.id		usb 0x0017
++device.name		HSPA Data Card
+
+ vendor.id		usb 0x1bbb
+&device.id		usb 0x007a
++device.name		Alcatel OneTouch (firmware upgrade mode)
+
+ vendor.id		usb 0x1bbb
 &device.id		usb 0x011e
 +device.name		Alcatel One Touch L100V / Telekom Speedstick LTE II
 
  vendor.id		usb 0x1bbb
+&device.id		usb 0x0169
++device.name		Alcatel ONE TOUCH Fierce
+
+ vendor.id		usb 0x1bbb
+&device.id		usb 0x0195
++device.name		Alcatel OneTouch L850V / Telekom Speedstick LTE
+
+ vendor.id		usb 0x1bbb
+&device.id		usb 0xa00e
++device.name		Vodafone Smart Tab 4G
+
+ vendor.id		usb 0x1bbb
+&device.id		usb 0xf000
++device.name		Alcatel OneTouch (mass storage mode)
+
+ vendor.id		usb 0x1bbb
 &device.id		usb 0xf017
 +device.name		Alcatel One Touch L100V / Telekom Speedstick LTE II
+
+ vendor.id		usb 0x1bbd
++vendor.name		Videology Imaging Solutions, Inc.
+
+ vendor.id		usb 0x1bbd
+&device.id		usb 0x0060
++device.name		1.3MP Mono Camera
+
+ vendor.id		usb 0x1bbd
+&device.id		usb 0x0066
++device.name		1.3MP Mono Camera
+
+ vendor.id		usb 0x1bbd
+&device.id		usb 0x0067
++device.name		1.3MP Mono Camera
+
+ vendor.id		usb 0x1bc0
++vendor.name		Beijing Senseshield Technology Co.,Ltd.
+
+ vendor.id		usb 0x1bc0
+&device.id		usb 0x0013
++device.name		Elitee-e
+
+ vendor.id		usb 0x1bc0
+&device.id		usb 0x0014
++device.name		Elite4
+
+ vendor.id		usb 0x1bc0
+&device.id		usb 0x0020
++device.name		iToken
+
+ vendor.id		usb 0x1bc0
+&device.id		usb 0x0021
++device.name		Mikey
+
+ vendor.id		usb 0x1bc0
+&device.id		usb 0x0051
++device.name		Elite5
+
+ vendor.id		usb 0x1bc0
+&device.id		usb 0x0055
++device.name		Elite5 v3.x
+
+ vendor.id		usb 0x1bc0
+&device.id		usb 0x485d
++device.name		EliteIV
 
  vendor.id		usb 0x1bc4
 +vendor.name		Ford Motor Co.
@@ -70752,8 +76433,16 @@
 +device.name		HE910
 
  vendor.id		usb 0x1bc7
+&device.id		usb 0x0022
++device.name		GE910-QUAD
+
+ vendor.id		usb 0x1bc7
 &device.id		usb 0x0023
 +device.name		HE910-D ECM
+
+ vendor.id		usb 0x1bc7
+&device.id		usb 0x0032
++device.name		LE910-EU V2
 
  vendor.id		usb 0x1bc7
 &device.id		usb 0x1003
@@ -70780,8 +76469,24 @@
 +device.name		CE910-DUAL
 
  vendor.id		usb 0x1bc7
+&device.id		usb 0x1012
++device.name		UE910 V2
+
+ vendor.id		usb 0x1bc7
+&device.id		usb 0x1101
++device.name		ME910C1
+
+ vendor.id		usb 0x1bc7
+&device.id		usb 0x110a
++device.name		ME310
+
+ vendor.id		usb 0x1bc7
 &device.id		usb 0x1200
-+device.name		LE920
++device.name		LE920 (old firmware)
+
+ vendor.id		usb 0x1bc7
+&device.id		usb 0x1201
++device.name		LE910 / LE920
 
  vendor.id		usb 0x1bce
 +vendor.name		Contac Cable Industrial Limited
@@ -70810,12 +76515,24 @@
 +device.name		Micro keyboard & mouse receiver
 
  vendor.id		usb 0x1bcf
+&device.id		usb 0x08a0
++device.name		Gaming mouse [Philips SPK9304]
+
+ vendor.id		usb 0x1bcf
 &device.id		usb 0x0c31
 +device.name		SPIF30x Serial-ATA bridge
 
  vendor.id		usb 0x1bcf
+&device.id		usb 0x2281
++device.name		SPCA2281 Web Camera
+
+ vendor.id		usb 0x1bcf
 &device.id		usb 0x2880
 +device.name		Dell HD Webcam
+
+ vendor.id		usb 0x1bcf
+&device.id		usb 0x2883
++device.name		Asus Webcam
 
  vendor.id		usb 0x1bcf
 &device.id		usb 0x2885
@@ -70824,6 +76541,10 @@
  vendor.id		usb 0x1bcf
 &device.id		usb 0x2888
 +device.name		HP Universal Camera
+
+ vendor.id		usb 0x1bcf
+&device.id		usb 0x2895
++device.name		Dell Integrated Webcam
 
  vendor.id		usb 0x1bcf
 &device.id		usb 0x28a2
@@ -70849,11 +76570,34 @@
 &device.id		usb 0x2b83
 +device.name		Laptop Integrated Webcam FHD
 
+ vendor.id		usb 0x1bcf
+&device.id		usb 0x2b91
++device.name		Dell E5570 integrated webcam
+
+ vendor.id		usb 0x1bcf
+&device.id		usb 0x2b97
++device.name		Laptop Integrated Webcam FHD
+
+ vendor.id		usb 0x1bcf
+&device.id		usb 0x2c6e
++device.name		Laptop Integrated WebCam HD
+
  vendor.id		usb 0x1bd0
 +vendor.name		Hangzhou Riyue Electronic Co., Ltd.
 
  vendor.id		usb 0x1bd5
 +vendor.name		BG Systems, Inc.
+
+ vendor.id		usb 0x1bda
++vendor.name		University Of Southampton
+
+ vendor.id		usb 0x1bda
+&device.id		usb 0x0010
++device.name		Power Board v4 Rev B
+
+ vendor.id		usb 0x1bda
+&device.id		usb 0x0011
++device.name		Student Robotics SBv4B
 
  vendor.id		usb 0x1bde
 +vendor.name		P-TWO INDUSTRIES, INC.
@@ -70911,6 +76655,21 @@
  vendor.id		usb 0x1c04
 +vendor.name		QNAP System Inc.
 
+ vendor.id		usb 0x1c04
+&device.id		usb 0x2074
++device.name		ASM1074 High-Speed hub
+
+ vendor.id		usb 0x1c04
+&device.id		usb 0x3074
++device.name		ASM1074 SuperSpeed hub
+
+ vendor.id		usb 0x1c05
++vendor.name		Shenxhen Stager Electric
+
+ vendor.id		usb 0x1c05
+&device.id		usb 0xea75
++device.name		G540 Programmer
+
  vendor.id		usb 0x1c0c
 +vendor.name		Ionics EMS, Inc.
 
@@ -70924,11 +76683,22 @@
  vendor.id		usb 0x1c10
 +vendor.name		Lanterra Industrial Co., Ltd.
 
+ vendor.id		usb 0x1c11
++vendor.name		Input Club Inc.
+
+ vendor.id		usb 0x1c11
+&device.id		usb 0xb04d
++device.name		ErgoDox Infinity
+
  vendor.id		usb 0x1c13
 +vendor.name		ALECTRONIC LIMITED
 
  vendor.id		usb 0x1c1a
 +vendor.name		Datel Electronics Ltd.
+
+ vendor.id		usb 0x1c1a
+&device.id		usb 0x0100
++device.name		Action Replay DS "3DS/DSi/DS/Lite Compatible"
 
  vendor.id		usb 0x1c1b
 +vendor.name		Volkswagen of America, Inc.
@@ -70950,6 +76720,49 @@
 
  vendor.id		usb 0x1c27
 +vendor.name		HuiYang D & S Cable Co., Ltd.
+
+ vendor.id		usb 0x1c28
++vendor.name		PMD Technologies
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc003
++device.name		CamCube
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc004
++device.name		CamBoard
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc005
++device.name		ConceptCam
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc006
++device.name		CamBoard 22
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc007
++device.name		CamBoard nano
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc008
++device.name		CamBoard mod
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc009
++device.name		CamBoard plus
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc00a
++device.name		DigiCam
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc00d
++device.name		CamBoard pico LDD
+
+ vendor.id		usb 0x1c28
+&device.id		usb 0xc00f
++device.name		CamBoard pico
 
  vendor.id		usb 0x1c29
 +vendor.name		Elster GmbH
@@ -70974,6 +76787,10 @@
 
  vendor.id		usb 0x1c37
 +vendor.name		Authorizer Technologies, Inc.
+
+ vendor.id		usb 0x1c37
+&device.id		usb 0x6190
++device.name		U2F Fido-compliant cryptotoken
 
  vendor.id		usb 0x1c3d
 +vendor.name		NONIN MEDICAL INC.
@@ -71000,8 +76817,19 @@
 &device.id		usb 0x0536
 +device.name		Swiss ColorPAL
 
+ vendor.id		usb 0x1c40
+&device.id		usb 0x0537
++device.name		MIST Board
+
  vendor.id		usb 0x1c49
 +vendor.name		Cherng Weei Technology Corp.
+
+ vendor.id		usb 0x1c4b
++vendor.name		Geratherm Medical AG
+
+ vendor.id		usb 0x1c4b
+&device.id		usb 0x026f
++device.name		Spirostik
 
  vendor.id		usb 0x1c4f
 +vendor.name		SiGma Micro
@@ -71023,6 +76851,22 @@
 +device.name		Keyboard
 
  vendor.id		usb 0x1c4f
+&device.id		usb 0x0032
++device.name		Optical Mouse with Scroll Wheel
+
+ vendor.id		usb 0x1c4f
+&device.id		usb 0x0034
++device.name		XM102K Optical Wheel Mouse
+
+ vendor.id		usb 0x1c4f
+&device.id		usb 0x0063
++device.name		Touchpad (integrated in detachable keyboard of Chuwi SurBook)
+
+ vendor.id		usb 0x1c4f
+&device.id		usb 0x0065
++device.name		Optical Wheel Mouse [Rapoo N1130]
+
+ vendor.id		usb 0x1c4f
 &device.id		usb 0x3000
 +device.name		Micro USB Web Camera
 
@@ -71030,15 +76874,37 @@
 &device.id		usb 0x3002
 +device.name		WebCam SiGma Micro
 
+ vendor.id		usb 0x1c57
++vendor.name		Zalman Tech Co., Ltd.
+
+ vendor.id		usb 0x1c57
+&device.id		usb 0x1e45
++device.name		FPSGUN FG1000 Mouse
+
  vendor.id		usb 0x1c6b
 +vendor.name		Philips & Lite-ON Digital Solutions Corporation
+
+ vendor.id		usb 0x1c6b
+&device.id		usb 0xa220
++device.name		DVD Writer Slimtype eSAU108
 
  vendor.id		usb 0x1c6b
 &device.id		usb 0xa222
 +device.name		DVD Writer Slimtype eTAU108
 
+ vendor.id		usb 0x1c6b
+&device.id		usb 0xa223
++device.name		DVD Writer Slimtype eUAU108
+
  vendor.id		usb 0x1c6c
 +vendor.name		Skydigital Inc.
+
+ vendor.id		usb 0x1c71
++vendor.name		Humanware Inc
+
+ vendor.id		usb 0x1c71
+&device.id		usb 0xc004
++device.name		Braille Note Apex (braille terminal mode)
 
  vendor.id		usb 0x1c73
 +vendor.name		AMT
@@ -71046,6 +76912,13 @@
  vendor.id		usb 0x1c73
 &device.id		usb 0x861f
 +device.name		Anysee E30 USB 2.0 DVB-T Receiver
+
+ vendor.id		usb 0x1c75
++vendor.name		Arturia
+
+ vendor.id		usb 0x1c75
+&device.id		usb 0x0288
++device.name		KeyStep
 
  vendor.id		usb 0x1c77
 +vendor.name		Kaetat Industrial Co., Ltd.
@@ -71060,11 +76933,26 @@
 +vendor.name		LighTuning Technology Inc.
 
  vendor.id		usb 0x1c7a
+&device.id		usb 0x0577
++device.name		Fingerprint Sensor
+
+ vendor.id		usb 0x1c7a
+&device.id		usb 0x0603
++device.name		ES603 Swipe Fingerprint Sensor
+
+ vendor.id		usb 0x1c7a
 &device.id		usb 0x0801
 +device.name		Fingerprint Reader
 
  vendor.id		usb 0x1c7b
 +vendor.name		LUXSHARE PRECISION INDUSTRY (SHENZHEN) CO., LTD.
+
+ vendor.id		usb 0x1c82
++vendor.name		Atracsys
+
+ vendor.id		usb 0x1c82
+&device.id		usb 0x0200
++device.name		spryTrac
 
  vendor.id		usb 0x1c83
 +vendor.name		Schomaecker GmbH
@@ -71072,6 +76960,18 @@
  vendor.id		usb 0x1c83
 &device.id		usb 0x0001
 +device.name		RS150 V2
+
+ vendor.id		usb 0x1c83
+&device.id		usb 0x0002
++device.name		RFID card reader
+
+ vendor.id		usb 0x1c83
+&device.id		usb 0x0003
++device.name		Communicator
+
+ vendor.id		usb 0x1c83
+&device.id		usb 0x0005
++device.name		Mobile RFID Reader
 
  vendor.id		usb 0x1c87
 +vendor.name		2N TELEKOMUNIKACE a.s.
@@ -71141,6 +77041,10 @@
 +vendor.name		Luminary Micro Inc.
 
  vendor.id		usb 0x1cbe
+&device.id		usb 0x0002
++device.name		CDC serial port [TivaWare]
+
+ vendor.id		usb 0x1cbe
 &device.id		usb 0x00fd
 +device.name		In-Circuit Debug Interface
 
@@ -71151,6 +77055,10 @@
  vendor.id		usb 0x1cbe
 &device.id		usb 0x0166
 +device.name		CANAL USB2CAN
+
+ vendor.id		usb 0x1cbe
+&device.id		usb 0x0240
++device.name		McGill Robotics TM4C Microcontroller
 
  vendor.id		usb 0x1cbf
 +vendor.name		FORTAT SKYMARK INDUSTRIAL COMPANY
@@ -71240,6 +77148,10 @@
 &device.id		usb 0x0027
 +device.name		deRFusb13E06
 
+ vendor.id		usb 0x1cf1
+&device.id		usb 0x0030
++device.name		ZigBee gateway [ConBee II]
+
  vendor.id		usb 0x1cfc
 +vendor.name		ANDES TECHNOLOGY CORPORATION
 
@@ -71272,6 +77184,13 @@
  vendor.id		usb 0x1d0b
 +vendor.name		HAN HUA CABLE & WIRE TECHNOLOGY (J.X.) CO., LTD.
 
+ vendor.id		usb 0x1d0d
++vendor.name		TDKMedia
+
+ vendor.id		usb 0x1d0d
+&device.id		usb 0x0214
++device.name		Trans-It Drive
+
  vendor.id		usb 0x1d0f
 +vendor.name		Sonix Technology Co., Ltd.
 
@@ -71301,7 +77220,15 @@
 +device.name		DK 5217 DVB-T Dongle
 
  vendor.id		usb 0x1d19
+&device.id		usb 0x1104
++device.name		MSI DigiVox Micro HD
+
+ vendor.id		usb 0x1d19
 &device.id		usb 0x6105
++device.name		Video grabber
+
+ vendor.id		usb 0x1d19
+&device.id		usb 0x610a
 +device.name		Video grabber
 
  vendor.id		usb 0x1d19
@@ -71317,32 +77244,48 @@
  vendor.id		usb 0x1d27
 +vendor.name		ASUS
 
+ vendor.id		usb 0x1d27
+&device.id		usb 0x0601
++device.name		Xtion
+
  vendor.id		usb 0x1d34
 +vendor.name		Dream Cheeky
 
  vendor.id		usb 0x1d34
 &device.id		usb 0x0001
-+device.name		Dream Cheeky Fidget
++device.name		Fidget
+
+ vendor.id		usb 0x1d34
+&device.id		usb 0x0002
++device.name		Fidget (Basketball)
+
+ vendor.id		usb 0x1d34
+&device.id		usb 0x0003
++device.name		Fidget (Golf Ball)
 
  vendor.id		usb 0x1d34
 &device.id		usb 0x0004
-+device.name		Dream Cheeky Webmail Notifier
++device.name		Webmail Notifier
 
  vendor.id		usb 0x1d34
 &device.id		usb 0x0008
-+device.name		Dream Cheeky button
++device.name		button
 
  vendor.id		usb 0x1d34
 &device.id		usb 0x000a
-+device.name		Dream Cheeky Mailbox Friends Alert
++device.name		Mailbox Friends Alert
 
  vendor.id		usb 0x1d34
 &device.id		usb 0x000d
-+device.name		Dream Cheeky Big Red Button
++device.name		Big Red Button
 
  vendor.id		usb 0x1d34
 &device.id		usb 0x0013
-+device.name		Dream Cheeky LED Message Board
++device.name		LED Message Board
+
+ vendor.id		usb 0x1d34
+&device.id		usb 0x0020
++device.name		Stress Ball
 
  vendor.id		usb 0x1d45
 +vendor.name		Touch
@@ -71350,6 +77293,14 @@
  vendor.id		usb 0x1d45
 &device.id		usb 0x1d45
 +device.name		Foxlink Optical touch sensor
+
+ vendor.id		usb 0x1d45
+&device.id		usb 0x459d
++device.name		BenQ F5
+
+ vendor.id		usb 0x1d45
+&device.id		usb 0x465c
++device.name		Harrier Mini by EE
 
  vendor.id		usb 0x1d4d
 +vendor.name		PEGATRON CORPORATION
@@ -71428,6 +77379,226 @@
  vendor.id		usb 0x1d50
 &device.id		usb 0x5300
 +device.name		Rockbox
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x530e
++device.name		iriver H10 20GB (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x530f
++device.name		iriver H10 5/6GB (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5314
++device.name		Apple iPod Color/Photo (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5315
++device.name		Apple iPod Nano 1g (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5316
++device.name		Apple iPod Video (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5318
++device.name		Apple iPod 4g Grayscale (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5319
++device.name		Apple iPod Mini 1g (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x531a
++device.name		Apple iPod Mini 2g (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x531c
++device.name		Apple iPod Nano 2g (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x531d
++device.name		Apple iPod Classic/6G (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5321
++device.name		Cowon D2 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5329
++device.name		Toshiba Gigabeat S (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5332
++device.name		Sandisk Sansa e200 series (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5334
++device.name		Sandisk Sansa c200 series (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5337
++device.name		Sandisk Sansa Clip (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5338
++device.name		Sandisk Sansa e200v2 series (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5339
++device.name		Sandisk Sansa m200 v4 series (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x533a
++device.name		Sandisk Sansa Fuze (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x533b
++device.name		Sandisk Sansa c200v2 series (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x533c
++device.name		Sandisk Sansa Clipv2 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x533e
++device.name		Sandisk Sansa Clip+ (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x533f
++device.name		Sandisk Sansa Fuze v2 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5340
++device.name		Sandisk Sansa Fuze+ (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5341
++device.name		Sandisk Sansa Zip (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5342
++device.name		Sandisk Sansa Connect (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5346
++device.name		Olympus M:Robe 500i (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5347
++device.name		Olympus m:robe MR-100 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5359
++device.name		Creative Zen X-Fi Style (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x535d
++device.name		Creative Zen X-Fi2 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x535e
++device.name		Creative Zen X-Fi3 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5360
++device.name		Creative Zen X-Fi (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5361
++device.name		Creative ZEN Mozaic (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5362
++device.name		Creative Zen (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5364
++device.name		Philips GoGear SA9200 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5365
++device.name		Philips GoGear HDD16x0 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5366
++device.name		Philips GoGear HDD63x0 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5378
++device.name		Onda VX747 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x5379
++device.name		Onda VX767 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x537b
++device.name		Onda VX777 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x538c
++device.name		Samsung YH-820 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x538d
++device.name		Samsung YH-920 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x538e
++device.name		Samsung YH-925 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53a0
++device.name		Packard Bell Vibe 500 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53b4
++device.name		Rockchip 27xx generic (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53be
++device.name		HiFiMAN HM-60x (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53bf
++device.name		HiFiMAN HM-801 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53d2
++device.name		HiFi E.T. MA9 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53d3
++device.name		HiFi E.T. MA9C (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53d4
++device.name		HiFi E.T. MA8 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53d5
++device.name		HiFi E.T. MA8C (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53dc
++device.name		Sony NWZ-E370/E380 series (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53dd
++device.name		Sony NWZ-E360 series (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53e6
++device.name		IHIFI 760 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53e7
++device.name		IHIFI 960 (Rockbox)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x53ff
++device.name		Generic Rockbox device
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x6000
@@ -71546,6 +77717,10 @@
 +device.name		EPOSMote II
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x601d
++device.name		UDS18B20 temperature sensor
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x601e
 +device.name		5x5 STM32 prototyping board
 
@@ -71578,12 +77753,20 @@
 +device.name		Keyglove (HID)
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x6026
++device.name		Keyglove (Serial)
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x6027
 +device.name		Key64 Keyboard
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x6028
 +device.name		Teensy 2.0 Development Board [ErgoDox Keyboard]
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6029
++device.name		Marlin 2.0 (Serial)
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x602a
@@ -71616,6 +77799,10 @@
  vendor.id		usb 0x1d50
 &device.id		usb 0x6031
 +device.name		Handmade GSM GPS tracker
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6032
++device.name		ncrmnt.org uISP
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x6033
@@ -71754,8 +77941,28 @@
 +device.name		Satlab/AAUSAT3 BlueBox
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x6055
++device.name		RADiuS ER900TRS-02 transciever with SMA Connector
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x6056
 +device.name		The Glitch
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6057
++device.name		OpenPipe MIDI Shield
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6058
++device.name		Novena OTG port
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6059
++device.name		xser serial
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x605a
++device.name		Daisho test
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x605b
@@ -71784,6 +77991,10 @@
  vendor.id		usb 0x1d50
 &device.id		usb 0x6061
 +device.name		Power Manager
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6062
++device.name		WhiteRabbit console and Wishbone bridge
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x6063
@@ -71834,6 +78045,10 @@
 +device.name		Reefangel Evolution 1.0
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x606f
++device.name		Geschwister Schneider CAN adapter
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x6070
 +device.name		Open Pinball Project
 
@@ -71870,6 +78085,10 @@
 +device.name		DTplug
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x6079
++device.name		Mood Light
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x607a
 +device.name		Fadecandy
 
@@ -71884,6 +78103,10 @@
  vendor.id		usb 0x1d50
 &device.id		usb 0x607d
 +device.name		Spark Core Arduino-compatible board with WiFi
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x607e
++device.name		OSHUG Wuthering multi-tool
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x607f
@@ -71916,6 +78139,10 @@
  vendor.id		usb 0x1d50
 &device.id		usb 0x6086
 +device.name		OneRNG entropy device
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6087
++device.name		Blinkytape (alternate endpoint config)
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x6088
@@ -72066,6 +78293,18 @@
 +device.name		OpenBLT generic microcontroller (bootloader)
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x60ad
++device.name		Clasic Gamepad Adapter (NES)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x60ae
++device.name		Clasic Gamepad Adapter (N64)
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x60af
++device.name		Clasic Gamepad Adapter (DB9)
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x60b0
 +device.name		Waterott Arduino based Clock (caterina bootloader)
 
@@ -72126,6 +78365,10 @@
 +device.name		Pixelmatix Aurora
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x60c0
++device.name		Nucular Keyboard adapter
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x60c1
 +device.name		BrewBit Model-T pOSHW temperature controller for homebrewers (bootloader)
 
@@ -72136,6 +78379,14 @@
  vendor.id		usb 0x1d50
 &device.id		usb 0x60c3
 +device.name		X Antenna Tracker arduino board
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x60c4
++device.name		CAN bus communication device
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x60c5
++device.name		PIC16F1 bootloader
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x60c6
@@ -72164,6 +78415,10 @@
  vendor.id		usb 0x1d50
 &device.id		usb 0x60cc
 +device.name		LamDiNao
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x60cd
++device.name		Open Lighting DMX512 / RDM widget
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x60de
@@ -72218,8 +78473,20 @@
 +device.name		Wiggleport FPGA-based I/O board
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x60eb
++device.name		candleLight CAN adapter
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x60ec
-+device.name		Duet 3D Printer Controller
++device.name		Duet 2 WiFi or Duet 2 Ethernet 3D printer control electronics
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x60ed
++device.name		Duet 2 Maestro 3D printer control electronics
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x60ee
++device.name		Duet 3 motion control electronics
 
  vendor.id		usb 0x1d50
 &device.id		usb 0x60f0
@@ -72282,12 +78549,28 @@
 +device.name		Magic Keys
 
  vendor.id		usb 0x1d50
+&device.id		usb 0x6114
++device.name		MIDI key
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6118
++device.name		Thomson MO5 keyboard
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x6122
++device.name		Ultimate Hacking Keyboard
+
+ vendor.id		usb 0x1d50
+&device.id		usb 0x614c
++device.name		dwtk In-Circuit Emulator
+
+ vendor.id		usb 0x1d50
 &device.id		usb 0x8085
 +device.name		Box0 (box0-v5)
 
  vendor.id		usb 0x1d50
 &device.id		usb 0xcc15
-+device.name		rad1o badge for CCC congress 2015
++device.name		rad1o badge for CCC summer camp 2015
 
  vendor.id		usb 0x1d57
 +vendor.name		Xenta
@@ -72303,6 +78586,10 @@
  vendor.id		usb 0x1d57
 &device.id		usb 0x000c
 +device.name		Optical Mouse
+
+ vendor.id		usb 0x1d57
+&device.id		usb 0x130f
++device.name		2.4Ghz wireless optical mouse receiver
 
  vendor.id		usb 0x1d57
 &device.id		usb 0x2400
@@ -72321,12 +78608,32 @@
 +device.name		Wireless Receiver (Keyboard and Mouse)
 
  vendor.id		usb 0x1d57
+&device.id		usb 0xac02
++device.name		ViFit Activity Tracker
+
+ vendor.id		usb 0x1d57
+&device.id		usb 0xac08
++device.name		RFID Receiver (Keyboard)
+
+ vendor.id		usb 0x1d57
 &device.id		usb 0xad02
 +device.name		SE340D PC Remote Control
 
  vendor.id		usb 0x1d57
+&device.id		usb 0xad03
++device.name		[T3] 2.4GHz and IR Air Mouse Remote Control
+
+ vendor.id		usb 0x1d57
 &device.id		usb 0xaf01
 +device.name		AUVIO Universal Remote Receiver for PlayStation 3
+
+ vendor.id		usb 0x1d57
+&device.id		usb 0xaf03
++device.name		Wireless Receiver
+
+ vendor.id		usb 0x1d57
+&device.id		usb 0xfa20
++device.name		2.4GHz Wireless Reciever (Mini Keyboard & Mouse)
 
  vendor.id		usb 0x1d5b
 +vendor.name		Smartronix, Inc.
@@ -72381,12 +78688,35 @@
 &device.id		usb 0x0200
 +device.name		Qemu Audio Device
 
+ vendor.id		usb 0x1d88
++vendor.name		Mahr GmbH
+
+ vendor.id		usb 0x1d88
+&device.id		usb 0x0001
++device.name		Measurement Device [MarECon]
+
+ vendor.id		usb 0x1d88
+&device.id		usb 0x0002
++device.name		Probe
+
+ vendor.id		usb 0x1d88
+&device.id		usb 0x0003
++device.name		Surface Measurement [PS10]
+
  vendor.id		usb 0x1d90
 +vendor.name		Citizen
 
  vendor.id		usb 0x1d90
 &device.id		usb 0x201e
 +device.name		PPU-700
+
+ vendor.id		usb 0x1d90
+&device.id		usb 0x2037
++device.name		CL-S631 Barcode Printer
+
+ vendor.id		usb 0x1d90
+&device.id		usb 0x20f0
++device.name		Thermal Receipt Printer [CT-E351]
 
  vendor.id		usb 0x1d9d
 +vendor.name		Sigma Sport
@@ -72399,6 +78729,20 @@
 &device.id		usb 0x1011
 +device.name		Docking Station Topline 2012
 
+ vendor.id		usb 0x1d9d
+&device.id		usb 0x1012
++device.name		Docking Station Topline 2016
+
+ vendor.id		usb 0x1dd2
++vendor.name		Leo Bodnar Electronics Ltd
+
+ vendor.id		usb 0x1dd3
++vendor.name		Dajc Inc.
+
+ vendor.id		usb 0x1dd3
+&device.id		usb 0x0001
++device.name		Expert I/O 1000
+
  vendor.id		usb 0x1de1
 +vendor.name		Actions Microelectronics Co.
 
@@ -72409,6 +78753,9 @@
  vendor.id		usb 0x1de1
 &device.id		usb 0xc101
 +device.name		Generic Display Device
+
+ vendor.id		usb 0x1de6
++vendor.name		MICRORISC s.r.o.
 
  vendor.id		usb 0x1e0e
 +vendor.name		Qualcomm / Option
@@ -72513,6 +78860,14 @@
 +device.name		LPC2378 [Robotino 3 Bootloader]
 
  vendor.id		usb 0x1e29
+&device.id		usb 0x040f
++device.name		LPC2148 [Robotino gripper]
+
+ vendor.id		usb 0x1e29
+&device.id		usb 0x0410
++device.name		LPC2148 [Robotino IR panel]
+
+ vendor.id		usb 0x1e29
 &device.id		usb 0x0501
 +device.name		CP2102 [CMSP]
 
@@ -72520,8 +78875,47 @@
 &device.id		usb 0x0601
 +device.name		CMMP-AS
 
+ vendor.id		usb 0x1e29
+&device.id		usb 0x0602
++device.name		FTDI232 [CMMS]
+
+ vendor.id		usb 0x1e2d
++vendor.name		Gemalto M2M GmbH
+
+ vendor.id		usb 0x1e2d
+&device.id		usb 0x004f
++device.name		EGS3 GSM/GPRS modem
+
+ vendor.id		usb 0x1e2d
+&device.id		usb 0x0054
++device.name		PH8 wireless module
+
+ vendor.id		usb 0x1e2d
+&device.id		usb 0x0058
++device.name		Wireless Module [Cinterion EHS6]
+
+ vendor.id		usb 0x1e2d
+&device.id		usb 0x0059
++device.name		Wireless Module [Cinterion BGx]
+
+ vendor.id		usb 0x1e2d
+&device.id		usb 0x005b
++device.name		Zoom 4625 Modem
+
+ vendor.id		usb 0x1e2d
+&device.id		usb 0x0061
++device.name		ALSx PLSx LTE modem
+
+ vendor.id		usb 0x1e2d
+&device.id		usb 0x00a0
++device.name		Cinterion ELS31-V
+
  vendor.id		usb 0x1e3d
 +vendor.name		Chipsbank Microelectronics Co., Ltd
+
+ vendor.id		usb 0x1e3d
+&device.id		usb 0x198a
++device.name		Flash Disk
 
  vendor.id		usb 0x1e3d
 &device.id		usb 0x2093
@@ -72538,6 +78932,17 @@
 &device.id		usb 0x0001
 +device.name		CS328A PC Oscilloscope
 
+ vendor.id		usb 0x1e41
+&device.id		usb 0x0004
++device.name		CS448
+
+ vendor.id		usb 0x1e44
++vendor.name		SHIMANO INC.
+
+ vendor.id		usb 0x1e44
+&device.id		usb 0x7220
++device.name		SM-BCR2
+
  vendor.id		usb 0x1e4e
 +vendor.name		Cubeternet
 
@@ -72548,6 +78953,10 @@
  vendor.id		usb 0x1e4e
 &device.id		usb 0x0102
 +device.name		GL-UPC822 UVC WebCam
+
+ vendor.id		usb 0x1e4e
+&device.id		usb 0x0109
++device.name		EtronTech CMOS based eSP570 WebCam [Onyx Titanium TC101]
 
  vendor.id		usb 0x1e54
 +vendor.name		TypeMatrix
@@ -72564,8 +78973,20 @@
 +device.name		DataStation maxi g.u
 
  vendor.id		usb 0x1e68
+&device.id		usb 0x004c
++device.name		DataStation Pocket Click
+
+ vendor.id		usb 0x1e68
 &device.id		usb 0x0050
 +device.name		DataStation maxi light
+
+ vendor.id		usb 0x1e68
+&device.id		usb 0x1045
++device.name		ST70408-3 [SurfTab breeze 7.0 quad 3G] (MTP Mode)
+
+ vendor.id		usb 0x1e68
+&device.id		usb 0x1046
++device.name		ST70408-3 [SurfTab breeze 7.0 quad 3G] (PTP Mode)
 
  vendor.id		usb 0x1e71
 +vendor.name		NZXT
@@ -72573,6 +78994,26 @@
  vendor.id		usb 0x1e71
 &device.id		usb 0x0001
 +device.name		Avatar Optical Mouse
+
+ vendor.id		usb 0x1e71
+&device.id		usb 0x170e
++device.name		Kraken X
+
+ vendor.id		usb 0x1e71
+&device.id		usb 0x1711
++device.name		Grid+ V3
+
+ vendor.id		usb 0x1e71
+&device.id		usb 0x1714
++device.name		Smart Device
+
+ vendor.id		usb 0x1e71
+&device.id		usb 0x1715
++device.name		Kraken M22
+
+ vendor.id		usb 0x1e71
+&device.id		usb 0x2006
++device.name		Smart Device V2
 
  vendor.id		usb 0x1e74
 +vendor.name		Coby Electronics Corporation
@@ -72605,6 +79046,21 @@
 &device.id		usb 0x7111
 +device.name		MP957 Music and Video Player
 
+ vendor.id		usb 0x1e7b
++vendor.name		Zurich Instruments
+
+ vendor.id		usb 0x1e7b
+&device.id		usb 0x0002
++device.name		HF2
+
+ vendor.id		usb 0x1e7b
+&device.id		usb 0x0003
++device.name		UHF
+
+ vendor.id		usb 0x1e7b
+&device.id		usb 0x0004
++device.name		MFLI
+
  vendor.id		usb 0x1e7d
 +vendor.name		ROCCAT
 
@@ -72613,8 +79069,28 @@
 +device.name		Pyra Mouse (wired)
 
  vendor.id		usb 0x1e7d
+&device.id		usb 0x2c2e
++device.name		Lua Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2c38
++device.name		Kiro Mouse
+
+ vendor.id		usb 0x1e7d
 &device.id		usb 0x2ced
 +device.name		Kone Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2cee
++device.name		Kova 2016 Gray Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2cef
++device.name		Kova 2016 White Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2cf0
++device.name		Kova 2016 Black Mouse
 
  vendor.id		usb 0x1e7d
 &device.id		usb 0x2cf6
@@ -72622,33 +79098,414 @@
 
  vendor.id		usb 0x1e7d
 &device.id		usb 0x2d50
-+device.name		Kova+ Mouse
++device.name		Kova[+] Mouse
 
  vendor.id		usb 0x1e7d
 &device.id		usb 0x2d51
-+device.name		Kone+ Mouse
++device.name		Kone[+] Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2d5a
++device.name		Savu Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2db4
++device.name		Kone Pure Optical Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2dbe
++device.name		Kone Pure Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2dbf
++device.name		Kone Pure Military Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2dc2
++device.name		Kone Pure Optical Black Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2dcb
++device.name		Kone Pure SE(L) Mouse
 
  vendor.id		usb 0x1e7d
 &device.id		usb 0x2e22
 +device.name		Kone XTD Mouse
 
  vendor.id		usb 0x1e7d
+&device.id		usb 0x2e23
++device.name		Kone XTD Optical Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2e27
++device.name		Kone AIMO Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2e4a
++device.name		Tyon Black Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2e4b
++device.name		Tyon White Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2e7c
++device.name		Nyth Black Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2e7d
++device.name		Nyth White Mouse
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2f76
++device.name		Sova Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2f94
++device.name		Sova MK Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2fa8
++device.name		Suora Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2fc6
++device.name		Skeltr Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x2fda
++device.name		Ryos MK FX Keyboard
+
+ vendor.id		usb 0x1e7d
 &device.id		usb 0x30d4
 +device.name		Arvo Keyboard
 
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x3138
++device.name		Ryos MK Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x316a
++device.name		Ryos TKL Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x319c
++device.name		Isku Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x31ce
++device.name		Ryos MK Glow Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x3232
++device.name		Ryos MK Pro Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x3246
++device.name		Suora FX Keyboard
+
+ vendor.id		usb 0x1e7d
+&device.id		usb 0x3264
++device.name		Isku FX Keyboard
+
+ vendor.id		usb 0x1e8e
++vendor.name		Airbus Defence and Space
+
+ vendor.id		usb 0x1e8e
+&device.id		usb 0x6001
++device.name		P8GR
+
+ vendor.id		usb 0x1e91
++vendor.name		Other World Computing
+
+ vendor.id		usb 0x1e91
+&device.id		usb 0xb0b1
++device.name		miniStack
+
  vendor.id		usb 0x1ea7
 +vendor.name		SHARKOON Technologies GmbH
+
+ vendor.id		usb 0x1ea7
+&device.id		usb 0x0030
++device.name		Trust GXT 158 Orna Laser Gaming Mouse
+
+ vendor.id		usb 0x1ea7
+&device.id		usb 0x0064
++device.name		2.4GHz Wireless rechargeable vertical mouse [More&Better]
 
  vendor.id		usb 0x1ea7
 &device.id		usb 0x0066
 +device.name		[Mediatrack Edge Mini Keyboard]
 
  vendor.id		usb 0x1ea7
+&device.id		usb 0x0907
++device.name		Keyboard
+
+ vendor.id		usb 0x1ea7
+&device.id		usb 0x1002
++device.name		Vintorez Gaming Mouse
+
+ vendor.id		usb 0x1ea7
 &device.id		usb 0x2007
 +device.name		SHARK ZONE K30 Illuminated Gaming Keyboard
 
+ vendor.id		usb 0x1eab
++vendor.name		Fujian Newland Computer Co., Ltd
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0103
++device.name		HR200 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0106
++device.name		HR200 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0110
++device.name		HR200 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0c03
++device.name		HR100/HR3260 cordless/HR3290 cordless/BS80 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0c06
++device.name		HR100/HR3260 cordless/HR3290 cordless/BS80 Barcode scanner engine (USB Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0c10
++device.name		HR100/HR3260 cordless/HR3290 cordless/BS80 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0d03
++device.name		EM2028 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0d06
++device.name		EM2028 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x0d10
++device.name		EM2028 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1303
++device.name		EM30xx/EM20xx/HR3260 corded/HR200C Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1306
++device.name		EM30xx/EM20xx/HR3260 corded/HR200C Barcode scanner engine (USB serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1310
++device.name		EM30xx/EM20xx/HR3260 corded/HR200C Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1403
++device.name		HR15-xx Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1406
++device.name		HR15-xx Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1410
++device.name		HR15-xx Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1603
++device.name		FM100-M/3250 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1606
++device.name		FM100-M/3250 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1610
++device.name		FM100-M/3250 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1903
++device.name		EM1300 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1906
++device.name		EM1300 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1910
++device.name		EM1300 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1a03
++device.name		HR3290 corded/HR22 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1a06
++device.name		HR3290 corded/HR22 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1a10
++device.name		HR3290 corded/HR22 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1c03
++device.name		HR2150 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1c06
++device.name		HR2150 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1c10
++device.name		HR2150 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1d03
++device.name		FM430 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1d06
++device.name		FM430 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1d10
++device.name		FM430 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1e03
++device.name		HR42 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1e06
++device.name		HR42 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1e10
++device.name		HR42 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1f03
++device.name		HR11+ Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1f06
++device.name		HR11+ Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x1f10
++device.name		HR11+ Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x2003
++device.name		EM2037v2 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x2006
++device.name		EM2037v2 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x2010
++device.name		EM2037v2 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8003
++device.name		EM13x5-LD/HR15-70/HR100-70/HR12/HR1150-70 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8006
++device.name		EM13x5-LD/HR15-70/HR100-70/HR12/HR1150-70 Barcode scanner engine (USB Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8010
++device.name		EM13x5-LD/HR15-70/HR100-70/HR12/HR1150-70 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8203
++device.name		EM3080-01/EM3095/FR20/FM30 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8206
++device.name		EM3080-01/EM3095/FR20/FM30 Barcode scanner engine (USB Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8210
++device.name		EM3080-01/EM3095/FR20/FM30 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8303
++device.name		HR2160 Barcode scanner engine (HID keyboard)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8306
++device.name		HR2160 Barcode scanner engine (Serial CDC)
+
+ vendor.id		usb 0x1eab
+&device.id		usb 0x8310
++device.name		HR2160 Barcode scanner engine (HID Pos)
+
+ vendor.id		usb 0x1eaf
++vendor.name		Leaflabs
+
+ vendor.id		usb 0x1eaf
+&device.id		usb 0x0003
++device.name		Maple DFU interface
+
+ vendor.id		usb 0x1eaf
+&device.id		usb 0x0004
++device.name		Maple serial interface
+
+ vendor.id		usb 0x1eb8
++vendor.name		Modacom Co., Ltd.
+
+ vendor.id		usb 0x1eb8
+&device.id		usb 0x7f00
++device.name		MW-U3500 WiMAX adapter
+
  vendor.id		usb 0x1ebb
 +vendor.name		NuCORE Technology, Inc.
+
+ vendor.id		usb 0x1ecb
++vendor.name		AMTelecom
+
+ vendor.id		usb 0x1ecb
+&device.id		usb 0x02e2
++device.name		JMR1140 [Jiofi]
+
+ vendor.id		usb 0x1ed8
++vendor.name		FENDER MUSICAL INSTRUMENTS CORPORATION
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0004
++device.name		Mustang I/II
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0005
++device.name		Mustang III/IV/V
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0006
++device.name		Mustang I/II [Firmware Update]
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0007
++device.name		Mustang III/IV/V [Firmware Update]
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0010
++device.name		Mustang Mini
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0011
++device.name		Mustang Mini [Firmware Update]
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0014
++device.name		Mustang I (V.2)
+
+ vendor.id		usb 0x1ed8
+&device.id		usb 0x0016
++device.name		Mustang IV v.2
 
  vendor.id		usb 0x1eda
 +vendor.name		AirTies Wireless Networks
@@ -72675,6 +79532,14 @@
  vendor.id		usb 0x1edb
 &device.id		usb 0xbd3b
 +device.name		Intensity Shuttle
+
+ vendor.id		usb 0x1edb
+&device.id		usb 0xbd46
++device.name		Mini Converter Analog to SDI
+
+ vendor.id		usb 0x1edb
+&device.id		usb 0xbd75
++device.name		2.5K Cinema Camera (BMCC)
 
  vendor.id		usb 0x1ee8
 +vendor.name		ONDA COMMUNICATION S.p.a.
@@ -72710,6 +79575,13 @@
 &device.id		usb 0x564a
 +device.name		Cassidian RIU CSMU/BSD Simulator
 
+ vendor.id		usb 0x1f0c
++vendor.name		CMX Systems
+
+ vendor.id		usb 0x1f0c
+&device.id		usb 0x2000
++device.name		HP StreamSmart 410 [NW278AA]
+
  vendor.id		usb 0x1f28
 +vendor.name		Cal-Comp
 
@@ -72722,11 +79594,23 @@
 +device.name		CD INSTALLER USB Device
 
  vendor.id		usb 0x1f3a
-+vendor.name		Onda (unverified)
++vendor.name		Allwinner Technology
+
+ vendor.id		usb 0x1f3a
+&device.id		usb 0x1000
++device.name		Prestigio PER3464B ebook reader (Mass storage mode)
+
+ vendor.id		usb 0x1f3a
+&device.id		usb 0x1002
++device.name		mediacom XPRO 415
+
+ vendor.id		usb 0x1f3a
+&device.id		usb 0x1010
++device.name		Android device in fastboot mode
 
  vendor.id		usb 0x1f3a
 &device.id		usb 0xefe8
-+device.name		V972 tablet in flashing mode
++device.name		sunxi SoC OTG connector in FEL/flashing mode
 
  vendor.id		usb 0x1f44
 +vendor.name		The Neat Company
@@ -72750,12 +79634,39 @@
 +vendor.name		G-Tek Electronics Group
 
  vendor.id		usb 0x1f4d
+&device.id		usb 0xa115
++device.name		EVOLVEO XtraTV stick [DVB-T]
+
+ vendor.id		usb 0x1f4d
 &device.id		usb 0xb803
 +device.name		Lifeview LV5TDLX DVB-T [RTL2832U]
 
  vendor.id		usb 0x1f4d
+&device.id		usb 0xc803
++device.name		NotOnlyTV (Lifeview) LV5TDLX DVB-T [RTL2832U]
+
+ vendor.id		usb 0x1f4d
 &device.id		usb 0xd220
 +device.name		Geniatech T220 DVB-T2 TV Stick
+
+ vendor.id		usb 0x1f52
++vendor.name		Systems & Electronic Development FZCO (SEDCO)
+
+ vendor.id		usb 0x1f52
+&device.id		usb 0x0001
++device.name		Ultima 49 Printer
+
+ vendor.id		usb 0x1f52
+&device.id		usb 0x0002
++device.name		Ultima 90 Printer
+
+ vendor.id		usb 0x1f52
+&device.id		usb 0x0003
++device.name		FormsPro 50 Printer
+
+ vendor.id		usb 0x1f52
+&device.id		usb 0x0004
++device.name		Ultima 90+ Printer
 
  vendor.id		usb 0x1f6f
 +vendor.name		Aliph
@@ -72772,12 +79683,32 @@
 +vendor.name		Innostor Technology Corporation
 
  vendor.id		usb 0x1f75
+&device.id		usb 0x0611
++device.name		IS611 SATA/PATA Bridge Controller
+
+ vendor.id		usb 0x1f75
+&device.id		usb 0x0621
++device.name		IS621 SATA Storage Controller
+
+ vendor.id		usb 0x1f75
 &device.id		usb 0x0888
 +device.name		IS888 SATA Storage Controller
 
  vendor.id		usb 0x1f75
 &device.id		usb 0x0902
 +device.name		IS902 UFD controller
+
+ vendor.id		usb 0x1f75
+&device.id		usb 0x0916
++device.name		IS916 Flash Drive
+
+ vendor.id		usb 0x1f75
+&device.id		usb 0x0917
++device.name		IS917 Mass storage
+
+ vendor.id		usb 0x1f75
+&device.id		usb 0x0918
++device.name		IS918 Flash Drive
 
  vendor.id		usb 0x1f82
 +vendor.name		TANDBERG
@@ -72788,6 +79719,10 @@
 
  vendor.id		usb 0x1f84
 +vendor.name		Alere, Inc.
+
+ vendor.id		usb 0x1f84
+&device.id		usb 0x1f7e
++device.name		Lateral Flow Engine
 
  vendor.id		usb 0x1f87
 +vendor.name		Stantum
@@ -72803,12 +79738,44 @@
 &device.id		usb 0x0241
 +device.name		AirView2-EXT
 
+ vendor.id		usb 0x1f9b
+&device.id		usb 0xb0b1
++device.name		UniFi VoIP Phone
+
  vendor.id		usb 0x1fab
 +vendor.name		Samsung Opto-Electroncs Co., Ltd.
 
  vendor.id		usb 0x1fab
 &device.id		usb 0x104d
 +device.name		ES65
+
+ vendor.id		usb 0x1fac
++vendor.name		Franklin Wireless
+
+ vendor.id		usb 0x1fac
+&device.id		usb 0x0232
++device.name		U770 3G/4G Wimax/4G LTE Modem
+
+ vendor.id		usb 0x1fae
++vendor.name		Lumidigm
+
+ vendor.id		usb 0x1fae
+&device.id		usb 0x0040
++device.name		M311 Fingerprint Scanner
+
+ vendor.id		usb 0x1fae
+&device.id		usb 0x212c
++device.name		M30x (Mercury) fingerprint sensor
+
+ vendor.id		usb 0x1fb2
++vendor.name		Withings
+
+ vendor.id		usb 0x1fb2
+&device.id		usb 0x0001
++device.name		Wi-Fi Body Scale (WBS01)
+
+ vendor.id		usb 0x1fba
++vendor.name		DERMALOG Identification Systems GmbH
 
  vendor.id		usb 0x1fbd
 +vendor.name		Delphin Technology AG
@@ -72825,12 +79792,36 @@
 +device.name		LPC1343
 
  vendor.id		usb 0x1fc9
+&device.id		usb 0x000c
++device.name		LPC4330FET180 [ARM Cortex M4 + M0] (device firmware upgrade mode)
+
+ vendor.id		usb 0x1fc9
+&device.id		usb 0x0082
++device.name		LPC4330FET180 [ARM Cortex M4 + M0] (mass storage controller mode)
+
+ vendor.id		usb 0x1fc9
 &device.id		usb 0x010b
 +device.name		PR533
 
  vendor.id		usb 0x1fc9
+&device.id		usb 0x0126
++device.name		i.MX 7ULP SystemOnChip in RecoveryMode
+
+ vendor.id		usb 0x1fc9
 &device.id		usb 0x012b
 +device.name		i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
+
+ vendor.id		usb 0x1fc9
+&device.id		usb 0x5002
++device.name		PTN5002 [Startech VGA/DVI-D adapter]
+
+ vendor.id		usb 0x1fc9
+&device.id		usb 0x8124
++device.name		SharkRF Bootloader
+
+ vendor.id		usb 0x1fc9
+&device.id		usb 0x824c
++device.name		LumiNode1
 
  vendor.id		usb 0x1fde
 +vendor.name		ILX Lightwave Corporation
@@ -72857,8 +79848,46 @@
 &device.id		usb 0x001a
 +device.name		Human Interface Device
 
+ vendor.id		usb 0x1ffb
++vendor.name		Pololu Corporation
+
+ vendor.id		usb 0x1ffb
+&device.id		usb 0x0081
++device.name		AVR Programmer
+
+ vendor.id		usb 0x1ffb
+&device.id		usb 0x0083
++device.name		Jrk 21v3 Motor Controller
+
+ vendor.id		usb 0x1ffb
+&device.id		usb 0x0089
++device.name		Micro Maestro 6-Servo Controller
+
+ vendor.id		usb 0x1ffb
+&device.id		usb 0x008a
++device.name		Mini Maestro 12-Channel Servo Controller
+
+ vendor.id		usb 0x1ffb
+&device.id		usb 0x008b
++device.name		Mini Maestro 18-Channel Servo Controller
+
+ vendor.id		usb 0x1ffb
+&device.id		usb 0x008c
++device.name		Mini Maestro 24-Channel Servo Controller
+
+ vendor.id		usb 0x1ffb
+&device.id		usb 0x00b0
++device.name		AVR Programmer v2
+
  vendor.id		usb 0x1fff
 +vendor.name		Ideofy Inc.
+
+ vendor.id		usb 0x2000
++vendor.name		CMX Systems
+
+ vendor.id		usb 0x2000
+&device.id		usb 0x1f0c
++device.name		HP StreamSmart 410 [NW278AA]
 
  vendor.id		usb 0x2001
 +vendor.name		D-Link Corp.
@@ -72884,6 +79913,10 @@
 +device.name		10/100 Ethernet
 
  vendor.id		usb 0x2001
+&device.id		usb 0x3101
++device.name		DWA-182 AC1200 DB Wireless Adapter(rev.A1) [Broadcom BCM43526]
+
+ vendor.id		usb 0x2001
 &device.id		usb 0x3200
 +device.name		DWL-120 802.11b Wireless Adapter(rev.E1) [Atmel at76c503a]
 
@@ -72906,6 +79939,34 @@
  vendor.id		usb 0x2001
 &device.id		usb 0x330a
 +device.name		DWA-133 802.11n Wireless N Adapter [Realtek RTL8192CU]
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x330d
++device.name		DWA-131 802.11n Wireless N Nano Adapter (rev.B1) [Realtek RTL8192CU]
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x330f
++device.name		DWA-125 Wireless N 150 Adapter(rev.D1) [Realtek RTL8188ETV]
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x3310
++device.name		DWA-123 Wireless N 150 Adapter (rev.D1)
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x3314
++device.name		DWA-171 AC600 DB Wireless Adapter(rev.A1) [Realtek RTL8811AU]
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x3315
++device.name		DWA-182 Wireless AC Dualband Adapter(rev.C) [Realtek RTL8812AU]
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x3317
++device.name		DWA-137 Wireless N High-Gain Adapter [Ralink RT5372]
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x3319
++device.name		DWA-131 Wireless N Nano Adapter (Rev. E1) [Realtek RTL8192EU]
 
  vendor.id		usb 0x2001
 &device.id		usb 0x3500
@@ -73024,6 +80085,10 @@
 +device.name		DWA-127 Wireless N 150 High-Gain Adapter(rev.A1) [Ralink RT3070]
 
  vendor.id		usb 0x2001
+&device.id		usb 0x3c1e
++device.name		DWA-125 Wireless N 150 Adapter(rev.B1) [Ralink RT5370]
+
+ vendor.id		usb 0x2001
 &device.id		usb 0x4000
 +device.name		DSB-650C Ethernet [klsi]
 
@@ -73046,6 +80111,10 @@
  vendor.id		usb 0x2001
 &device.id		usb 0x4102
 +device.name		10/100 Ethernet
+
+ vendor.id		usb 0x2001
+&device.id		usb 0x4a00
++device.name		DUB-1312 Gigabit Ethernet Adapter
 
  vendor.id		usb 0x2001
 &device.id		usb 0x5100
@@ -73117,6 +80186,24 @@
 &device.id		usb 0xea61
 +device.name		dc3500
 
+ vendor.id		usb 0x2006
++vendor.name		LenovoMobile
+
+ vendor.id		usb 0x2009
++vendor.name		iStorage
+
+ vendor.id		usb 0x2009
+&device.id		usb 0x5004
++device.name		datAshur 4GB
+
+ vendor.id		usb 0x2009
+&device.id		usb 0x5016
++device.name		datAshur 16GB
+
+ vendor.id		usb 0x2009
+&device.id		usb 0x5032
++device.name		datAshur 32GB
+
  vendor.id		usb 0x200c
 +vendor.name		Reloop
 
@@ -73126,6 +80213,10 @@
 
  vendor.id		usb 0x2013
 +vendor.name		PCTV Systems
+
+ vendor.id		usb 0x2013
+&device.id		usb 0x0242
++device.name		QuatroStick 510e
 
  vendor.id		usb 0x2013
 &device.id		usb 0x0245
@@ -73140,8 +80231,43 @@
 +device.name		PCTV 282E
 
  vendor.id		usb 0x2013
+&device.id		usb 0x024c
++device.name		DVB-S2 Stick 460e
+
+ vendor.id		usb 0x2013
 &device.id		usb 0x024f
 +device.name		nanoStick T2 290e
+
+ vendor.id		usb 0x2013
+&device.id		usb 0x0251
++device.name		QuatroStick nano 520e
+
+ vendor.id		usb 0x2013
+&device.id		usb 0x0258
++device.name		DVB-S2 Stick 461e
+
+ vendor.id		usb 0x2013
+&device.id		usb 0x025a
++device.name		AndroiDTV 78e
+
+ vendor.id		usb 0x2013
+&device.id		usb 0x025f
++device.name		tripleStick 292e
+
+ vendor.id		usb 0x2013
+&device.id		usb 0x0262
++device.name		microStick 79e
+
+ vendor.id		usb 0x2018
++vendor.name		Deutsche Telekom AG
+
+ vendor.id		usb 0x2018
+&device.id		usb 0x0406
++device.name		Eumex 800
+
+ vendor.id		usb 0x2018
+&device.id		usb 0x0408
++device.name		Eumex 800
 
  vendor.id		usb 0x2019
 +vendor.name		PLANEX
@@ -73242,6 +80368,16 @@
 &device.id		usb 0xed18
 +device.name		GW-USHyper300 / GW-USH300N 802.11bgn Wireless Adapter [Realtek RTL8191SU]
 
+ vendor.id		usb 0x201e
++vendor.name		Haier
+
+ vendor.id		usb 0x201e
+&device.id		usb 0x2009
++device.name		CE100 CDMA EVDO
+
+ vendor.id		usb 0x203a
++vendor.name		PARALLELS
+
  vendor.id		usb 0x203d
 +vendor.name		Encore Electronics Inc.
 
@@ -73253,12 +80389,24 @@
 +vendor.name		Hauppauge
 
  vendor.id		usb 0x2040
+&device.id		usb 0x0265
++device.name		WinTV-dualHD DVB
+
+ vendor.id		usb 0x2040
+&device.id		usb 0x026d
++device.name		WinTV-dualHD ATSC
+
+ vendor.id		usb 0x2040
 &device.id		usb 0x0c80
 +device.name		Windham
 
  vendor.id		usb 0x2040
 &device.id		usb 0x0c90
 +device.name		Windham
+
+ vendor.id		usb 0x2040
+&device.id		usb 0x1605
++device.name		WinTV-HVR 930C HD
 
  vendor.id		usb 0x2040
 &device.id		usb 0x1700
@@ -73299,6 +80447,10 @@
  vendor.id		usb 0x2040
 &device.id		usb 0x2400
 +device.name		WinTV PVR USB2 (Model 24019)
+
+ vendor.id		usb 0x2040
+&device.id		usb 0x4200
++device.name		WinTV
 
  vendor.id		usb 0x2040
 &device.id		usb 0x4700
@@ -73354,7 +80506,11 @@
 
  vendor.id		usb 0x2040
 &device.id		usb 0x6513
-+device.name		WinTV HVR-980
++device.name		WinTV HVR-950/HVR-980
+
+ vendor.id		usb 0x2040
+&device.id		usb 0x6600
++device.name		WinTV HVR-900H (Model 660xx)
 
  vendor.id		usb 0x2040
 &device.id		usb 0x7050
@@ -73393,6 +80549,14 @@
 +device.name		WinTV Nova-T-500
 
  vendor.id		usb 0x2040
+&device.id		usb 0xb123
++device.name		WinTV-HVR-955Q
+
+ vendor.id		usb 0x2040
+&device.id		usb 0xb138
++device.name		WinTV-HVR-900 model 00246 [WinTV-T Video]
+
+ vendor.id		usb 0x2040
 &device.id		usb 0xb910
 +device.name		Windham
 
@@ -73416,16 +80580,232 @@
 +vendor.name		Texas Instruments
 
  vendor.id		usb 0x2047
+&device.id		usb 0x0013
++device.name		MSP eZ-FET lite
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0014
++device.name		MSP-FET
+
+ vendor.id		usb 0x2047
 &device.id		usb 0x0200
-+device.name		MSP430 USB HID Bootstrap Loader
++device.name		MSP430 Bootloader
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0203
++device.name		eZ-FET Bootloader
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0204
++device.name		MSP-FET Bootloader
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0300
++device.name		MSP430 CDC Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0301
++device.name		MSP430 HID Datapipe Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0302
++device.name		MSP430 CDC+HID Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0309
++device.name		MSP430 HID Mouse Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0313
++device.name		MSP430 CDC+CDC Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0314
++device.name		MSP430 HID+HID Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0315
++device.name		MSP430 HID Keyboard Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0316
++device.name		MSP430 MSC File System Emulation Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0317
++device.name		MSP430 MSC SD Card Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0318
++device.name		MSP430 MSC Multiple LUNs Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0319
++device.name		MSP430 MSC+CDC+HID Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0320
++device.name		MSP430 SYSBIOS Tasks MSC+CDC+HID Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0321
++device.name		MSP430 SYSBIOS SWIs MSC+CDC+HID Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0322
++device.name		MSP430 MSC Double-Buffering Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0323
++device.name		MSP430 MSC CD-ROM Example
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03df
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e0
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e1
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e2
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e3
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e4
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e5
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e6
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e7
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e8
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03e9
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03ea
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03eb
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03ec
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03ed
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03ee
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03ef
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f0
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f1
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f2
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f3
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f4
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f5
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f6
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f7
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f8
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03f9
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03fa
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03fb
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03fc
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x03fd
++device.name		MSP430 User Experiment
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0401
++device.name		MSP430 Keyboard Example
 
  vendor.id		usb 0x2047
 &device.id		usb 0x0855
 +device.name		Invensense Embedded MotionApp HID Sensor
 
  vendor.id		usb 0x2047
+&device.id		usb 0x08f8
++device.name		FDC2x14/LDC13xx/LDC16xx EVM
+
+ vendor.id		usb 0x2047
 &device.id		usb 0x0964
 +device.name		Inventio Software MSP430
+
+ vendor.id		usb 0x2047
+&device.id		usb 0x0a76
++device.name		GEOKON S-3810A-5 USB-RS485 CONVERTER
+
+ vendor.id		usb 0x2047
+&device.id		usb 0xffe7
++device.name		HID v1.00 Device [Improv Device]
 
  vendor.id		usb 0x2058
 +vendor.name		Nano River Technology
@@ -73460,6 +80840,30 @@
 &device.id		usb 0x0004
 +device.name		NOOK Tablet
 
+ vendor.id		usb 0x2080
+&device.id		usb 0x0005
++device.name		BNTV600 [Nook HD+]
+
+ vendor.id		usb 0x2080
+&device.id		usb 0x0006
++device.name		BNTV400 [Nook HD]
+
+ vendor.id		usb 0x2080
+&device.id		usb 0x0007
++device.name		BNRV500 [Nook Glowlight]
+
+ vendor.id		usb 0x2080
+&device.id		usb 0x000a
++device.name		BNRV510 [Nook Glowlight Plus]
+
+ vendor.id		usb 0x2080
+&device.id		usb 0x000b
++device.name		BNRV520 [Nook Glowlight 3]
+
+ vendor.id		usb 0x2080
+&device.id		usb 0x000c
++device.name		BNRV700 [Nook Glowlight Plus]
+
  vendor.id		usb 0x2086
 +vendor.name		SIMPASS
 
@@ -73482,6 +80886,14 @@
 +vendor.name		Clay Logic
 
  vendor.id		usb 0x20a0
+&device.id		usb 0x0006
++device.name		flirc
+
+ vendor.id		usb 0x20a0
+&device.id		usb 0x4107
++device.name		GPF Crypto Stick V1.2
+
+ vendor.id		usb 0x20a0
 &device.id		usb 0x4123
 +device.name		IKALOGIC SCANALOGIC 2
 
@@ -73500,6 +80912,22 @@
  vendor.id		usb 0x20a0
 &device.id		usb 0x415c
 +device.name		PipXtreme
+
+ vendor.id		usb 0x20a0
+&device.id		usb 0x41e5
++device.name		BlinkStick
+
+ vendor.id		usb 0x20a0
+&device.id		usb 0x4211
++device.name		Nitrokey Start
+
+ vendor.id		usb 0x20a0
+&device.id		usb 0x4223
++device.name		ATSAMD21 [castAR]
+
+ vendor.id		usb 0x20a0
+&device.id		usb 0x428d
++device.name		Electrosense wideband converter
 
  vendor.id		usb 0x20b1
 +vendor.name		XMOS Ltd
@@ -73539,12 +80967,23 @@
 +device.name		IDBG in normal mode
 
  vendor.id		usb 0x20b7
+&device.id		usb 0x9db1
++device.name		Glasgow Debug Tool
+
+ vendor.id		usb 0x20b7
 &device.id		usb 0xc25b
 +device.name		C2 Dongle
 
  vendor.id		usb 0x20b7
 &device.id		usb 0xcb72
 +device.name		ben-wpan, cntr
+
+ vendor.id		usb 0x20bc
++vendor.name		ShenZhen ShanWan Technology Co., Ltd.
+
+ vendor.id		usb 0x20bc
+&device.id		usb 0x5500
++device.name		Frostbite controller
 
  vendor.id		usb 0x20ce
 +vendor.name		Minicircuits
@@ -73568,6 +81007,13 @@
 &device.id		usb 0x0001
 +device.name		Entropy Key [UDEKEY01]
 
+ vendor.id		usb 0x20f0
++vendor.name		L3Harris Technologies
+
+ vendor.id		usb 0x20f0
+&device.id		usb 0x2102
++device.name		EWLA V2 Module
+
  vendor.id		usb 0x20f1
 +vendor.name		NET New Electronic Technology GmbH
 
@@ -73579,8 +81025,28 @@
 +vendor.name		TRENDnet
 
  vendor.id		usb 0x20f4
+&device.id		usb 0x646b
++device.name		TEW-646UBH High Power 150Mbps Wireless N Adapter [Realtek RTL8188SU]
+
+ vendor.id		usb 0x20f4
 &device.id		usb 0x648b
 +device.name		TEW-648UBM 802.11n 150Mbps Micro Wireless N Adapter [Realtek RTL8188CUS]
+
+ vendor.id		usb 0x20f4
+&device.id		usb 0x664b
++device.name		TEW-664UB H/W:V2.0R
+
+ vendor.id		usb 0x20f4
+&device.id		usb 0x804b
++device.name		TEW-804UB 802.11a/b/g/n/ac (1x1) Wireless Adapter [Realtek RTL8811AU]
+
+ vendor.id		usb 0x20f4
+&device.id		usb 0x805b
++device.name		TEW-805UB 300Mbps+867Mbps Wireless AC Adapter [Realtek RTL8812AU]
+
+ vendor.id		usb 0x20f4
+&device.id		usb 0x806b
++device.name		TEW-806UBH 802.11a/b/g/n/ac (1x1) Wireless Adapter [MediaTek MT7610U]
 
  vendor.id		usb 0x20f7
 +vendor.name		XIMEA
@@ -73609,6 +81075,14 @@
 +vendor.name		RT Systems
 
  vendor.id		usb 0x2100
+&device.id		usb 0x0e56
++device.name		USB62C Radio Cable [Yaesu 857/D - 897/D]
+
+ vendor.id		usb 0x2100
+&device.id		usb 0x9e50
++device.name		USB-59 Radio Cable [Yaesu VX-8/D/DR]
+
+ vendor.id		usb 0x2100
 &device.id		usb 0x9e52
 +device.name		Yaesu VX-7
 
@@ -73619,6 +81093,10 @@
  vendor.id		usb 0x2100
 &device.id		usb 0x9e57
 +device.name		RTS01 Radio Cable
+
+ vendor.id		usb 0x2100
+&device.id		usb 0x9e58
++device.name		USB63C Radio Cable [Yaesu FTDX-1200]
 
  vendor.id		usb 0x2100
 &device.id		usb 0x9e5d
@@ -73635,8 +81113,30 @@
 &device.id		usb 0x0201
 +device.name		SIIG 4-to-2 Printer Switch
 
+ vendor.id		usb 0x2101
+&device.id		usb 0x1402
++device.name		Keyboard/Mouse Switch
+
+ vendor.id		usb 0x2104
++vendor.name		Tobii Technology AB
+
+ vendor.id		usb 0x2104
+&device.id		usb 0x0050
++device.name		Eye tracker [EYEX2]
+
+ vendor.id		usb 0x2104
+&device.id		usb 0x0124
++device.name		Eyechip
+
+ vendor.id		usb 0x2107
++vendor.name		RDING TECH CO.,LTD
+
  vendor.id		usb 0x2109
 +vendor.name		VIA Labs, Inc.
+
+ vendor.id		usb 0x2109
+&device.id		usb 0x0210
++device.name		Hub
 
  vendor.id		usb 0x2109
 &device.id		usb 0x0700
@@ -73645,6 +81145,14 @@
  vendor.id		usb 0x2109
 &device.id		usb 0x0701
 +device.name		VL701 SATA 3Gb/s bridge
+
+ vendor.id		usb 0x2109
+&device.id		usb 0x0711
++device.name		VL711 SATA 6Gb/s bridge
+
+ vendor.id		usb 0x2109
+&device.id		usb 0x0715
++device.name		VL817 SATA Adaptor
 
  vendor.id		usb 0x2109
 &device.id		usb 0x0810
@@ -73659,6 +81167,18 @@
 +device.name		VL812 Hub
 
  vendor.id		usb 0x2109
+&device.id		usb 0x0813
++device.name		VL813 Hub
+
+ vendor.id		usb 0x2109
+&device.id		usb 0x0820
++device.name		VL820 Hub
+
+ vendor.id		usb 0x2109
+&device.id		usb 0x2210
++device.name		Hub
+
+ vendor.id		usb 0x2109
 &device.id		usb 0x2811
 +device.name		Hub
 
@@ -73667,8 +81187,20 @@
 +device.name		VL812 Hub
 
  vendor.id		usb 0x2109
+&device.id		usb 0x2813
++device.name		VL813 Hub
+
+ vendor.id		usb 0x2109
+&device.id		usb 0x2820
++device.name		VL820 Hub
+
+ vendor.id		usb 0x2109
 &device.id		usb 0x3431
 +device.name		Hub
+
+ vendor.id		usb 0x2109
+&device.id		usb 0x711f
++device.name		External
 
  vendor.id		usb 0x2109
 &device.id		usb 0x8110
@@ -73689,6 +81221,61 @@
 &device.id		usb 0x8000
 +device.name		DepthSense 311 (Color)
 
+ vendor.id		usb 0x2116
++vendor.name		KT Tech
+
+ vendor.id		usb 0x2116
+&device.id		usb 0x000a
++device.name		IDE Hard Drive Enclosure
+
+ vendor.id		usb 0x211f
++vendor.name		CELOT Corporation
+
+ vendor.id		usb 0x211f
+&device.id		usb 0x6801
++device.name		CDMA Products
+
+ vendor.id		usb 0x2123
++vendor.name		Cheeky Dream
+
+ vendor.id		usb 0x2123
+&device.id		usb 0x1010
++device.name		Rocket Launcher
+
+ vendor.id		usb 0x2125
++vendor.name		Fiberpro Inc.
+
+ vendor.id		usb 0x2125
+&device.id		usb 0x0000
++device.name		Bootloader
+
+ vendor.id		usb 0x2125
+&device.id		usb 0x0010
++device.name		MCB-100 Series
+
+ vendor.id		usb 0x2133
++vendor.name		signotec GmbH
+
+ vendor.id		usb 0x2133
+&device.id		usb 0x0001
++device.name		LCD Signature Pad Sigma
+
+ vendor.id		usb 0x2133
+&device.id		usb 0x0018
++device.name		Delta Pen
+
+ vendor.id		usb 0x2133
+&device.id		usb 0x0019
++device.name		Delta Touch
+
+ vendor.id		usb 0x2133
+&device.id		usb 0x001c
++device.name		Kronos Pen
+
+ vendor.id		usb 0x2133
+&device.id		usb 0x0022
++device.name		Epsilon Pen
+
  vendor.id		usb 0x2149
 +vendor.name		Advanced Silicon S.A.
 
@@ -73697,11 +81284,29 @@
 +device.name		Touchscreen Controller
 
  vendor.id		usb 0x2149
+&device.id		usb 0x2306
++device.name		TS58xxA/TC56xxA [CoolTouch]
+
+ vendor.id		usb 0x2149
 &device.id		usb 0x2703
 +device.name		TS58xxA/TC56xxA [CoolTouch]
 
+ vendor.id		usb 0x214b
++vendor.name		Huasheng Electronics
+
+ vendor.id		usb 0x214b
+&device.id		usb 0x7000
++device.name		4-port hub [Maxxter ACT-HUB2-4P, HS8836, iSoul ultra-slim]
+
+ vendor.id		usb 0x214e
++vendor.name		Swiftpoint
+
+ vendor.id		usb 0x214e
+&device.id		usb 0x0005
++device.name		Z - Gaming mouse [SM700]
+
  vendor.id		usb 0x2162
-+vendor.name		Creative (?)
++vendor.name		Broadxent (Creative Labs)
 
  vendor.id		usb 0x2162
 &device.id		usb 0x2031
@@ -73714,6 +81319,13 @@
  vendor.id		usb 0x2162
 &device.id		usb 0x8001
 +device.name		Broadxent BritePort DSL Bridge 8010U
+
+ vendor.id		usb 0x2166
++vendor.name		JVC Kenwood
+
+ vendor.id		usb 0x2166
+&device.id		usb 0x600b
++device.name		TH-D74
 
  vendor.id		usb 0x2184
 +vendor.name		GW Instek
@@ -73730,12 +81342,114 @@
 &device.id		usb 0x0011
 +device.name		AFG Function Generator (CDC)
 
+ vendor.id		usb 0x2184
+&device.id		usb 0x0017
++device.name		DSO
+
+ vendor.id		usb 0x2184
+&device.id		usb 0x0018
++device.name		DSO
+
+ vendor.id		usb 0x2184
+&device.id		usb 0x0036
++device.name		AFG-125 Function Generator (CDC)
+
+ vendor.id		usb 0x2188
++vendor.name		No brand
+
+ vendor.id		usb 0x2188
+&device.id		usb 0x0610
++device.name		Hub
+
+ vendor.id		usb 0x2188
+&device.id		usb 0x0611
++device.name		Hub
+
+ vendor.id		usb 0x2188
+&device.id		usb 0x0620
++device.name		Hub
+
+ vendor.id		usb 0x2188
+&device.id		usb 0x0625
++device.name		Hub
+
+ vendor.id		usb 0x2188
+&device.id		usb 0x0754
++device.name		Card Reader
+
+ vendor.id		usb 0x2188
+&device.id		usb 0x4042
++device.name		CalDigit Pro Audio
+
+ vendor.id		usb 0x219c
++vendor.name		Seal One AG
+
+ vendor.id		usb 0x219c
+&device.id		usb 0x0010
++device.name		USB 2200 K Secure Sign Token
+
  vendor.id		usb 0x21a1
 +vendor.name		Emotiv Systems Pty. Ltd.
 
  vendor.id		usb 0x21a1
 &device.id		usb 0x0001
 +device.name		EPOC Consumer Headset Wireless Dongle
+
+ vendor.id		usb 0x21a4
++vendor.name		Electronic Arts Inc.
+
+ vendor.id		usb 0x21a4
+&device.id		usb 0xac27
++device.name		SPORTS Active 2 Wireless Controller for PS3
+
+ vendor.id		usb 0x21a4
+&device.id		usb 0xac40
++device.name		SPORTS Active 2 Wireless Controller for Wii
+
+ vendor.id		usb 0x21a9
++vendor.name		Saleae, Inc.
+
+ vendor.id		usb 0x21a9
+&device.id		usb 0x1001
++device.name		16-channel Logic Analyzer [Logic16]
+
+ vendor.id		usb 0x21a9
+&device.id		usb 0x1003
++device.name		Logic 4
+
+ vendor.id		usb 0x21a9
+&device.id		usb 0x1004
++device.name		Logic8
+
+ vendor.id		usb 0x21a9
+&device.id		usb 0x1005
++device.name		Logic Pro 8
+
+ vendor.id		usb 0x21a9
+&device.id		usb 0x1006
++device.name		Logic Pro 16
+
+ vendor.id		usb 0x21ab
++vendor.name		Planeta Informatica
+
+ vendor.id		usb 0x21ab
+&device.id		usb 0x0010
++device.name		RC700 NFC SmartCard Reader
+
+ vendor.id		usb 0x21ab
+&device.id		usb 0x0011
++device.name		DSR700 SmartCard Reader
+
+ vendor.id		usb 0x21b4
++vendor.name		AudioQuest
+
+ vendor.id		usb 0x21b4
+&device.id		usb 0x0081
++device.name		DragonFly
+
+ vendor.id		usb 0x21b4
+&device.id		usb 0x0082
++device.name		DragonFly Red
 
  vendor.id		usb 0x21d6
 +vendor.name		Agecodagis SARL
@@ -73819,12 +81533,27 @@
 &device.id		usb 0x330c
 +device.name		RK3399 in Mask ROM mode
 
+ vendor.id		usb 0x221a
++vendor.name		ZTEX GmbH
+
+ vendor.id		usb 0x221a
+&device.id		usb 0x0100
++device.name		FPGA Boards
+
  vendor.id		usb 0x2222
 +vendor.name		MacAlly
 
  vendor.id		usb 0x2222
 &device.id		usb 0x0004
 +device.name		iWebKey Keyboard
+
+ vendor.id		usb 0x2222
+&device.id		usb 0x0005
++device.name		ICEKey Keyboard
+
+ vendor.id		usb 0x2222
+&device.id		usb 0x1001
++device.name		Generic Hub
 
  vendor.id		usb 0x2222
 &device.id		usb 0x2520
@@ -73834,6 +81563,9 @@
 &device.id		usb 0x4050
 +device.name		AirStick joystick
 
+ vendor.id		usb 0x2226
++vendor.name		Copper Mountain technologies
+
  vendor.id		usb 0x2227
 +vendor.name		SAMWOO Enterprise
 
@@ -73841,12 +81573,38 @@
 &device.id		usb 0x3105
 +device.name		SKYDATA SKD-U100
 
+ vendor.id		usb 0x222a
++vendor.name		ILI Technology Corp.
+
+ vendor.id		usb 0x222a
+&device.id		usb 0x0001
++device.name		Multi-Touch Screen
+
+ vendor.id		usb 0x222a
+&device.id		usb 0x0037
++device.name		Multi-Touch Screen
+
+ vendor.id		usb 0x2230
++vendor.name		Plugable
+
+ vendor.id		usb 0x2230
+&device.id		usb 0x0001
++device.name		UD-160-A / M Integrated Hub
+
+ vendor.id		usb 0x2230
+&device.id		usb 0x0003
++device.name		DC-125 / M Integrated Hub
+
  vendor.id		usb 0x2232
 +vendor.name		Silicon Motion
 
  vendor.id		usb 0x2232
 &device.id		usb 0x1005
 +device.name		WebCam SCB-0385N
+
+ vendor.id		usb 0x2232
+&device.id		usb 0x1024
++device.name		Webcam SC-13HDL11624N [Namuga Co., Ltd.]
 
  vendor.id		usb 0x2232
 &device.id		usb 0x1028
@@ -73859,6 +81617,10 @@
  vendor.id		usb 0x2232
 &device.id		usb 0x1037
 +device.name		WebCam SC-03FFM12339N
+
+ vendor.id		usb 0x2232
+&device.id		usb 0x1045
++device.name		WebCam SC-10HDP12631N
 
  vendor.id		usb 0x2233
 +vendor.name		RadioShack Corporation
@@ -73873,6 +81635,21 @@
  vendor.id		usb 0x2237
 &device.id		usb 0x4161
 +device.name		eReader White
+
+ vendor.id		usb 0x2237
+&device.id		usb 0x4163
++device.name		Touch
+
+ vendor.id		usb 0x2237
+&device.id		usb 0x4173
++device.name		Glo
+
+ vendor.id		usb 0x2245
++vendor.name		Aspeed Technology, Inc.
+
+ vendor.id		usb 0x2245
+&device.id		usb 0x1500
++device.name		AST1500/1510 PC-over-LAN Virtual Hub
 
  vendor.id		usb 0x224f
 +vendor.name		APDM
@@ -73905,6 +81682,13 @@
 &device.id		usb 0x0008
 +device.name		V2 Access Point
 
+ vendor.id		usb 0x2256
++vendor.name		Faderfox
+
+ vendor.id		usb 0x2256
+&device.id		usb 0x1007
++device.name		LV3 MIDI Controller
+
  vendor.id		usb 0x225d
 +vendor.name		Morpho
 
@@ -73918,7 +81702,7 @@
 
  vendor.id		usb 0x225d
 &device.id		usb 0x0009
-+device.name		CBM Fingerprint Sensor [CBM-V3]
++device.name		CBM-V3 Fingerprint Sensor
 
  vendor.id		usb 0x225d
 &device.id		usb 0x000a
@@ -73926,7 +81710,7 @@
 
  vendor.id		usb 0x225d
 &device.id		usb 0x000b
-+device.name		MSO1300 Fingerprint Sensor [MSO1300-V3]
++device.name		MSO1300-V3 Fingerprint Sensor
 
  vendor.id		usb 0x225d
 &device.id		usb 0x000c
@@ -73934,11 +81718,58 @@
 
  vendor.id		usb 0x225d
 &device.id		usb 0x000d
-+device.name		MSO1350 Fingerprint Sensor & SmartCard Reader [MSO1350-V3]
++device.name		MSO1350-V3 Fingerprint Sensor & SmartCard Reader
 
  vendor.id		usb 0x225d
 &device.id		usb 0x000e
 +device.name		MorphoAccess SIGMA Biometric Access Control Terminal
+
+ vendor.id		usb 0x225d
+&device.id		usb 0x9015
++device.name		Tablet 2
+
+ vendor.id		usb 0x225d
+&device.id		usb 0x9024
++device.name		Tablet 2
+
+ vendor.id		usb 0x225d
+&device.id		usb 0x9039
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0x904d
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0x904e
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0x9091
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0x9092
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0xf000
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0xf003
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0xf006
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x225d
+&device.id		usb 0xf00e
++device.name		Tablet 2 secure multifunction biometric tablet
+
+ vendor.id		usb 0x226e
++vendor.name		DISPLAX
 
  vendor.id		usb 0x228d
 +vendor.name		8D Technologies inc.
@@ -73947,12 +81778,29 @@
 &device.id		usb 0x0001
 +device.name		Terminal Bike Key Reader
 
+ vendor.id		usb 0x22a4
++vendor.name		VERZO Technology
+
  vendor.id		usb 0x22a6
 +vendor.name		Pie Digital, Inc.
 
  vendor.id		usb 0x22a6
 &device.id		usb 0xffff
 +device.name		PieKey "beta" 4GB model 4E4F41482E4F5247 (SM3251Q BB)
+
+ vendor.id		usb 0x22a7
++vendor.name		Fortinet Technologies
+
+ vendor.id		usb 0x22a7
+&device.id		usb 0x1001
++device.name		FortiGate Device
+
+ vendor.id		usb 0x22b1
++vendor.name		Secret Labs LLC
+
+ vendor.id		usb 0x22b1
+&device.id		usb 0x1000
++device.name		Netduino MCU pcb
 
  vendor.id		usb 0x22b8
 +vendor.name		Motorola PCS
@@ -73968,6 +81816,10 @@
  vendor.id		usb 0x22b8
 &device.id		usb 0x0005
 +device.name		V.60c/V.60i GSM Phone
+
+ vendor.id		usb 0x22b8
+&device.id		usb 0x002e
++device.name		XT1806
 
  vendor.id		usb 0x22b8
 &device.id		usb 0x0830
@@ -74090,6 +81942,14 @@
 +device.name		XT300[SPICE]
 
  vendor.id		usb 0x22b8
+&device.id		usb 0x2e82
++device.name		XT1541 [Moto G 3rd Gen]
+
+ vendor.id		usb 0x22b8
+&device.id		usb 0x2e83
++device.name		XT1033 [Moto G], PTP mode
+
+ vendor.id		usb 0x22b8
 &device.id		usb 0x3001
 +device.name		A835/E1000 GSM Phone (P2K)
 
@@ -74164,6 +82024,10 @@
  vendor.id		usb 0x22b8
 &device.id		usb 0x4285
 +device.name		Droid X (Mass storage)
+
+ vendor.id		usb 0x22b8
+&device.id		usb 0x42d9
++device.name		XT910 [Droid RAZR]
 
  vendor.id		usb 0x22b8
 &device.id		usb 0x4801
@@ -74286,8 +82150,20 @@
 +device.name		Argon chipset flash
 
  vendor.id		usb 0x22b8
+&device.id		usb 0x6411
++device.name		ROKR Z6 (print mode)
+
+ vendor.id		usb 0x22b8
 &device.id		usb 0x6415
 +device.name		ROKR Z6 (MTP mode)
+
+ vendor.id		usb 0x22b8
+&device.id		usb 0x6422
++device.name		ROKR Z6 (modem mode)
+
+ vendor.id		usb 0x22b8
+&device.id		usb 0x6426
++device.name		ROKR Z6 (storage mode)
 
  vendor.id		usb 0x22b8
 &device.id		usb 0x6604
@@ -74302,6 +82178,14 @@
 +device.name		Q Smartphone
 
  vendor.id		usb 0x22b8
+&device.id		usb 0x7086
++device.name		Atrix
+
+ vendor.id		usb 0x22b8
+&device.id		usb 0x70a8
++device.name		Xoom Tablet
+
+ vendor.id		usb 0x22b8
 &device.id		usb 0xfe01
 +device.name		StarTAC III MS900
 
@@ -74314,6 +82198,14 @@
 
  vendor.id		usb 0x22ba
 +vendor.name		Technology Innovation Holdings, Ltd
+
+ vendor.id		usb 0x22ba
+&device.id		usb 0x0108
++device.name		Double Shock Steering Wheel HID
+
+ vendor.id		usb 0x22ba
+&device.id		usb 0x0109
++device.name		Double Shock Steering Wheel Hub
 
  vendor.id		usb 0x22c9
 +vendor.name		StepOver GmbH
@@ -74361,6 +82253,56 @@
  vendor.id		usb 0x22cd
 +vendor.name		Kinova Robotics Inc.
 
+ vendor.id		usb 0x22d4
++vendor.name		Laview Technology
+
+ vendor.id		usb 0x22d4
+&device.id		usb 0x1301
++device.name		Mionix NAOS 8200 [STM32F103 MCU]
+
+ vendor.id		usb 0x22d4
+&device.id		usb 0x1308
++device.name		Mionix Avior 7000
+
+ vendor.id		usb 0x22d4
+&device.id		usb 0x130c
++device.name		Mionix Naos 7000
+
+ vendor.id		usb 0x22d4
+&device.id		usb 0x1316
++device.name		Mionix Castor
+
+ vendor.id		usb 0x22d9
++vendor.name		OPPO Electronics Corp.
+
+ vendor.id		usb 0x22d9
+&device.id		usb 0x2765
++device.name		Oppo N1
+
+ vendor.id		usb 0x22d9
+&device.id		usb 0x2767
++device.name		Oppo Find 5 (X909)
+
+ vendor.id		usb 0x22db
++vendor.name		Phase One
+
+ vendor.id		usb 0x22db
+&device.id		usb 0x0003
++device.name		IQ3 100MP IG030372
+
+ vendor.id		usb 0x22dc
++vendor.name		Mellanox Technologies
+
+ vendor.id		usb 0x22dc
+&device.id		usb 0x0004
++device.name		BlueField SOC
+
+ vendor.id		usb 0x22de
++vendor.name		WeTelecom Incorporated
+
+ vendor.id		usb 0x22df
++vendor.name		Medicom MTD, Ltd
+
  vendor.id		usb 0x22e0
 +vendor.name		secunet Security Networks AG
 
@@ -74371,6 +82313,65 @@
  vendor.id		usb 0x22e0
 &device.id		usb 0x0003
 +device.name		SINA ID Token A
+
+ vendor.id		usb 0x22e8
++vendor.name		Cambridge Audio
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0x6512
++device.name		651N Audio
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0x6969
++device.name		Audio Prototype
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0x7512
++device.name		751R Audio
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0x770a
++device.name		X70A Audio
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0x850c
++device.name		851C Audio [Azur 850C]
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0x851d
++device.name		851D Audio [Azur 851D]
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xca02
++device.name		Audio
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xca04
++device.name		Audio
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xca06
++device.name		AmpMagic
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xdac2
++device.name		DacMagic Plus
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xdac3
++device.name		Azur DacMagic 100
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xdac4
++device.name		Azur DacMagic 100
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xdac6
++device.name		DacMagicXS 2.0
+
+ vendor.id		usb 0x22e8
+&device.id		usb 0xdac8
++device.name		Audio
 
  vendor.id		usb 0x2304
 +vendor.name		Pinnacle Systems, Inc.
@@ -74555,12 +82556,50 @@
 &device.id		usb 0x061e
 +device.name		PCTV Deluxe (PAL) Device
 
+ vendor.id		usb 0x2304
+&device.id		usb 0x2304
++device.name		1689
+
+ vendor.id		usb 0x230d
++vendor.name		Teracom
+
+ vendor.id		usb 0x230d
+&device.id		usb 0x0103
++device.name		Huwaii 3g wireless modem
+
+ vendor.id		usb 0x2314
++vendor.name		INQ Mobile
+
  vendor.id		usb 0x2318
 +vendor.name		Shining Technologies, Inc. [hex]
 
  vendor.id		usb 0x2318
 &device.id		usb 0x0011
 +device.name		CitiDISK Jr. IDE Enclosure
+
+ vendor.id		usb 0x2319
++vendor.name		Tronsmart
+
+ vendor.id		usb 0x2319
+&device.id		usb 0x0014
++device.name		TSM01 Air Mouse + Keyboard
+
+ vendor.id		usb 0x232b
++vendor.name		Pantum Ltd.
+
+ vendor.id		usb 0x232b
+&device.id		usb 0x0810
++device.name		P2000
+
+ vendor.id		usb 0x232e
++vendor.name		EA Elektro-Automatik GmbH & Co. KG
+
+ vendor.id		usb 0x232e
+&device.id		usb 0x0010
++device.name		EA-PS-2000 B Series Power Supply
+
+ vendor.id		usb 0x2340
++vendor.name		Teleepoch
 
  vendor.id		usb 0x2341
 +vendor.name		Arduino SA
@@ -74574,8 +82613,20 @@
 +device.name		Mega 2560 (CDC ACM)
 
  vendor.id		usb 0x2341
+&device.id		usb 0x0036
++device.name		Leonardo Bootloader
+
+ vendor.id		usb 0x2341
 &device.id		usb 0x003b
 +device.name		Serial Adapter (CDC ACM)
+
+ vendor.id		usb 0x2341
+&device.id		usb 0x003d
++device.name		Due Programming Port
+
+ vendor.id		usb 0x2341
+&device.id		usb 0x003e
++device.name		Due
 
  vendor.id		usb 0x2341
 &device.id		usb 0x003f
@@ -74598,11 +82649,41 @@
 +device.name		Serial R3 (CDC ACM)
 
  vendor.id		usb 0x2341
+&device.id		usb 0x0049
++device.name		ISP
+
+ vendor.id		usb 0x2341
 &device.id		usb 0x8036
 +device.name		Leonardo (CDC ACM, HID)
 
+ vendor.id		usb 0x2341
+&device.id		usb 0x8038
++device.name		Robot Control Board (CDC ACM, HID)
+
+ vendor.id		usb 0x2341
+&device.id		usb 0x8039
++device.name		Robot Motor Board (CDC ACM, HID)
+
+ vendor.id		usb 0x2349
++vendor.name		P2 Engineering Group, LLC
+
+ vendor.id		usb 0x234b
++vendor.name		Free Software Initiative of Japan
+
+ vendor.id		usb 0x234b
+&device.id		usb 0x0000
++device.name		Gnuk Token
+
+ vendor.id		usb 0x234b
+&device.id		usb 0x0001
++device.name		NeuG True RNG
+
  vendor.id		usb 0x2357
 +vendor.name		TP-Link
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x0005
++device.name		M7350 4G Mi-Fi Router
 
  vendor.id		usb 0x2357
 &device.id		usb 0x0100
@@ -74626,7 +82707,7 @@
 
  vendor.id		usb 0x2357
 &device.id		usb 0x0107
-+device.name		TL-WN821N Version 5 RTL8192EU
++device.name		TL-WN821N v5/v6 [RTL8192EU]
 
  vendor.id		usb 0x2357
 &device.id		usb 0x0108
@@ -74634,15 +82715,43 @@
 
  vendor.id		usb 0x2357
 &device.id		usb 0x0109
-+device.name		TL WN823N RTL8192EU
++device.name		TL-WN823N v2/v3 [Realtek RTL8192EU]
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x010b
++device.name		Archer T2UHP [MediaTek MT7610U]
 
  vendor.id		usb 0x2357
 &device.id		usb 0x010c
-+device.name		TL-WN722N v2
++device.name		TL-WN722N v2/v3 [Realtek RTL8188EUS]
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x010d
++device.name		Archer T4U v2 [Realtek RTL8812AU]
 
  vendor.id		usb 0x2357
 &device.id		usb 0x010e
-+device.name		TL-WN722N v2
++device.name		Archer T4UH v2 [Realtek RTL8812AU]
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x010f
++device.name		Archer T4UHP [Realtek RTL8812AU]
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x0115
++device.name		Archer T4U ver.3
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x011e
++device.name		AC600 wireless Realtek RTL8811AU [Archer T2U Nano]
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x0120
++device.name		Archer T2U PLUS [RTL8821AU]
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x012d
++device.name		Archer T3U [Realtek RTL8812BU]
 
  vendor.id		usb 0x2357
 &device.id		usb 0x0200
@@ -74651,6 +82760,82 @@
  vendor.id		usb 0x2357
 &device.id		usb 0x0201
 +device.name		HSUPA Modem MA180
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x0600
++device.name		UE300 10/100/1000 LAN (mass storage CD-ROM mode) [Realtek RTL8153]
+
+ vendor.id		usb 0x2357
+&device.id		usb 0x0601
++device.name		UE300 10/100/1000 LAN (ethernet mode) [Realtek RTL8153]
+
+ vendor.id		usb 0x2366
++vendor.name		Bitmanufaktur GmbH
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0001
++device.name		Reserved Prototyping PID
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0002
++device.name		OpenBeacon USB 2
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0003
++device.name		OpenPCD 2 RFID Reader for 13.56MHz
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0004
++device.name		OpenBeacon
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0005
++device.name		Blinkenlights WDIM
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0006
++device.name		Blinkenlights WMCU
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0007
++device.name		OpenBeacon Ethernet EasyReader PoE II - Active 2.4GHz RFID Reader
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0008
++device.name		OpenBeacon WLAN
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x0009
++device.name		OpenPCD 2 RFID Reader for 13.56MHz
+
+ vendor.id		usb 0x2366
+&device.id		usb 0x000a
++device.name		OpenPCD 2 Audio & LCD Display
+
+ vendor.id		usb 0x2367
++vendor.name		Teenage Engineering
+
+ vendor.id		usb 0x2367
+&device.id		usb 0x0002
++device.name		OP-1 Portable synthesizer
+
+ vendor.id		usb 0x2367
+&device.id		usb 0x000c
++device.name		OP-Z Portable synthesizer
+
+ vendor.id		usb 0x2368
++vendor.name		Peterson Electro-Musical Products Inc.
+
+ vendor.id		usb 0x2368
+&device.id		usb 0x0001
++device.name		BBS-1 [BodyBeat Sync]
+
+ vendor.id		usb 0x236a
++vendor.name		SiBEAM
+
+ vendor.id		usb 0x236a
+&device.id		usb 0x1965
++device.name		SB6501 802.11ad Wireless Network Adapter
 
  vendor.id		usb 0x2373
 +vendor.name		Pumatronix Ltda
@@ -74666,6 +82851,131 @@
 &device.id		usb 0x0001
 +device.name		Digital Audio Player
 
+ vendor.id		usb 0x2378
++vendor.name		OnLive
+
+ vendor.id		usb 0x2378
+&device.id		usb 0x100a
++device.name		Universal Wireless Controller
+
+ vendor.id		usb 0x237d
++vendor.name		Cradlepoint
+
+ vendor.id		usb 0x237d
+&device.id		usb 0x0400
++device.name		MC400
+
+ vendor.id		usb 0x2386
++vendor.name		Raydium Corporation
+
+ vendor.id		usb 0x2386
+&device.id		usb 0x3125
++device.name		Touch System
+
+ vendor.id		usb 0x2386
+&device.id		usb 0x4328
++device.name		Touch System
+
+ vendor.id		usb 0x2386
+&device.id		usb 0x432f
++device.name		Touch System
+
+ vendor.id		usb 0x238b
++vendor.name		Hytera Communications
+
+ vendor.id		usb 0x238b
+&device.id		usb 0x0a11
++device.name		DMR Radio
+
+ vendor.id		usb 0x239a
++vendor.name		Adafruit
+
+ vendor.id		usb 0x239a
+&device.id		usb 0x0001
++device.name		CDC Bootloader
+
+ vendor.id		usb 0x239a
+&device.id		usb 0x801e
++device.name		Trinket M0
+
+ vendor.id		usb 0x23a0
++vendor.name		BIFIT
+
+ vendor.id		usb 0x23a0
+&device.id		usb 0x0001
++device.name		Token iBank2key
+
+ vendor.id		usb 0x23a0
+&device.id		usb 0x0002
++device.name		iBank2Key Type M Token
+
+ vendor.id		usb 0x23a0
+&device.id		usb 0x0003
++device.name		iToken
+
+ vendor.id		usb 0x23a0
+&device.id		usb 0x0008
++device.name		MS_KEY K - Angara
+
+ vendor.id		usb 0x23a6
++vendor.name		Tronical Components GmbH
+
+ vendor.id		usb 0x23a6
+&device.id		usb 0x2000
++device.name		Gibson Firebird X Pedal Board
+
+ vendor.id		usb 0x23a6
+&device.id		usb 0x2001
++device.name		Gibson Firebird X Switch Board
+
+ vendor.id		usb 0x23b4
++vendor.name		Dental Wings Inc.
+
+ vendor.id		usb 0x23b4
+&device.id		usb 0x0200
++device.name		DW0200 Color Camera
+
+ vendor.id		usb 0x23b4
+&device.id		usb 0x0300
++device.name		DW0300 Hight Speed Monochrome Camera
+
+ vendor.id		usb 0x23c7
++vendor.name		Gemini
+
+ vendor.id		usb 0x23c7
+&device.id		usb 0x1021
++device.name		FirstMix
+
+ vendor.id		usb 0x23fc
++vendor.name		SesKion GmbH
+
+ vendor.id		usb 0x23fc
+&device.id		usb 0x0201
++device.name		SPI-Simulyzer box for SPI data communication
+
+ vendor.id		usb 0x23fc
+&device.id		usb 0x0202
++device.name		PSI5-Simulyzer box for PSI5 (Peripheral-Sensor-Interfacs) data communication
+
+ vendor.id		usb 0x23fc
+&device.id		usb 0x0203
++device.name		SENT-Simulyzer box for SENT data communication
+
+ vendor.id		usb 0x23fc
+&device.id		usb 0x0204
++device.name		DSI-Simulyzer box for DSI3 data communication
+
+ vendor.id		usb 0x2405
++vendor.name		Custom Computer Services, Inc
+
+ vendor.id		usb 0x2405
+&device.id		usb 0x0002
++device.name		West Mountain Radio RIGblaster Advantage Audio
+
+ vendor.id		usb 0x2405
+&device.id		usb 0x0003
++device.name		West Mountain Radio RIGblaster Advantage
+
  vendor.id		usb 0x2406
 +vendor.name		SANHO Digital Electronics Co., Ltd.
 
@@ -74673,12 +82983,103 @@
 &device.id		usb 0x6688
 +device.name		PD7X Portable Storage
 
+ vendor.id		usb 0x2420
++vendor.name		IRiver
+
+ vendor.id		usb 0x242e
++vendor.name		Vossloh-Schwabe Deutschland GmbH
+
+ vendor.id		usb 0x242e
+&device.id		usb 0x0001
++device.name		DALI Master
+
+ vendor.id		usb 0x242e
+&device.id		usb 0x0002
++device.name		LiCS Bootloader Mode
+
+ vendor.id		usb 0x242e
+&device.id		usb 0x0003
++device.name		LiCS Running Mode
+
+ vendor.id		usb 0x242e
+&device.id		usb 0x0004
++device.name		iProgrammer
+
+ vendor.id		usb 0x242e
+&device.id		usb 0x0005
++device.name		NFC programming device
+
+ vendor.id		usb 0x2433
++vendor.name		ASETEK
+
+ vendor.id		usb 0x2433
+&device.id		usb 0xb200
++device.name		[NZXT Kraken X60]
+
  vendor.id		usb 0x2443
 +vendor.name		Aessent Technology Ltd
 
  vendor.id		usb 0x2443
 &device.id		usb 0x00dc
 +device.name		aes220 FPGA Mini-Module
+
+ vendor.id		usb 0x2457
++vendor.name		Ocean Optics Inc.
+
+ vendor.id		usb 0x2457
+&device.id		usb 0x100a
++device.name		HR2000 Spectrometer 1.00.0
+
+ vendor.id		usb 0x2457
+&device.id		usb 0x1012
++device.name		HR4000 Spectrometer
+
+ vendor.id		usb 0x2458
++vendor.name		Bluegiga Technologies
+
+ vendor.id		usb 0x2458
+&device.id		usb 0x0001
++device.name		BLED112 Bluetooth 4.0 Single Mode Dongle
+
+ vendor.id		usb 0x245f
++vendor.name		Chord Electronics Limited
+
+ vendor.id		usb 0x2464
++vendor.name		Nest
+
+ vendor.id		usb 0x2464
+&device.id		usb 0x0001
++device.name		Learning Thermostat
+
+ vendor.id		usb 0x2464
+&device.id		usb 0x0002
++device.name		Learning Thermostat (2nd Generation)
+
+ vendor.id		usb 0x2464
+&device.id		usb 0x0010
++device.name		Protect : Smoke + Carbon Monoxide
+
+ vendor.id		usb 0x2464
+&device.id		usb 0x0020
++device.name		Heat Link
+
+ vendor.id		usb 0x2466
++vendor.name		Fractal Audio Systems
+
+ vendor.id		usb 0x2466
+&device.id		usb 0x8003
++device.name		Axe-Fx II
+
+ vendor.id		usb 0x2466
+&device.id		usb 0x8010
++device.name		Axe-FX III
+
+ vendor.id		usb 0x2476
++vendor.name		YEI Technology
+
+ vendor.id		usb 0x2476
+&device.id		usb 0x1040
++device.name		3-Space Embedded Sensor
 
  vendor.id		usb 0x2478
 +vendor.name		Tripp-Lite
@@ -74694,8 +83095,181 @@
 &device.id		usb 0x8366
 +device.name		Wireless Optical Mouse ACT-MUSW-002
 
+ vendor.id		usb 0x248a
+&device.id		usb 0x8367
++device.name		Telink Wireless Receiver
+
  vendor.id		usb 0x249c
 +vendor.name		M2Tech s.r.l.
+
+ vendor.id		usb 0x24a4
++vendor.name		Primare AB
+
+ vendor.id		usb 0x24a4
+&device.id		usb 0x0002
++device.name		I15_v1.06 [Primare Audio DAC]
+
+ vendor.id		usb 0x24ae
++vendor.name		Shenzhen Rapoo Technology Co., Ltd.
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x0001
++device.name		KX Keyboard
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x0197
++device.name		meva Barcode Scanner
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x1813
++device.name		E9260 Wireless Multi-mode Keyboard
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x2000
++device.name		2.4G Wireless Device Serial
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x2001
++device.name		5 GHz Wireless Receiver
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x2003
++device.name		5GHz Wireless Transceiver
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x4110
++device.name		Optical Gaming Mouse [V280]
+
+ vendor.id		usb 0x24ae
+&device.id		usb 0x6000
++device.name		Wireless Audio
+
+ vendor.id		usb 0x24c0
++vendor.name		Chaney Instrument
+
+ vendor.id		usb 0x24c0
+&device.id		usb 0x0003
++device.name		Model 01036 weather center
+
+ vendor.id		usb 0x24c6
++vendor.name		ThrustMaster, Inc.
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5000
++device.name		Razer Atrox Gaming Arcade Stick
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5300
++device.name		PowerA Mini ProEX Controller for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5303
++device.name		Airflo Wired Controller for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x530a
++device.name		ProEX Controller for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x531a
++device.name		Pro Ex mini for XBOX
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5397
++device.name		FUS1ON Tournament Controller
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x541a
++device.name		PowerA CPFA115320-01 [Mini Controller for Xbox One]
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x542a
++device.name		Spectra for Xbox One
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x543a
++device.name		PowerA Wired Controller for Xbox One
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5500
++device.name		Horipad EX2 Turbo
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5501
++device.name		Hori Real Arcade Pro.VX-SA for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5502
++device.name		Hori Fighting Stick VX Alt for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5503
++device.name		Hori Fighting Edge for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5506
++device.name		Hori Soulcalibur V Stick for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x550d
++device.name		Hori Gem Controller for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x550e
++device.name		Real Arcade Pro V Kai for Xbox One / Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x551a
++device.name		Fusion Pro Controller
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x561a
++device.name		Fusion Controller for Xbox One
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5b00
++device.name		Ferrari 458 Italia Racing Wheel
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5b02
++device.name		GPX Controller
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0x5d04
++device.name		Sabertooth Elite
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0xfa00
++device.name		INF-8032385 Disney Infinity Reader
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0xfafb
++device.name		Aplay Controller
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0xfafd
++device.name		Afterglow Gamepad for Xbox 360
+
+ vendor.id		usb 0x24c6
+&device.id		usb 0xfafe
++device.name		Rock Candy Gamepad for Xbox 360
+
+ vendor.id		usb 0x24cf
++vendor.name		Lytro, Inc.
+
+ vendor.id		usb 0x24cf
+&device.id		usb 0x00a1
++device.name		Light Field Camera
+
+ vendor.id		usb 0x24dc
++vendor.name		Aladdin R.D.
+
+ vendor.id		usb 0x24dc
+&device.id		usb 0x0406
++device.name		JaCarta SF GOST
+
+ vendor.id		usb 0x24e0
++vendor.name		Yoctopuce Sarl
 
  vendor.id		usb 0x24e1
 +vendor.name		Paratronic
@@ -74707,6 +83281,60 @@
  vendor.id		usb 0x24e1
 &device.id		usb 0x3005
 +device.name		Radius
+
+ vendor.id		usb 0x24e3
++vendor.name		K-Touch
+
+ vendor.id		usb 0x24ea
++vendor.name		Meva
+
+ vendor.id		usb 0x24ea
+&device.id		usb 0x0197
++device.name		Barcode Scanner
+
+ vendor.id		usb 0x24ed
++vendor.name		Zen Group
+
+ vendor.id		usb 0x24ed
+&device.id		usb 0x044d
++device.name		Chat Headset
+
+ vendor.id		usb 0x24f0
++vendor.name		Metadot
+
+ vendor.id		usb 0x24f0
+&device.id		usb 0x0105
++device.name		Das Keyboard 4
+
+ vendor.id		usb 0x24f0
+&device.id		usb 0x0140
++device.name		Das Keyboard 4
+
+ vendor.id		usb 0x24f0
+&device.id		usb 0x2020
++device.name		Das Keyboard 5Q
+
+ vendor.id		usb 0x24ff
++vendor.name		Acroname Inc.
+
+ vendor.id		usb 0x2500
++vendor.name		Ettus Research LLC
+
+ vendor.id		usb 0x2500
+&device.id		usb 0x0020
++device.name		USRP B210
+
+ vendor.id		usb 0x2500
+&device.id		usb 0x0021
++device.name		USRP B200-mini
+
+ vendor.id		usb 0x2500
+&device.id		usb 0x0022
++device.name		USRP B205-mini
+
+ vendor.id		usb 0x2500
+&device.id		usb 0x0200
++device.name		USRP B200
 
  vendor.id		usb 0x2516
 +vendor.name		Cooler Master Co., Ltd.
@@ -74733,11 +83361,23 @@
 
  vendor.id		usb 0x2516
 &device.id		usb 0x0011
-+device.name		Storm Quick Fire TK
++device.name		Storm Quick Fire TK 6keys
+
+ vendor.id		usb 0x2516
+&device.id		usb 0x0014
++device.name		Storm Quick Fire TK Nkeys
+
+ vendor.id		usb 0x2516
+&device.id		usb 0x0015
++device.name		Storm QuickFire Pro/Ultimate keyboard
 
  vendor.id		usb 0x2516
 &device.id		usb 0x0017
 +device.name		CM Storm Quick Fire Stealth
+
+ vendor.id		usb 0x2516
+&device.id		usb 0x001a
++device.name		Storm Quick Fire XT
 
  vendor.id		usb 0x2516
 &device.id		usb 0x0020
@@ -74752,12 +83392,67 @@
 +device.name		Alcor mouse
 
  vendor.id		usb 0x2516
+&device.id		usb 0x0042
++device.name		Masterkeys Lite L Combo RGB Keyboard
+
+ vendor.id		usb 0x2516
+&device.id		usb 0x0044
++device.name		Masterkeys Lite L Combo RGB Mouse
+
+ vendor.id		usb 0x2516
+&device.id		usb 0x0046
++device.name		Masterkeys PRO L
+
+ vendor.id		usb 0x2516
 &device.id		usb 0x0047
 +device.name		MasterKeys Pro L
 
  vendor.id		usb 0x2516
+&device.id		usb 0x0055
++device.name		MasterKeys L
+
+ vendor.id		usb 0x2516
+&device.id		usb 0x1006
++device.name		MasterCase SL600M
+
+ vendor.id		usb 0x2516
 &device.id		usb 0x9494
 +device.name		Sirus Headset
+
+ vendor.id		usb 0x2520
++vendor.name		ANA-U GmbH
+
+ vendor.id		usb 0x2520
+&device.id		usb 0x0001
++device.name		EasyPrinter S3
+
+ vendor.id		usb 0x2527
++vendor.name		Software Bisque
+
+ vendor.id		usb 0x2527
+&device.id		usb 0x1388
++device.name		Paramount 5
+
+ vendor.id		usb 0x2537
++vendor.name		Norelsys
+
+ vendor.id		usb 0x2537
+&device.id		usb 0x1066
++device.name		NS1066
+
+ vendor.id		usb 0x2537
+&device.id		usb 0x1068
++device.name		NS1068/NS1068X SATA Bridge Controller
+
+ vendor.id		usb 0x2544
++vendor.name		Energy Micro AS
+
+ vendor.id		usb 0x2546
++vendor.name		Ravensburger
+
+ vendor.id		usb 0x2546
+&device.id		usb 0xe301
++device.name		TipToi Pen
 
  vendor.id		usb 0x2548
 +vendor.name		Pulse-Eight
@@ -74770,12 +83465,362 @@
 &device.id		usb 0x1002
 +device.name		CEC Adapter
 
+ vendor.id		usb 0x254e
++vendor.name		SHF Communication Technologies AG
+
+ vendor.id		usb 0x254e
+&device.id		usb 0xe2b3
++device.name		SHF 58035 A BiasBoard
+
+ vendor.id		usb 0x2554
++vendor.name		ASSA ABLOY AB
+
+ vendor.id		usb 0x2555
++vendor.name		Basis Science Inc.
+
+ vendor.id		usb 0x2555
+&device.id		usb 0x0001
++device.name		B1 Fitness Band
+
+ vendor.id		usb 0x255e
++vendor.name		Beijing Bonxeon Technology Co., Ltd.
+
+ vendor.id		usb 0x255e
+&device.id		usb 0x0001
++device.name		Device
+
+ vendor.id		usb 0x255e
+&device.id		usb 0x0002
++device.name		Dual
+
+ vendor.id		usb 0x2560
++vendor.name		e-con Systems
+
+ vendor.id		usb 0x2560
+&device.id		usb 0xc152
++device.name		See3CAM_CU51 5 Mpx monochrome camera
+
+ vendor.id		usb 0x2563
++vendor.name		ShenZhen ShanWan Technology Co., Ltd.
+
+ vendor.id		usb 0x2563
+&device.id		usb 0x031d
++device.name		DXT Mouse
+
+ vendor.id		usb 0x2563
+&device.id		usb 0x0523
++device.name		BM0523 WirelessGamepad
+
+ vendor.id		usb 0x2563
+&device.id		usb 0x0575
++device.name		ZD-V+ Wired Gaming Controller
+
+ vendor.id		usb 0x256b
++vendor.name		Perreaux Industries Ltd
+
+ vendor.id		usb 0x256b
+&device.id		usb 0x0121
++device.name		Audiant 80i
+
+ vendor.id		usb 0x256f
++vendor.name		3Dconnexion
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc62e
++device.name		SpaceMouse Wireless (cabled)
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc62f
++device.name		SpaceMouse Wireless Receiver
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc631
++device.name		SpaceMouse Pro Wireless (cabled)
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc632
++device.name		SpaceMouse Pro Wireless Receiver
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc633
++device.name		SpaceMouse Enterprise
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc635
++device.name		SpaceMouse Compact
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc651
++device.name		CadMouse Wireless
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc652
++device.name		Universal Receiver
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc654
++device.name		CadMouse Pro Wireless
+
+ vendor.id		usb 0x256f
+&device.id		usb 0xc657
++device.name		CadMouse Pro Wireless Left
+
+ vendor.id		usb 0x2573
++vendor.name		ESI Audiotechnik GmbH
+
+ vendor.id		usb 0x2573
+&device.id		usb 0x0017
++device.name		MAYA22
+
+ vendor.id		usb 0x2574
++vendor.name		AVer Information, Inc.
+
+ vendor.id		usb 0x2574
+&device.id		usb 0x0901
++device.name		VC520
+
+ vendor.id		usb 0x2574
+&device.id		usb 0x0910
++device.name		CAM520
+
+ vendor.id		usb 0x2574
+&device.id		usb 0x0920
++device.name		VC320
+
+ vendor.id		usb 0x2574
+&device.id		usb 0x0930
++device.name		CAM530
+
+ vendor.id		usb 0x2574
+&device.id		usb 0x0940
++device.name		CAM340
+
+ vendor.id		usb 0x2574
+&device.id		usb 0x0950
++device.name		VC322
+
+ vendor.id		usb 0x2574
+&device.id		usb 0x0960
++device.name		VB342
+
+ vendor.id		usb 0x2575
++vendor.name		Weida Hi-Tech Co., Ltd.
+
+ vendor.id		usb 0x2576
++vendor.name		AFO Co., Ltd.
+
+ vendor.id		usb 0x2576
+&device.id		usb 0x0003
++device.name		TCM
+
+ vendor.id		usb 0x2576
+&device.id		usb 0x0005
++device.name		BL [Boot Loader]
+
+ vendor.id		usb 0x2576
+&device.id		usb 0x0011
++device.name		THM
+
+ vendor.id		usb 0x2578
++vendor.name		Pluscom
+
+ vendor.id		usb 0x2578
+&device.id		usb 0x4168
++device.name		2.4GHZ Wireless Arc Folding Mouse
+
+ vendor.id		usb 0x2581
++vendor.name		Plug-up
+
+ vendor.id		usb 0x2581
+&device.id		usb 0x1807
++device.name		Generic HID Smartcard
+
+ vendor.id		usb 0x2581
+&device.id		usb 0x1808
++device.name		WinUSB Smartcard
+
+ vendor.id		usb 0x2581
+&device.id		usb 0xf1d0
++device.name		FIDO U2F Security Key
+
+ vendor.id		usb 0x258d
++vendor.name		Sequans Communications
+
+ vendor.id		usb 0x259a
++vendor.name		TriQuint Semiconductor
+
+ vendor.id		usb 0x25a7
++vendor.name		Areson Technology Corp
+
+ vendor.id		usb 0x25a7
+&device.id		usb 0x2410
++device.name		Laser mouse
+
+ vendor.id		usb 0x25a7
+&device.id		usb 0xfa23
++device.name		2.4G Receiver
+
+ vendor.id		usb 0x25a7
+&device.id		usb 0xfa61
++device.name		Elecom Co., Ltd MR-K013 Multicard Reader
+
  vendor.id		usb 0x25b5
 +vendor.name		FlatFrog
 
  vendor.id		usb 0x25b5
 &device.id		usb 0x0002
 +device.name		Multitouch 3200
+
+ vendor.id		usb 0x25bb
++vendor.name		Brunner Elektronik AG
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x0063
++device.name		PRT.5105 [Yoke]
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x0064
++device.name		PRT.5105 [reserved]
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x0065
++device.name		PRT.5096 [Battery Management System]
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x0066
++device.name		PRT.5096 [Battery Management System]
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x0067
++device.name		PRT.5094
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x0068
++device.name		PRT.5094
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x0069
++device.name		PRT.5119 [Ethernet2CAN LC Gateway]
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x006a
++device.name		PRT.5113 [CLS CANaerospace Gateway]
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x006b
++device.name		PRT.5123
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x006c
++device.name		PRT.5123 [reserved]
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x006d
++device.name		PRT.5127
+
+ vendor.id		usb 0x25bb
+&device.id		usb 0x00ff
++device.name		MSP430 HID Update Agent
+
+ vendor.id		usb 0x25bf
++vendor.name		Elegant Invention
+
+ vendor.id		usb 0x25bf
+&device.id		usb 0x0001
++device.name		Isostick
+
+ vendor.id		usb 0x25bf
+&device.id		usb 0x0002
++device.name		Isostick updater
+
+ vendor.id		usb 0x25c4
++vendor.name		ARCAM
+
+ vendor.id		usb 0x25c6
++vendor.name		Vitus Audio (AVA Group A/S)
+
+ vendor.id		usb 0x25c8
++vendor.name		Visual Planet Ltd
+
+ vendor.id		usb 0x25c8
+&device.id		usb 0x0014
++device.name		Single User touchfoil(tm) (SU2-80)
+
+ vendor.id		usb 0x25da
++vendor.name		Netatmo
+
+ vendor.id		usb 0x25da
+&device.id		usb 0x0001
++device.name		Weather Station
+
+ vendor.id		usb 0x25e3
++vendor.name		Lumigon
+
+ vendor.id		usb 0x25f0
++vendor.name		ShanWan
+
+ vendor.id		usb 0x25f0
+&device.id		usb 0xc131
++device.name		Gioteck PS3 2.4G Wireless Controller
+
+ vendor.id		usb 0x25fb
++vendor.name		Pentax Ricoh Imaging Co., Ltd
+
+ vendor.id		usb 0x25fb
+&device.id		usb 0x0102
++device.name		K-5
+
+ vendor.id		usb 0x2604
++vendor.name		Tenda
+
+ vendor.id		usb 0x2604
+&device.id		usb 0x0012
++device.name		U12
+
+ vendor.id		usb 0x2625
++vendor.name		MilDef AB
+
+ vendor.id		usb 0x2626
++vendor.name		Aruba Networks
+
+ vendor.id		usb 0x2626
+&device.id		usb 0xea60
++device.name		UART Bridge Controller [cp210x]
+
+ vendor.id		usb 0x262a
++vendor.name		SAVITECH Corp.
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x100e
++device.name		SA9027 Audio Streaming Controller
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x10e0
++device.name		SA9023 Audio Streaming Controller
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x9020
++device.name		SA9020 audio controller
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x9023
++device.name		SA9023 audio controller
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x9027
++device.name		SA9027 audio controller
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x9226
++device.name		SA9226 192KHz audio controller
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x9227
++device.name		SA9227 384KHz audio controller
+
+ vendor.id		usb 0x262a
+&device.id		usb 0x9228
++device.name		SA9228 384KHz/DSD audio controller
 
  vendor.id		usb 0x2632
 +vendor.name		TwinMOS
@@ -74836,11 +83881,30 @@
 +device.name		MTw
 
  vendor.id		usb 0x2639
+&device.id		usb 0x0300
++device.name		Motion Tracker Development Board
+
+ vendor.id		usb 0x2639
+&device.id		usb 0x0301
++device.name		MTi Converter
+
+ vendor.id		usb 0x2639
 &device.id		usb 0xd00d
 +device.name		Wireless Receiver
 
+ vendor.id		usb 0x264a
++vendor.name		Thermaltake
+
+ vendor.id		usb 0x264a
+&device.id		usb 0x1004
++device.name		Ventus
+
  vendor.id		usb 0x2650
 +vendor.name		Electronics For Imaging, Inc. [hex]
+
+ vendor.id		usb 0x2650
+&device.id		usb 0x1311
++device.name		eBeam Classic [Luidia]
 
  vendor.id		usb 0x2659
 +vendor.name		Sundtek
@@ -74901,12 +83965,353 @@
 &device.id		usb 0x1213
 +device.name		MediaTV Pro III MiniPCIe (US)
 
+ vendor.id		usb 0x2662
++vendor.name		Moog Music Inc.
+
+ vendor.id		usb 0x266e
++vendor.name		Silicon Integrated Systems
+
+ vendor.id		usb 0x2672
++vendor.name		GoPro
+
+ vendor.id		usb 0x2672
+&device.id		usb 0x0004
++device.name		Hero 3
+
+ vendor.id		usb 0x2672
+&device.id		usb 0x0006
++device.name		HERO 3+ Silver Edition
+
+ vendor.id		usb 0x2672
+&device.id		usb 0x0007
++device.name		HERO 3+ Black
+
+ vendor.id		usb 0x2672
+&device.id		usb 0x000e
++device.name		HERO4 Black
+
+ vendor.id		usb 0x2672
+&device.id		usb 0x0011
++device.name		Hero 3+ Black
+
  vendor.id		usb 0x2676
 +vendor.name		Basler AG
 
  vendor.id		usb 0x2676
 &device.id		usb 0xba02
 +device.name		ace
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba03
++device.name		ba03 dart Vision Caera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba04
++device.name		ba04 pulse Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba05
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba06
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba07
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba08
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba09
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba0a
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba0b
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba0c
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba0d
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba0e
++device.name		Vision Camera
+
+ vendor.id		usb 0x2676
+&device.id		usb 0xba0f
++device.name		Vision Camera
+
+ vendor.id		usb 0x2685
++vendor.name		Cardo Peripheral Systems LTD
+
+ vendor.id		usb 0x2685
+&device.id		usb 0x0900
++device.name		[Packtalk Bold Bluetooth Motorcycle Intercom]
+
+ vendor.id		usb 0x2687
++vendor.name		Fitbit Inc.
+
+ vendor.id		usb 0x2687
+&device.id		usb 0xfb01
++device.name		Base Station
+
+ vendor.id		usb 0x2689
++vendor.name		StepOver International GmbH
+
+ vendor.id		usb 0x2689
+&device.id		usb 0x0601
++device.name		naturaSign Pad POS
+
+ vendor.id		usb 0x2689
+&device.id		usb 0x0901
++device.name		naturaSign Pad Light
+
+ vendor.id		usb 0x2689
+&device.id		usb 0x0ce1
++device.name		Pad Vivid US
+
+ vendor.id		usb 0x2689
+&device.id		usb 0x0cf1
++device.name		Pad Biometric US 5.0
+
+ vendor.id		usb 0x2689
+&device.id		usb 0x0d01
++device.name		duraSign Pad US 10.0
+
+ vendor.id		usb 0x2689
+&device.id		usb 0x0df1
++device.name		duraSign Pad Biometric US 10.0
+
+ vendor.id		usb 0x268b
++vendor.name		Dimension Engineering
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0101
++device.name		DELink 2
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0201
++device.name		Sabertooth 2x32
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0405
++device.name		Evolv DNA 200
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0406
++device.name		Evolv DNA 200
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0407
++device.name		Evolv DNA 200
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0408
++device.name		Evolv DNA 75
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0409
++device.name		Evolv DNA 250
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0412
++device.name		Evolv DNA 60
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0413
++device.name		Evolv DNA 200
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0414
++device.name		Evolv DNA 250
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0415
++device.name		Evolv DNA 75
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0416
++device.name		Evolv DNA 60
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0417
++device.name		Evolv DNA Go
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0419
++device.name		Evolv DNA 250 Color
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0423
++device.name		Evolv DNA 200
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0424
++device.name		Evolv DNA 250
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0425
++device.name		Evolv DNA 75
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x0426
++device.name		Evolv DNA 60
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8405
++device.name		Evolv DNA 200 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8406
++device.name		Evolv DNA 200 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8407
++device.name		Evolv DNA 200 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8408
++device.name		Evolv DNA 75 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8409
++device.name		Evolv DNA 250 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8412
++device.name		Evolv DNA 60 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8413
++device.name		Evolv DNA 200 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8414
++device.name		Evolv DNA 250 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8415
++device.name		Evolv DNA 75 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8416
++device.name		Evolv DNA 60 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8423
++device.name		Evolv DNA 200 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8424
++device.name		Evolv DNA 250 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8425
++device.name		Evolv DNA 75 (recovery mode)
+
+ vendor.id		usb 0x268b
+&device.id		usb 0x8426
++device.name		Evolv DNA 60 (recovery mode)
+
+ vendor.id		usb 0x26a9
++vendor.name		Research Industrial Systems Engineering
+
+ vendor.id		usb 0x26a9
+&device.id		usb 0x0001
++device.name		Payment Terminal v1.0
+
+ vendor.id		usb 0x26aa
++vendor.name		Yaesu Musen
+
+ vendor.id		usb 0x26aa
+&device.id		usb 0x0001
++device.name		FT-1D
+
+ vendor.id		usb 0x26aa
+&device.id		usb 0x000e
++device.name		FTA-550
+
+ vendor.id		usb 0x26aa
+&device.id		usb 0x000f
++device.name		FTA-750
+
+ vendor.id		usb 0x26b5
++vendor.name		Electrocompaniet
+
+ vendor.id		usb 0x26b5
+&device.id		usb 0x0002
++device.name		ECD 2
+
+ vendor.id		usb 0x26b5
+&device.id		usb 0x0003
++device.name		ECD 2 (Audio Class 1)
+
+ vendor.id		usb 0x26b5
+&device.id		usb 0x0004
++device.name		PI 2D
+
+ vendor.id		usb 0x26b5
+&device.id		usb 0x0005
++device.name		PI 2D (Audio Class 1)
+
+ vendor.id		usb 0x26b5
+&device.id		usb 0x0006
++device.name		ECI 6
+
+ vendor.id		usb 0x26b5
+&device.id		usb 0x0007
++device.name		ECI 6 (Audio Class 1)
+
+ vendor.id		usb 0x26b5
+&device.id		usb 0x0020
++device.name		ECI 80
+
+ vendor.id		usb 0x26bd
++vendor.name		Integral Memory
+
+ vendor.id		usb 0x26bd
+&device.id		usb 0x9917
++device.name		Fusion Flash Drive
+
+ vendor.id		usb 0x26e2
++vendor.name		Ingenieurbuero Dietzsch und Thiele, PartG
+
+ vendor.id		usb 0x26f2
++vendor.name		Micromega
+
+ vendor.id		usb 0x26f2
+&device.id		usb 0x0200
++device.name		MyDac
+
+ vendor.id		usb 0x2707
++vendor.name		Bardac Corporation
+
+ vendor.id		usb 0x2707
+&device.id		usb 0x0005
++device.name		drive.web
+
+ vendor.id		usb 0x270d
++vendor.name		Rosand Technologies
+
+ vendor.id		usb 0x270d
+&device.id		usb 0x1001
++device.name		R-Idge Bootloader
+
+ vendor.id		usb 0x270d
+&device.id		usb 0x1002
++device.name		R-Idge Router
 
  vendor.id		usb 0x2717
 +vendor.name		Xiaomi Inc.
@@ -74967,8 +84372,30 @@
 &device.id		usb 0xff88
 +device.name		Mi/Redmi series (RNDIS + ADB)
 
+ vendor.id		usb 0x272a
++vendor.name		StarLeaf Ltd.
+
+ vendor.id		usb 0x272c
++vendor.name		Signum Systems
+
+ vendor.id		usb 0x272c
+&device.id		usb 0x7d13
++device.name		I-jet
+
  vendor.id		usb 0x2730
 +vendor.name		Citizen
+
+ vendor.id		usb 0x2730
+&device.id		usb 0x0fff
++device.name		CT-S2000/4000/310/CLP-521/621/631/CL-S700 Series
+
+ vendor.id		usb 0x2730
+&device.id		usb 0x1004
++device.name		PPU-700
+
+ vendor.id		usb 0x2730
+&device.id		usb 0x2002
++device.name		CT-S2000 Thermal Printer (Parallel mode)
 
  vendor.id		usb 0x2730
 &device.id		usb 0x200f
@@ -75136,6 +84563,34 @@
 &device.id		usb 0x1005
 +device.name		ColorHug2 bootloader
 
+ vendor.id		usb 0x2756
++vendor.name		Victor Hasselblad AB
+
+ vendor.id		usb 0x2756
+&device.id		usb 0x0002
++device.name		X1D Camera
+
+ vendor.id		usb 0x2759
++vendor.name		Philip Morris Products S.A.
+
+ vendor.id		usb 0x2759
+&device.id		usb 0x0003
++device.name		IQOS Pocket Charger 2.4
+
+ vendor.id		usb 0x2765
++vendor.name		Firstbeat Technologies, Ltd.
+
+ vendor.id		usb 0x2765
+&device.id		usb 0x0004
++device.name		Bodyguard 2
+
+ vendor.id		usb 0x2766
++vendor.name		LifeScan
+
+ vendor.id		usb 0x2766
+&device.id		usb 0x0000
++device.name		OneTouch Verio
+
  vendor.id		usb 0x2770
 +vendor.name		NHJ, Ltd
 
@@ -75183,12 +84638,37 @@
 &device.id		usb 0x930c
 +device.name		CCD Webcam(PC370R)
 
+ vendor.id		usb 0x27a8
++vendor.name		Square, Inc.
+
+ vendor.id		usb 0x27a8
+&device.id		usb 0xa120
++device.name		Contactless + Chip Reader
+
  vendor.id		usb 0x27b8
 +vendor.name		ThingM
 
  vendor.id		usb 0x27b8
 &device.id		usb 0x01ed
 +device.name		blink(1)
+
+ vendor.id		usb 0x27bd
++vendor.name		Codethink Ltd.
+
+ vendor.id		usb 0x27bd
+&device.id		usb 0x0001
++device.name		Slab Node Manager
+
+ vendor.id		usb 0x27bd
+&device.id		usb 0x0002
++device.name		Slab Node Manager JTAG
+
+ vendor.id		usb 0x27c0
++vendor.name		Cadwell Laboratories, Inc.
+
+ vendor.id		usb 0x27c0
+&device.id		usb 0x0818
++device.name		Paperlike HD-FT
 
  vendor.id		usb 0x27c6
 +vendor.name		Shenzhen Goodix Technology Co.,Ltd.
@@ -75207,6 +84687,14 @@
 
  vendor.id		usb 0x27c6
 &device.id		usb 0x530c
++device.name		Fingerprint Reader
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x532d
++device.name		Fingerprint
+
+ vendor.id		usb 0x27c6
+&device.id		usb 0x5381
 +device.name		Fingerprint Reader
 
  vendor.id		usb 0x27c6
@@ -75233,6 +84721,51 @@
 &device.id		usb 0x5740
 +device.name		Fingerprint Reader
 
+ vendor.id		usb 0x27d4
++vendor.name		Blackstar Amplification Limited
+
+ vendor.id		usb 0x27dd
++vendor.name		Mindeo
+
+ vendor.id		usb 0x27dd
+&device.id		usb 0x0002
++device.name		Mindeo Virtual COM Port
+
+ vendor.id		usb 0x27f2
++vendor.name		Softnautics LLP
+
+ vendor.id		usb 0x2803
++vendor.name		StarLine LLC.
+
+ vendor.id		usb 0x2803
+&device.id		usb 0x0001
++device.name		Controller Area Network car alarm module [SLCAN-2]
+
+ vendor.id		usb 0x2806
++vendor.name		SIMPASS
+
+ vendor.id		usb 0x2806
+&device.id		usb 0x0001
++device.name		N-PASS X1
+
+ vendor.id		usb 0x2817
++vendor.name		Signal Hound, Inc.
+
+ vendor.id		usb 0x2817
+&device.id		usb 0x0002
++device.name		BB60C Spectrum Analyzer
+
+ vendor.id		usb 0x2817
+&device.id		usb 0x0004
++device.name		SM200A Spectrum Analyzer
+
+ vendor.id		usb 0x2818
++vendor.name		Codex Digital Limited
+
+ vendor.id		usb 0x2818
+&device.id		usb 0x0001
++device.name		Transfer Drive Dock
+
  vendor.id		usb 0x2821
 +vendor.name		ASUSTek Computer Inc.
 
@@ -75247,6 +84780,84 @@
  vendor.id		usb 0x2821
 &device.id		usb 0x3300
 +device.name		WL-140 / Hawking HWU36D 802.11b Wireless Adapter [Intersil PRISM 3]
+
+ vendor.id		usb 0x2822
++vendor.name		REFLEXdigital
+
+ vendor.id		usb 0x2833
++vendor.name		Oculus VR, Inc.
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0001
++device.name		Rift Developer Kit 1
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0021
++device.name		Rift DK2
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0031
++device.name		Rift CV1
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0101
++device.name		Latency Tester
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0137
++device.name		Quest Headset
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0201
++device.name		Camera DK2
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0211
++device.name		Rift CV1 Sensor
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x0330
++device.name		Rift CV1 Audio
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x1031
++device.name		Rift CV1
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x2021
++device.name		Rift DK2
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x2031
++device.name		Rift CV1
+
+ vendor.id		usb 0x2833
+&device.id		usb 0x3031
++device.name		Rift CV1
+
+ vendor.id		usb 0x2836
++vendor.name		OUYA
+
+ vendor.id		usb 0x286b
++vendor.name		STANEO SAS
+
+ vendor.id		usb 0x286b
+&device.id		usb 0x0003
++device.name		D6BB/D9 seismic digitizer
+
+ vendor.id		usb 0x2886
++vendor.name		Seeed Technology Co., Ltd.
+
+ vendor.id		usb 0x2886
+&device.id		usb 0x0002
++device.name		Seeeduino Lite
+
+ vendor.id		usb 0x2890
++vendor.name		Teknic, Inc
+
+ vendor.id		usb 0x2890
+&device.id		usb 0x0213
++device.name		ClearPath 4-axis Comm Hub
 
  vendor.id		usb 0x2899
 +vendor.name		Toptronic Industrial Co., Ltd
@@ -75307,6 +84918,54 @@
 +device.name		Gamecube/N64 controller v2.9 (Joystick mode)
 
  vendor.id		usb 0x289b
+&device.id		usb 0x000e
++device.name		VirtualBoy controller
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0010
++device.name		WUSBMote v1.2 (Joystick mode)
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0011
++device.name		WUSBMote v1.2 (Mouse mode)
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0012
++device.name		WUSBMote v1.2.1 (Joystick mode)
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0013
++device.name		WUSBMote v1.2.1 (Mouse mode)
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0014
++device.name		WUSBMote v1.3 (Joystick mode)
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0015
++device.name		WUSBMote v1.3 (Mouse mode)
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0016
++device.name		WUSBMote v1.3 (I2C interface mode)
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0017
++device.name		Gamecube/N64 controller v3.0
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0018
++device.name		Atari Jaguar controller
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x0019
++device.name		MultiDB9joy v3
+
+ vendor.id		usb 0x289b
+&device.id		usb 0x001a
++device.name		MultiDB9joy v3 (multitap mode)
+
+ vendor.id		usb 0x289b
 &device.id		usb 0x0100
 +device.name		Dual-relay board
 
@@ -75317,6 +84976,34 @@
  vendor.id		usb 0x289b
 &device.id		usb 0x0502
 +device.name		Precision barometer
+
+ vendor.id		usb 0x289d
++vendor.name		Seek Thermal, Inc.
+
+ vendor.id		usb 0x289d
+&device.id		usb 0x0010
++device.name		PIR206 Thermal Camera [Seek Compact]
+
+ vendor.id		usb 0x28bd
++vendor.name		XP-Pen
+
+ vendor.id		usb 0x28bd
+&device.id		usb 0x0920
++device.name		Star G960 Graphic Tablet
+
+ vendor.id		usb 0x28c7
++vendor.name		Ultimaker B.V.
+
+ vendor.id		usb 0x28c7
+&device.id		usb 0x0001
++device.name		3D printer serial interface
+
+ vendor.id		usb 0x28d4
++vendor.name		Devialet
+
+ vendor.id		usb 0x28d4
+&device.id		usb 0x0008
++device.name		120/200/250/400/800/D-Premier
 
  vendor.id		usb 0x28de
 +vendor.name		Valve Software
@@ -75334,8 +85021,97 @@
 +device.name		Lighthouse FPGA RX
 
  vendor.id		usb 0x28de
+&device.id		usb 0x2012
++device.name		Virtual Reality Controller [VRC]
+
+ vendor.id		usb 0x28de
 &device.id		usb 0x2101
 +device.name		Watchman Dongle
+
+ vendor.id		usb 0x28de
+&device.id		usb 0x2500
++device.name		Lighthouse Base Station
+
+ vendor.id		usb 0x28e0
++vendor.name		PT. Prasimax Inovasi Teknologi
+
+ vendor.id		usb 0x28e0
+&device.id		usb 0x1001
++device.name		BTS Monitoring Config for Prototype
+
+ vendor.id		usb 0x28e0
+&device.id		usb 0x5740
++device.name		TRUMON TS-107
+
+ vendor.id		usb 0x28e0
+&device.id		usb 0x5741
++device.name		TRUMON TS-108
+
+ vendor.id		usb 0x28e9
++vendor.name		GDMicroelectronics
+
+ vendor.id		usb 0x28e9
+&device.id		usb 0x0189
++device.name		GD32 DFU Bootloader (Longan Nano)
+
+ vendor.id		usb 0x28f3
++vendor.name		Clover Network, Inc.
+
+ vendor.id		usb 0x28f3
+&device.id		usb 0x2000
++device.name		Mobile Wi-Fi (C200)
+
+ vendor.id		usb 0x28f3
+&device.id		usb 0x3000
++device.name		Mini
+
+ vendor.id		usb 0x28f3
+&device.id		usb 0x4000
++device.name		Flex
+
+ vendor.id		usb 0x28f9
++vendor.name		Profitap HQ BV
+
+ vendor.id		usb 0x28f9
+&device.id		usb 0x0001
++device.name		Profishark 1G Black
+
+ vendor.id		usb 0x28f9
+&device.id		usb 0x0003
++device.name		Profishark 1G+
+
+ vendor.id		usb 0x28f9
+&device.id		usb 0x0004
++device.name		Profishark 1G
+
+ vendor.id		usb 0x28f9
+&device.id		usb 0x0005
++device.name		Profishark 10G
+
+ vendor.id		usb 0x28f9
+&device.id		usb 0x0006
++device.name		Profishark 100M
+
+ vendor.id		usb 0x290c
++vendor.name		R. Hamilton & Co. Ltd.
+
+ vendor.id		usb 0x290c
+&device.id		usb 0x4b4d
++device.name		Mercury iPod Dock
+
+ vendor.id		usb 0x2912
++vendor.name		Audioengine
+
+ vendor.id		usb 0x2912
+&device.id		usb 0x20c8
++device.name		D1 24-bit DAC
+
+ vendor.id		usb 0x2912
+&device.id		usb 0x30c8
++device.name		D1 24-bit DAC
+
+ vendor.id		usb 0x2916
++vendor.name		Yota Devices
 
  vendor.id		usb 0x2931
 +vendor.name		Jolla Oy
@@ -75351,6 +85127,10 @@
  vendor.id		usb 0x2931
 &device.id		usb 0x0a05
 +device.name		Jolla PC connection
+
+ vendor.id		usb 0x2931
+&device.id		usb 0x0a07
++device.name		Phone MTP
 
  vendor.id		usb 0x2931
 &device.id		usb 0x0afe
@@ -75370,6 +85150,140 @@
  vendor.id		usb 0x2939
 &device.id		usb 0x495b
 +device.name		X-MCB2
+
+ vendor.id		usb 0x2939
+&device.id		usb 0x49b1
++device.name		X-MCB1
+
+ vendor.id		usb 0x2939
+&device.id		usb 0x49b2
++device.name		X-MCB2
+
+ vendor.id		usb 0x2939
+&device.id		usb 0x49c1
++device.name		X-MCC1
+
+ vendor.id		usb 0x2939
+&device.id		usb 0x49c2
++device.name		X-MCC2
+
+ vendor.id		usb 0x2939
+&device.id		usb 0x49c3
++device.name		X-MCC3
+
+ vendor.id		usb 0x2939
+&device.id		usb 0x49c4
++device.name		X-MCC4
+
+ vendor.id		usb 0x2957
++vendor.name		Obsidian Research Corporation
+
+ vendor.id		usb 0x2957
+&device.id		usb 0x0001
++device.name		Management Console
+
+ vendor.id		usb 0x2961
++vendor.name		Miselu
+
+ vendor.id		usb 0x2961
+&device.id		usb 0x0001
++device.name		C.24 keyboard
+
+ vendor.id		usb 0x296b
++vendor.name		Xacti Corporation
+
+ vendor.id		usb 0x296b
+&device.id		usb 0x3917
++device.name		CX-WE100 Camera
+
+ vendor.id		usb 0x2972
++vendor.name		FiiO Electronics Technology
+
+ vendor.id		usb 0x2972
+&device.id		usb 0x0007
++device.name		X3 2nd gen audio player / DAC
+
+ vendor.id		usb 0x298d
++vendor.name		Next Biometrics
+
+ vendor.id		usb 0x298d
+&device.id		usb 0x2020
++device.name		NB-2020-U Fingerprint Reader
+
+ vendor.id		usb 0x29bd
++vendor.name		Silicon Works
+
+ vendor.id		usb 0x29bd
+&device.id		usb 0x4101
++device.name		Multi-touch Device
+
+ vendor.id		usb 0x29c1
++vendor.name		Taztag
+
+ vendor.id		usb 0x29c1
+&device.id		usb 0x1105
++device.name		M17-G903-1 [Tazpad]
+
+ vendor.id		usb 0x29c1
+&device.id		usb 0x1107
++device.name		M17-G903-A [Tazpad] (CCID)
+
+ vendor.id		usb 0x29c2
++vendor.name		Lewitt GmbH
+
+ vendor.id		usb 0x29c2
+&device.id		usb 0x0001
++device.name		DGT 650
+
+ vendor.id		usb 0x29c2
+&device.id		usb 0x0003
++device.name		DGT 450
+
+ vendor.id		usb 0x29c2
+&device.id		usb 0x0009
++device.name		DGT 260
+
+ vendor.id		usb 0x29c2
+&device.id		usb 0x0011
++device.name		Stream 4x5
+
+ vendor.id		usb 0x29c3
++vendor.name		Noviga
+
+ vendor.id		usb 0x29e2
++vendor.name		Huatune Technology (Shanghai) Co., Ltd.
+
+ vendor.id		usb 0x29e7
++vendor.name		Brunel University
+
+ vendor.id		usb 0x29e8
++vendor.name		4Links Limited
+
+ vendor.id		usb 0x29ea
++vendor.name		Kinesis Corporation
+
+ vendor.id		usb 0x29ea
+&device.id		usb 0x0102
++device.name		Advantage2 Keyboard
+
+ vendor.id		usb 0x29f1
++vendor.name		Canaan Creative Co., Ltd
+
+ vendor.id		usb 0x29f1
+&device.id		usb 0x33f1
++device.name		Avalon nano 1.0
+
+ vendor.id		usb 0x29f1
+&device.id		usb 0x33f2
++device.name		Avalon USB2IIC Converter
+
+ vendor.id		usb 0x29f1
+&device.id		usb 0x33f3
++device.name		Avalon nano 2.0
+
+ vendor.id		usb 0x29f1
+&device.id		usb 0x40f1
++device.name		Avalon4 mini
 
  vendor.id		usb 0x2a03
 +vendor.name		dog hunter AG
@@ -75400,7 +85314,7 @@
 
  vendor.id		usb 0x2a03
 &device.id		usb 0x003b
-+device.name		Arduino Serial
++device.name		Arduino usb2serial
 
  vendor.id		usb 0x2a03
 &device.id		usb 0x003c
@@ -75466,12 +85380,130 @@
 &device.id		usb 0x804d
 +device.name		Arduino Zero Pro (CDC ACM)
 
+ vendor.id		usb 0x2a0e
++vendor.name		Shenzhen DreamSource Technology Co., Ltd.
+
+ vendor.id		usb 0x2a13
++vendor.name		Grabba International
+
+ vendor.id		usb 0x2a13
+&device.id		usb 0x0000
++device.name		S-Series data capture device
+
+ vendor.id		usb 0x2a19
++vendor.name		Numato Systems Pvt. Ltd
+
+ vendor.id		usb 0x2a19
+&device.id		usb 0x1002
++device.name		Mimas V2 Spartan6 FPGA Development Board
+
+ vendor.id		usb 0x2a19
+&device.id		usb 0x5440
++device.name		TimVideos' HDMI2USB Opsis (FX2) - Unconfigured device
+
+ vendor.id		usb 0x2a19
+&device.id		usb 0x5441
++device.name		TimVideos' HDMI2USB Opsis (FX2) - Firmware load/upgrade
+
+ vendor.id		usb 0x2a19
+&device.id		usb 0x5442
++device.name		TimVideos' HDMI2USB Opsis (FX2) - HDMI/DVI Capture Device
+
+ vendor.id		usb 0x2a1d
++vendor.name		Oxford Nanopore Technologies, Ltd
+
+ vendor.id		usb 0x2a1d
+&device.id		usb 0x0000
++device.name		MinION
+
+ vendor.id		usb 0x2a1d
+&device.id		usb 0x0001
++device.name		MinION
+
+ vendor.id		usb 0x2a1d
+&device.id		usb 0x0010
++device.name		VolTRAX
+
+ vendor.id		usb 0x2a1d
+&device.id		usb 0x0011
++device.name		VolTRAX
+
+ vendor.id		usb 0x2a1d
+&device.id		usb 0x0020
++device.name		GridION
+
+ vendor.id		usb 0x2a1d
+&device.id		usb 0x0021
++device.name		GridION
+
  vendor.id		usb 0x2a37
 +vendor.name		RTD Embedded Technologies, Inc.
 
  vendor.id		usb 0x2a37
 &device.id		usb 0x5110
 +device.name		UPS35110/UPS25110
+
+ vendor.id		usb 0x2a39
++vendor.name		RME
+
+ vendor.id		usb 0x2a39
+&device.id		usb 0x3fb0
++device.name		Babyface Pro (Class Compliant Mode)
+
+ vendor.id		usb 0x2a39
+&device.id		usb 0x3fc0
++device.name		Babyface Pro
+
+ vendor.id		usb 0x2a39
+&device.id		usb 0x3fc1
++device.name		Fireface UFX+
+
+ vendor.id		usb 0x2a39
+&device.id		usb 0x3fc2
++device.name		Fireface UFX+
+
+ vendor.id		usb 0x2a39
+&device.id		usb 0x3fd1
++device.name		Fireface UFX+
+
+ vendor.id		usb 0x2a3c
++vendor.name		Trinamic Motion Control GmbH & Co KG
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0100
++device.name		Stepper Device
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0200
++device.name		BLDC/PMSM Device
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0300
++device.name		Motor Control Device
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0400
++device.name		Motor Control Device
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0500
++device.name		PANdrive(TM)
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0600
++device.name		motionCookie(TM)
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0700
++device.name		Evaluation Device
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0800
++device.name		Interface Device
+
+ vendor.id		usb 0x2a3c
+&device.id		usb 0x0900
++device.name		Generic Device
 
  vendor.id		usb 0x2a45
 +vendor.name		Meizu Corp.
@@ -75508,6 +85540,90 @@
 &device.id		usb 0x2012
 +device.name		MX Phone (MTP & ACM)
 
+ vendor.id		usb 0x2a47
++vendor.name		Mundo Reader, S.L.
+
+ vendor.id		usb 0x2a47
+&device.id		usb 0x0c02
++device.name		bq Aquaris E4.5
+
+ vendor.id		usb 0x2a47
+&device.id		usb 0x201d
++device.name		Tablet Edison 3
+
+ vendor.id		usb 0x2a47
+&device.id		usb 0x903a
++device.name		bq Aquaris U
+
+ vendor.id		usb 0x2a4b
++vendor.name		EMULEX Corporation
+
+ vendor.id		usb 0x2a4b
+&device.id		usb 0x0400
++device.name		Pilot4 Integrated Hub
+
+ vendor.id		usb 0x2a62
++vendor.name		Flymaster Avionics
+
+ vendor.id		usb 0x2a62
+&device.id		usb 0xb301
++device.name		LiveSD
+
+ vendor.id		usb 0x2a62
+&device.id		usb 0xb302
++device.name		NavSD
+
+ vendor.id		usb 0x2a6e
++vendor.name		Bare Conductive
+
+ vendor.id		usb 0x2a6e
+&device.id		usb 0x0003
++device.name		Touch Board
+
+ vendor.id		usb 0x2a6e
+&device.id		usb 0x8003
++device.name		Touch Board
+
+ vendor.id		usb 0x2a70
++vendor.name		OnePlus Technology (Shenzhen) Co., Ltd.
+
+ vendor.id		usb 0x2a70
+&device.id		usb 0x4ee7
++device.name		ONEPLUS A3010 [OnePlus 3T] / A5010 [OnePlus 5T] / A6003 [OnePlus 6] (Charging + USB debugging modes)
+
+ vendor.id		usb 0x2a70
+&device.id		usb 0x904d
++device.name		A3000 phone (PTP mode) [3T]
+
+ vendor.id		usb 0x2a70
+&device.id		usb 0x904e
++device.name		A3000 phone (PTP mode, with debug) [3T]
+
+ vendor.id		usb 0x2a88
++vendor.name		DFU Technology Ltd
+
+ vendor.id		usb 0x2a88
+&device.id		usb 0xffff
++device.name		DFU
+
+ vendor.id		usb 0x2a8d
++vendor.name		Keysight Technologies, Inc.
+
+ vendor.id		usb 0x2ab6
++vendor.name		T+A elektroakustik GmbH & Co KG, Germany
+
+ vendor.id		usb 0x2ab6
+&device.id		usb 0x0001
++device.name		PDP3000HV DAC
+
+ vendor.id		usb 0x2ab6
+&device.id		usb 0x0002
++device.name		MP1000E, MP2000R, MP2500R, MP3100HV
+
+ vendor.id		usb 0x2ab6
+&device.id		usb 0x0003
++device.name		TA HD AUDIO V2
+
  vendor.id		usb 0x2ac7
 +vendor.name		Ultrahaptics Ltd.
 
@@ -75543,12 +85659,215 @@
 &device.id		usb 0xffff
 +device.name		DFU
 
+ vendor.id		usb 0x2ad1
++vendor.name		Picotronic GmbH
+
+ vendor.id		usb 0x2ad1
+&device.id		usb 0x7ab8
++device.name		Turningtable
+
+ vendor.id		usb 0x2ae5
++vendor.name		Fairphone B.V.
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0x9015
++device.name		2 (Mass storage & ADB)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0x9024
++device.name		2 (RNDIS & ADB)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0x9039
++device.name		2 (MTP & ADB)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0x904d
++device.name		2 (PTP)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0x904e
++device.name		2 (PTP & ADB)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0x90de
++device.name		2 (Charging)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0xf000
++device.name		2 (Mass storage)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0xf003
++device.name		2 (MTP)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0xf005
++device.name		2 (tethering)
+
+ vendor.id		usb 0x2ae5
+&device.id		usb 0xf00e
++device.name		2 (RNDIS)
+
+ vendor.id		usb 0x2aec
++vendor.name		Ambiq Micro, Inc.
+
+ vendor.id		usb 0x2aec
+&device.id		usb 0x6011
++device.name		Converter
+
+ vendor.id		usb 0x2af4
++vendor.name		ROLI Ltd.
+
+ vendor.id		usb 0x2af4
+&device.id		usb 0x0100
++device.name		Seaboard GRAND
+
+ vendor.id		usb 0x2af4
+&device.id		usb 0x0200
++device.name		Seaboard RISE
+
+ vendor.id		usb 0x2af4
+&device.id		usb 0x0300
++device.name		BlueWing Proto
+
+ vendor.id		usb 0x2af4
+&device.id		usb 0x0400
++device.name		VOICE
+
+ vendor.id		usb 0x2af4
+&device.id		usb 0x0500
++device.name		BLOCKS
+
+ vendor.id		usb 0x2b03
++vendor.name		STEREOLABS
+
+ vendor.id		usb 0x2b03
+&device.id		usb 0xf580
++device.name		ZED camera
+
+ vendor.id		usb 0x2b03
+&device.id		usb 0xf582
++device.name		ZED camera
+
+ vendor.id		usb 0x2b03
+&device.id		usb 0xf680
++device.name		ZED-M camera
+
+ vendor.id		usb 0x2b03
+&device.id		usb 0xf681
++device.name		ZED-M HID Interface
+
+ vendor.id		usb 0x2b03
+&device.id		usb 0xf682
++device.name		ZED-M camera
+
+ vendor.id		usb 0x2b03
+&device.id		usb 0xf683
++device.name		ZED-M HID Interface
+
+ vendor.id		usb 0x2b03
+&device.id		usb 0xf684
++device.name		ZED-M camera
+
+ vendor.id		usb 0x2b0e
++vendor.name		LeEco
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x171b
++device.name		Le2
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x171e
++device.name		Le2 in USB tethering mode
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x1830
++device.name		Le1 Pro
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x1844
++device.name		Le Max2
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x2b0e
++device.name		LeEco
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x6108
++device.name		Lex720 [LePro 3] in connection sharing usb
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x610b
++device.name		Lex720 [LePro 3] in Camera mode
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x610c
++device.name		Lex720 [LePro 3]
+
+ vendor.id		usb 0x2b0e
+&device.id		usb 0x610d
++device.name		Lex720 [LePro 3] in debug
+
+ vendor.id		usb 0x2b23
++vendor.name		Red Hat, Inc.
+
+ vendor.id		usb 0x2b23
+&device.id		usb 0xcafe
++device.name		UsbDk (USB Development Kit)
+
  vendor.id		usb 0x2b24
 +vendor.name		KeepKey LLC
 
  vendor.id		usb 0x2b24
 &device.id		usb 0x0001
-+device.name		Bitcoin hardware wallet
++device.name		Bitcoin Wallet [KeepKey]
+
+ vendor.id		usb 0x2b24
+&device.id		usb 0x0002
++device.name		Bitcoin Wallet
+
+ vendor.id		usb 0x2b3e
++vendor.name		NewAE Technology Inc.
+
+ vendor.id		usb 0x2b3e
+&device.id		usb 0xace2
++device.name		CW1173 [ChipWhisperer-Lite]
+
+ vendor.id		usb 0x2b4c
++vendor.name		ZUK
+
+ vendor.id		usb 0x2b4c
+&device.id		usb 0x1004
++device.name		Z1 MTP
+
+ vendor.id		usb 0x2bc5
++vendor.name		Orbbec 3D Technology International, Inc
+
+ vendor.id		usb 0x2bc5
+&device.id		usb 0x0401
++device.name		Astra
+
+ vendor.id		usb 0x2bc5
+&device.id		usb 0x0403
++device.name		Astra Pro
+
+ vendor.id		usb 0x2bc5
+&device.id		usb 0x0407
++device.name		Astra Mini S
+
+ vendor.id		usb 0x2bcc
++vendor.name		InoTec GmbH Organisationssysteme
+
+ vendor.id		usb 0x2bd6
++vendor.name		Coroware, Inc.
+
+ vendor.id		usb 0x2bd6
+&device.id		usb 0x4201
++device.name		RS-485 Controller and Interface [Cypress Semiconductor]
+
+ vendor.id		usb 0x2bd8
++vendor.name		ROPEX Industrie-Elektronik GmbH
 
  vendor.id		usb 0x2c02
 +vendor.name		Planex Communications
@@ -75570,6 +85889,39 @@
  vendor.id		usb 0x2c23
 &device.id		usb 0x1b83
 +device.name		NIC
+
+ vendor.id		usb 0x2c4e
++vendor.name		Mercucys INC
+
+ vendor.id		usb 0x2c4e
+&device.id		usb 0x0100
++device.name		MW300UM RTL8192EU wifi
+
+ vendor.id		usb 0x2c4f
++vendor.name		Canon Electronic Business Machines Co., Ltd.
+
+ vendor.id		usb 0x2c4f
+&device.id		usb 0x3003
++device.name		PR Wireless Presenter
+
+ vendor.id		usb 0x2c55
++vendor.name		Magic Leap, Inc.
+
+ vendor.id		usb 0x2c55
+&device.id		usb 0xa100
++device.name		ML1 Lightpack (MLDB)
+
+ vendor.id		usb 0x2c55
+&device.id		usb 0xb100
++device.name		ML1 Lightpack (fastboot)
+
+ vendor.id		usb 0x2c55
+&device.id		usb 0xc001
++device.name		ML1 Control (COM)
+
+ vendor.id		usb 0x2c55
+&device.id		usb 0xc002
++device.name		ML1 Control (Bootloader)
 
  vendor.id		usb 0x2c7c
 +vendor.name		Quectel Wireless Solutions Co., Ltd.
@@ -75602,6 +85954,96 @@
 &device.id		usb 0x0435
 +device.name		AG35 LTE modem
 
+ vendor.id		usb 0x2c97
++vendor.name		Ledger
+
+ vendor.id		usb 0x2c97
+&device.id		usb 0x0000
++device.name		Blue
+
+ vendor.id		usb 0x2c97
+&device.id		usb 0x0001
++device.name		Nano S
+
+ vendor.id		usb 0x2c97
+&device.id		usb 0x0004
++device.name		Nano X
+
+ vendor.id		usb 0x2c99
++vendor.name		Prusa
+
+ vendor.id		usb 0x2c99
+&device.id		usb 0x0001
++device.name		i3 MK2S
+
+ vendor.id		usb 0x2c9c
++vendor.name		Vayyar Imaging Ltd.
+
+ vendor.id		usb 0x2c9c
+&device.id		usb 0x1000
++device.name		Walabot Makers Series
+
+ vendor.id		usb 0x2c9c
+&device.id		usb 0x1020
++device.name		Walabot DIY
+
+ vendor.id		usb 0x2c9c
+&device.id		usb 0x1022
++device.name		Walabot DIY Plus
+
+ vendor.id		usb 0x2c9c
+&device.id		usb 0x1030
++device.name		Walabot Home (vHC)
+
+ vendor.id		usb 0x2c9c
+&device.id		usb 0x9100
++device.name		VNAKit
+
+ vendor.id		usb 0x2c9d
++vendor.name		Nod Inc
+
+ vendor.id		usb 0x2c9d
+&device.id		usb 0x90a0
++device.name		Goa
+
+ vendor.id		usb 0x2c9d
+&device.id		usb 0xbac5
++device.name		Backspin
+
+ vendor.id		usb 0x2ca3
++vendor.name		DJI Technology Co., Ltd.
+
+ vendor.id		usb 0x2ca3
+&device.id		usb 0x0008
++device.name		Mavic Mini MR1SD25 Remote controller
+
+ vendor.id		usb 0x2cb7
++vendor.name		Fibocom
+
+ vendor.id		usb 0x2cb7
+&device.id		usb 0x0210
++device.name		L830-EB-00 LTE WWAN Modem
+
+ vendor.id		usb 0x2cc0
++vendor.name		Hangzhou Zero Zero Infinity Technology Co., Ltd.
+
+ vendor.id		usb 0x2cc2
++vendor.name		Lautsprecher Teufel GmbH
+
+ vendor.id		usb 0x2ccf
++vendor.name		Hypersecu
+
+ vendor.id		usb 0x2ccf
+&device.id		usb 0x0880
++device.name		HyperFIDO
+
+ vendor.id		usb 0x2cd9
++vendor.name		Cambrionix Ltd
+
+ vendor.id		usb 0x2cd9
+&device.id		usb 0x0804
++device.name		PowerSync4 USBPD Hub
+
  vendor.id		usb 0x2cdc
 +vendor.name		Sea & Sun Technology GmbH
 
@@ -75609,15 +86051,302 @@
 &device.id		usb 0xf232
 +device.name		CTD48Mc CTD Probe
 
+ vendor.id		usb 0x2ce5
++vendor.name		InX8 Inc [AKiTiO]
+
+ vendor.id		usb 0x2ce5
+&device.id		usb 0x0014
++device.name		Mass Storage [NT2 U31C]
+
+ vendor.id		usb 0x2cf0
++vendor.name		Nuand LLC
+
+ vendor.id		usb 0x2cf0
+&device.id		usb 0x5246
++device.name		bladeRF
+
+ vendor.id		usb 0x2cf0
+&device.id		usb 0x5250
++device.name		bladeRF 2.0 micro
+
+ vendor.id		usb 0x2d1f
++vendor.name		Wacom Taiwan Information Co. Ltd.
+
+ vendor.id		usb 0x2d25
++vendor.name		Kronegger GmbH.
+
+ vendor.id		usb 0x2d2d
++vendor.name		proxmark.org
+
+ vendor.id		usb 0x2d2d
+&device.id		usb 0x504d
++device.name		Proxmark3
+
+ vendor.id		usb 0x2d37
++vendor.name		Zhuhai Poskey Technology Co.,Ltd
+
+ vendor.id		usb 0x2d6b
++vendor.name		NetUP Inc.
+
+ vendor.id		usb 0x2d6b
+&device.id		usb 0x7777
++device.name		Joker TV universal DTV receiver
+
+ vendor.id		usb 0x2d81
++vendor.name		Evollve Inc.
+
+ vendor.id		usb 0x2d81
+&device.id		usb 0x4f01
++device.name		Ozobot Evo
+
+ vendor.id		usb 0x2d84
++vendor.name		Zhuhai Poskey Technology Co.,Ltd
+
+ vendor.id		usb 0x2d84
+&device.id		usb 0xb806
++device.name		DT-108B Thermal Label Printer
+
+ vendor.id		usb 0x2dc8
++vendor.name		8BitDo
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0x5006
++device.name		M30 Bluetooth gamepad
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0x5750
++device.name		Bootloader
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0x6000
++device.name		SF30 Pro gamepad
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0x6001
++device.name		SN30/SF30 Pro gamepad
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0xab11
++device.name		F30 gamepad
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0xab12
++device.name		N30 gamepad
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0xab20
++device.name		SN30/SF30 gamepad
+
+ vendor.id		usb 0x2dc8
+&device.id		usb 0xab21
++device.name		SF30 gamepad
+
  vendor.id		usb 0x2dcf
 +vendor.name		Dialog Semiconductor
+
+ vendor.id		usb 0x2dcf
+&device.id		usb 0xc951
++device.name		Audio Class 1.0 Devices
 
  vendor.id		usb 0x2dcf
 &device.id		usb 0xc952
 +device.name		Audio Class 2.0 Devices
 
+ vendor.id		usb 0x2def
++vendor.name		Kirale Technologies
+
+ vendor.id		usb 0x2def
+&device.id		usb 0x0000
++device.name		KiNOS Boot DFU
+
+ vendor.id		usb 0x2def
+&device.id		usb 0x0102
++device.name		KTWM102 Module
+
+ vendor.id		usb 0x2df2
++vendor.name		LIPS Corporation
+
+ vendor.id		usb 0x2df2
+&device.id		usb 0x0213
++device.name		LIPSedge DL 3D ToF Camera
+
+ vendor.id		usb 0x2df2
+&device.id		usb 0x0215
++device.name		LIPSedge DL RGB Camera
+
+ vendor.id		usb 0x2df2
+&device.id		usb 0x2102
++device.name		LIPSedge 5 Megapixel RGB Camera
+
+ vendor.id		usb 0x2e04
++vendor.name		HMD Global
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0x0001
++device.name		Nokia 3310 3G
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0x0002
++device.name		Nokia 3310 3G
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0x0a14
++device.name		Nokia 3310 3G
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0xc008
++device.name		Tethering Network Interface
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0xc009
++device.name		Nokia 1 (bootloader)
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0xc025
++device.name		Nokia 8 (MTP mode)
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0xc026
++device.name		Nokia Smartphone
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0xc029
++device.name		Nokia 8 (PTP mode)
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0xc031
++device.name		Nokia 1 (PTP)
+
+ vendor.id		usb 0x2e04
+&device.id		usb 0xc03f
++device.name		Nokia 8 (MIDI mode)
+
+ vendor.id		usb 0x2e0e
++vendor.name		Hatteland Display AS
+
+ vendor.id		usb 0x2e0e
+&device.id		usb 0x0001
++device.name		CAN Gateway
+
+ vendor.id		usb 0x2e24
++vendor.name		Hyperkin
+
+ vendor.id		usb 0x2e24
+&device.id		usb 0x0652
++device.name		Duke Xbox One controller
+
+ vendor.id		usb 0x2e24
+&device.id		usb 0x1688
++device.name		X91 Xbox One controller
+
+ vendor.id		usb 0x2e3b
++vendor.name		uSens Inc.
+
+ vendor.id		usb 0x2e57
++vendor.name		MEGWARE Computer Vertrieb und Service GmbH
+
+ vendor.id		usb 0x2e57
+&device.id		usb 0x454d
++device.name		SlideSX EnergyMeter
+
+ vendor.id		usb 0x2e57
+&device.id		usb 0x454e
++device.name		SlideSX EnergyMeter DFU
+
+ vendor.id		usb 0x2e57
+&device.id		usb 0x5cba
++device.name		SlideSX / ClustSafe Bus Adapter
+
+ vendor.id		usb 0x2e69
++vendor.name		Swift Navigation
+
+ vendor.id		usb 0x2e69
+&device.id		usb 0x1001
++device.name		Piksi Multi
+
+ vendor.id		usb 0x2e95
++vendor.name		SCUF Gaming
+
+ vendor.id		usb 0x2e95
+&device.id		usb 0x7725
++device.name		Controller
+
+ vendor.id		usb 0x2f76
++vendor.name		KeyXentic Inc.
+
+ vendor.id		usb 0x2f76
+&device.id		usb 0x0905
++device.name		KX905 Smart Terminal
+
+ vendor.id		usb 0x2f76
+&device.id		usb 0x0906
++device.name		KX906 Smart Card Reader
+
+ vendor.id		usb 0x2f76
+&device.id		usb 0x1906
++device.name		KX906 Smart Token (Mass Storage)
+
+ vendor.id		usb 0x2fad
++vendor.name		Definium Technologies
+
+ vendor.id		usb 0x2fb0
++vendor.name		Infocrypt
+
  vendor.id		usb 0x2fb2
 +vendor.name		Fujitsu, Ltd
+
+ vendor.id		usb 0x2fc0
++vendor.name		Sensidyne, LP
+
+ vendor.id		usb 0x2fc0
+&device.id		usb 0x0001
++device.name		Project Archer
+
+ vendor.id		usb 0x2fc6
++vendor.name		Comtrue Inc.
+
+ vendor.id		usb 0x2fc6
+&device.id		usb 0x6012
++device.name		UAC2 Device GB
+
+ vendor.id		usb 0x2fe0
++vendor.name		Xaptum, Inc.
+
+ vendor.id		usb 0x2fe0
+&device.id		usb 0x8b01
++device.name		XAP-RC-001 ENF Router Card
+
+ vendor.id		usb 0x2fe0
+&device.id		usb 0x8b02
++device.name		XAP-RW-001 ENF Router Card with WiFi
+
+ vendor.id		usb 0x2fe0
+&device.id		usb 0x8bde
++device.name		XAP-EA-002 ENF Access Card
+
+ vendor.id		usb 0x2fe0
+&device.id		usb 0x8bee
++device.name		XAP-EA-003 ENF Access Card
+
+ vendor.id		usb 0x2fe3
++vendor.name		NordicSemiconductor
+
+ vendor.id		usb 0x2fe7
++vendor.name		ELGIN S.A.
+
+ vendor.id		usb 0x2fe7
+&device.id		usb 0x0001
++device.name		SMART S@T
+
+ vendor.id		usb 0x2feb
++vendor.name		Beijing Veikk E-Commerce Co., Ltd.
+
+ vendor.id		usb 0x2feb
+&device.id		usb 0x0004
++device.name		Veikk A15 Pen Tablet
+
+ vendor.id		usb 0x2ff4
++vendor.name		Quixant Plc
 
  vendor.id		usb 0x3016
 +vendor.name		Boundary Devices, LLC
@@ -75625,6 +86354,158 @@
  vendor.id		usb 0x3016
 &device.id		usb 0x0001
 +device.name		Nitrogen Bootloader
+
+ vendor.id		usb 0x3036
++vendor.name		Control iD
+
+ vendor.id		usb 0x3036
+&device.id		usb 0x0001
++device.name		Print iD
+
+ vendor.id		usb 0x3036
+&device.id		usb 0x0002
++device.name		iDBio
+
+ vendor.id		usb 0x3037
++vendor.name		Beijing Chushifengmang Technology Development Co.,Ltd.
+
+ vendor.id		usb 0x3057
++vendor.name		Kingsis Corporation
+
+ vendor.id		usb 0x3057
+&device.id		usb 0x0002
++device.name		ZOWIE Gaming mouse
+
+ vendor.id		usb 0x308f
++vendor.name		Input Club
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0000
++device.name		Infinity 60% Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0001
++device.name		Infinity 60% - Standard
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0002
++device.name		Infinity 60% - Hacker
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0003
++device.name		Infinity Ergodox Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0004
++device.name		Infinity Ergodox
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0005
++device.name		WhiteFox Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0006
++device.name		WhiteFox - Vanilla
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0007
++device.name		WhiteFox - ISO
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0008
++device.name		WhiteFox - Aria
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0009
++device.name		WhiteFox - Winkeyless
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x000a
++device.name		WhiteFox - True Fox
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x000b
++device.name		WhiteFox - Jack of All Trades
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x000c
++device.name		Infinity 60% LED Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x000d
++device.name		Infinity 60% LED - Standard
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x000e
++device.name		Infinity 60% LED - Hacker
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x000f
++device.name		Infinity 60% LED - Alphabet
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0010
++device.name		K-Type Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0011
++device.name		K-Type
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0012
++device.name		Kira Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0013
++device.name		Kira
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0014
++device.name		Gemini Dawn/Dusk Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0015
++device.name		Gemini Dawn/Dusk
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0016
++device.name		Re:Type Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0017
++device.name		Re:Type
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0018
++device.name		Re:Type USB Hub
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x0019
++device.name		WhiteFox (SAM4S) Bootloader
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x001a
++device.name		WhiteFox (SAM4S) - Vanilla
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x001b
++device.name		WhiteFox (SAM4S) - ISO
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x001c
++device.name		WhiteFox (SAM4S) - Aria
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x001d
++device.name		WhiteFox (SAM4S) - Winkeyless
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x001e
++device.name		WhiteFox (SAM4S) - True Fox
+
+ vendor.id		usb 0x308f
+&device.id		usb 0x001f
++device.name		WhiteFox (SAM4S) - Jack of All Trades
 
  vendor.id		usb 0x30a4
 +vendor.name		Blues Wireless
@@ -75650,6 +86531,35 @@
 &device.id		usb 0x1001
 +device.name		F-01L
 
+ vendor.id		usb 0x30f2
++vendor.name		Varex Imaging
+
+ vendor.id		usb 0x3111
++vendor.name		Hiperscan GmbH
+
+ vendor.id		usb 0x3111
+&device.id		usb 0x0000
++device.name		SGS-NT Microspectrometer
+
+ vendor.id		usb 0x3112
++vendor.name		Meteca SA
+
+ vendor.id		usb 0x3112
+&device.id		usb 0x0001
++device.name		MBC-WB01 (CDC-ACM)
+
+ vendor.id		usb 0x3112
+&device.id		usb 0x0002
++device.name		MBC-WB01 (Bootloader)
+
+ vendor.id		usb 0x3112
+&device.id		usb 0x0003
++device.name		ABC (CDC ACM)
+
+ vendor.id		usb 0x3112
+&device.id		usb 0x0004
++device.name		ABC (Bootloader)
+
  vendor.id		usb 0x3125
 +vendor.name		Eagletron
 
@@ -75659,6 +86569,52 @@
 
  vendor.id		usb 0x3136
 +vendor.name		Navini Networks
+
+ vendor.id		usb 0x3145
++vendor.name		SafeLogic Inc.
+
+ vendor.id		usb 0x3147
++vendor.name		Tanvas, Inc.
+
+ vendor.id		usb 0x316c
++vendor.name		SigmaSense, LLC
+
+ vendor.id		usb 0x316d
++vendor.name		Purism, SPC
+
+ vendor.id		usb 0x316d
+&device.id		usb 0x4c4b
++device.name		Librem Key
+
+ vendor.id		usb 0x316e
++vendor.name		SPECINFOSYSTEMS
+
+ vendor.id		usb 0x316e
+&device.id		usb 0x0001
++device.name		DIAMOND token
+
+ vendor.id		usb 0x3171
++vendor.name		8086 Consultancy
+
+ vendor.id		usb 0x3171
+&device.id		usb 0x0011
++device.name		ClusterCTRL DA
+
+ vendor.id		usb 0x3171
+&device.id		usb 0x0012
++device.name		ClusterCTRL pHAT
+
+ vendor.id		usb 0x3171
+&device.id		usb 0x0013
++device.name		ClusterCTRL A+6
+
+ vendor.id		usb 0x3171
+&device.id		usb 0x0014
++device.name		ClusterCTRL Triple
+
+ vendor.id		usb 0x3171
+&device.id		usb 0x0015
++device.name		ClusterCTRL Single
 
  vendor.id		usb 0x3176
 +vendor.name		Whanam Electronics Co., Ltd
@@ -75678,12 +86634,87 @@
 &device.id		usb 0xf281
 +device.name		MSO-28
 
+ vendor.id		usb 0x31c9
++vendor.name		BeiJing LanXum Computer Technology Co., Ltd.
+
+ vendor.id		usb 0x31c9
+&device.id		usb 0x1001
++device.name		Printer
+
+ vendor.id		usb 0x31c9
+&device.id		usb 0x1301
++device.name		Black and White Laser Printer
+
+ vendor.id		usb 0x31c9
+&device.id		usb 0x1501
++device.name		LaserPrint GA50 series
+
+ vendor.id		usb 0x3200
++vendor.name		Alcatel-Lucent Enterprise
+
+ vendor.id		usb 0x3200
+&device.id		usb 0x2100
++device.name		ALE 8058s
+
+ vendor.id		usb 0x3200
+&device.id		usb 0x2101
++device.name		ALE 8068s
+
+ vendor.id		usb 0x3200
+&device.id		usb 0x2102
++device.name		8078s
+
+ vendor.id		usb 0x3219
++vendor.name		Smak Tecnologia e Automacao LTDA
+
+ vendor.id		usb 0x3219
+&device.id		usb 0x0044
++device.name		SKO44 Optical Keyboard
+
+ vendor.id		usb 0x321c
++vendor.name		Premio, Inc.
+
+ vendor.id		usb 0x324c
++vendor.name		CUPRIS Ltd.
+
+ vendor.id		usb 0x326d
++vendor.name		Agile Display Solutions Co., Ltd
+
+ vendor.id		usb 0x326d
+&device.id		usb 0x0001
++device.name		Avocor USB Camera
+
  vendor.id		usb 0x3275
 +vendor.name		VidzMedia Pte Ltd
 
  vendor.id		usb 0x3275
 &device.id		usb 0x4fb1
 +device.name		MonsterTV P2H
+
+ vendor.id		usb 0x3293
++vendor.name		Unhuman Inc.
+
+ vendor.id		usb 0x32b3
++vendor.name		TEXA
+
+ vendor.id		usb 0x32b3
+&device.id		usb 0xd1a6
++device.name		TXT Multihub
+
+ vendor.id		usb 0x32b3
+&device.id		usb 0xd1a7
++device.name		TXT Multihub
+
+ vendor.id		usb 0x3310
++vendor.name		MUDITA Sp. z o.o.
+
+ vendor.id		usb 0x3310
+&device.id		usb 0x0100
++device.name		Pure
+
+ vendor.id		usb 0x3310
+&device.id		usb 0x0101
++device.name		Pure tethering
 
  vendor.id		usb 0x3333
 +vendor.name		InLine
@@ -75714,12 +86745,34 @@
 &device.id		usb 0xa0a3
 +device.name		deltaX 5 BT (D) PDA
 
+ vendor.id		usb 0x3340
+&device.id		usb 0xffff
++device.name		Mio DigiWalker Sync
+
  vendor.id		usb 0x3344
 +vendor.name		Leaguer Microelectronics (LME)
 
  vendor.id		usb 0x3344
 &device.id		usb 0x3744
 +device.name		OEM PC Remote
+
+ vendor.id		usb 0x3384
++vendor.name		System76
+
+ vendor.id		usb 0x3384
+&device.id		usb 0x0000
++device.name		Thelio Io (thelio-io)
+
+ vendor.id		usb 0x3384
+&device.id		usb 0x0001
++device.name		Launch Configurable Keyboard (launch_1)
+
+ vendor.id		usb 0x348f
++vendor.name		ISY
+
+ vendor.id		usb 0x348f
+&device.id		usb 0x2322
++device.name		Wireless Presenter
 
  vendor.id		usb 0x3504
 +vendor.name		Micro Star
@@ -75751,6 +86804,10 @@
 &device.id		usb 0x0054
 +device.name		Flash Drive (2GB)
 
+ vendor.id		usb 0x3538
+&device.id		usb 0x0901
++device.name		Traveling Disk U273 (4GB)
+
  vendor.id		usb 0x3579
 +vendor.name		DIVA
 
@@ -75763,10 +86820,17 @@
 
  vendor.id		usb 0x357d
 &device.id		usb 0x7788
-+device.name		QuickPort XT
++device.name		JMicron JMS567 ATA/ATAPI Bridge
 
  vendor.id		usb 0x3636
 +vendor.name		InVibro
+
+ vendor.id		usb 0x3767
++vendor.name		Fanatec
+
+ vendor.id		usb 0x3767
+&device.id		usb 0x0101
++device.name		Speedster 3 Forceshock Wheel
 
  vendor.id		usb 0x3838
 +vendor.name		WEM
@@ -75774,6 +86838,10 @@
  vendor.id		usb 0x3838
 &device.id		usb 0x0001
 +device.name		5-in-1 Card Reader
+
+ vendor.id		usb 0x3838
+&device.id		usb 0x1031
++device.name		2.4G Wireless Mouse
 
  vendor.id		usb 0x3923
 +vendor.name		National Instruments Corp.
@@ -75843,8 +86911,12 @@
 +device.name		DAQPad-6052E
 
  vendor.id		usb 0x3923
-&device.id		usb 0x702b
+&device.id		usb 0x702a
 +device.name		GPIB-USB-B
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x702b
++device.name		GPIB-USB-B Initialization
 
  vendor.id		usb 0x3923
 &device.id		usb 0x703c
@@ -75855,12 +86927,80 @@
 +device.name		GPIB-USB-HS
 
  vendor.id		usb 0x3923
+&device.id		usb 0x7166
++device.name		USB-8451
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x716e
++device.name		USB-8451 Firmware Loader
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x717a
++device.name		USB-6008
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x717b
++device.name		USB-6009
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x71d6
++device.name		USB-6008 OEM
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x71d7
++device.name		USB-6009 OEM
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x71d8
++device.name		USB-6009 OEM
+
+ vendor.id		usb 0x3923
 &device.id		usb 0x7254
 +device.name		NI MIO (data acquisition card) firmware updater
 
  vendor.id		usb 0x3923
 &device.id		usb 0x729e
 +device.name		USB-6251 (OEM) data acquisition card
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x7346
++device.name		USB-6229
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x755b
++device.name		myDAQ
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76af
++device.name		USB-6000
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76b0
++device.name		USB-6000 OEM
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76bf
++device.name		USB-6001
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76c0
++device.name		USB-6001 OEM
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76c4
++device.name		USB-6002
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76c5
++device.name		USB-6002 OEM
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76c6
++device.name		USB-6003
+
+ vendor.id		usb 0x3923
+&device.id		usb 0x76c7
++device.name		USB-6003 OEM
 
  vendor.id		usb 0x40bb
 +vendor.name		I-O Data
@@ -76008,7 +87148,7 @@
 
  vendor.id		usb 0x413c
 &device.id		usb 0x2003
-+device.name		Keyboard
++device.name		Keyboard SK-8115
 
  vendor.id		usb 0x413c
 &device.id		usb 0x2005
@@ -76028,7 +87168,7 @@
 
  vendor.id		usb 0x413c
 &device.id		usb 0x2101
-+device.name		SmartCard Reader Keyboard
++device.name		SK-3205 SmartCard Reader Keyboard
 
  vendor.id		usb 0x413c
 &device.id		usb 0x2105
@@ -76036,11 +87176,31 @@
 
  vendor.id		usb 0x413c
 &device.id		usb 0x2106
-+device.name		Dell QuietKey Keyboard
++device.name		QuietKey Keyboard
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x2107
++device.name		KB212-B Quiet Key Keyboard
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x2113
++device.name		KB216 Wired Keyboard
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x2134
++device.name		Hub of E-Port Replicator
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x21d7
++device.name		Dell Wireless 5560 HSPA+ Mobile Broadband Modem
 
  vendor.id		usb 0x413c
 &device.id		usb 0x2500
 +device.name		DRAC4 Remote Access Card
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x2501
++device.name		Keyboard and mouse dongle
 
  vendor.id		usb 0x413c
 &device.id		usb 0x2513
@@ -76057,6 +87217,14 @@
  vendor.id		usb 0x413c
 &device.id		usb 0x3016
 +device.name		Optical 5-Button Wheel Mouse
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x301a
++device.name		Dell MS116 Optical Mouse
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x301b
++device.name		Universal Bluetooth Receiver
 
  vendor.id		usb 0x413c
 &device.id		usb 0x3200
@@ -76163,6 +87331,10 @@
 +device.name		Photo AIO 928
 
  vendor.id		usb 0x413c
+&device.id		usb 0x5133
++device.name		968 AIO Printer
+
+ vendor.id		usb 0x413c
 &device.id		usb 0x5200
 +device.name		Laser Printer
 
@@ -76195,6 +87367,10 @@
 +device.name		Printing Support
 
  vendor.id		usb 0x413c
+&device.id		usb 0x5228
++device.name		Laser Printer 1720dn
+
+ vendor.id		usb 0x413c
 &device.id		usb 0x5300
 +device.name		Laser Printer
 
@@ -76207,8 +87383,16 @@
 +device.name		Laser Printer
 
  vendor.id		usb 0x413c
+&device.id		usb 0x5404
++device.name		1250c Color Printer
+
+ vendor.id		usb 0x413c
 &device.id		usb 0x5513
 +device.name		WLA3310 Wireless Adapter [Intersil ISL3887]
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x5534
++device.name		Hub of E-Port Replicator
 
  vendor.id		usb 0x413c
 &device.id		usb 0x5601
@@ -76219,8 +87403,16 @@
 +device.name		Laser Printer 3000cn
 
  vendor.id		usb 0x413c
+&device.id		usb 0x5607
++device.name		MFP Color Laser Printer 3115cn
+
+ vendor.id		usb 0x413c
 &device.id		usb 0x5631
 +device.name		Laser Printer 5100cn
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x564a
++device.name		C1765 series Multifunction Color LaserPrinter, Scanner & Copier
 
  vendor.id		usb 0x413c
 &device.id		usb 0x5905
@@ -76359,6 +87551,10 @@
 +device.name		Mobile 360 in DFU
 
  vendor.id		usb 0x413c
+&device.id		usb 0x8143
++device.name		Broadcom BCM20702A0 Bluetooth
+
+ vendor.id		usb 0x413c
 &device.id		usb 0x8147
 +device.name		F3507g Mobile Broadband Module
 
@@ -76415,8 +87611,36 @@
 +device.name		DW375 Bluetooth Module
 
  vendor.id		usb 0x413c
+&device.id		usb 0x818e
++device.name		DW5560 miniPCIe HSPA+ Mobile Broadband Modem
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x8197
++device.name		BCM20702A0 Bluetooth Module
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x81a0
++device.name		Wireless 5808 Mobile Broadband (Sierra Wireless MC7355 Mini PCIE, 4G UMTS,HSDPA,HSPA+,LTE,1xRTT,EVDO Rev A,GSM,GPRS)
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x81a3
++device.name		Hub of E-Port Replicator
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x81a8
++device.name		Wireless 5808 Mobile Broadband (Sierra Wireless Mini PCIE, 4G UMTS,HSDPA,HSPA+,LTE,1xRTT,EVDO Rev A,GSM,GPRS)
+
+ vendor.id		usb 0x413c
 &device.id		usb 0x8501
 +device.name		Bluetooth Adapter
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x9001
++device.name		ATA Bridge
+
+ vendor.id		usb 0x413c
+&device.id		usb 0x9009
++device.name		Portable Device
 
  vendor.id		usb 0x413c
 &device.id		usb 0x9500
@@ -76431,8 +87655,24 @@
 +device.name		Internal 2.0 Hub
 
  vendor.id		usb 0x413c
+&device.id		usb 0xa101
++device.name		Internal Dual SD Card module
+
+ vendor.id		usb 0x413c
+&device.id		usb 0xa102
++device.name		iDRAC Virtual NIC
+
+ vendor.id		usb 0x413c
+&device.id		usb 0xa503
++device.name		AC511 Sound Bar
+
+ vendor.id		usb 0x413c
 &device.id		usb 0xa700
 +device.name		Hub (in 1905FP LCD Monitor)
+
+ vendor.id		usb 0x413c
+&device.id		usb 0xb007
++device.name		Streak 5 Android Tablet
 
  vendor.id		usb 0x4146
 +vendor.name		USBest Technology
@@ -76493,12 +87733,16 @@
 &device.id		usb 0x0720
 +device.name		Dynex DX-BUSB
 
+ vendor.id		usb 0x4317
+&device.id		usb 0x0721
++device.name		Dynex DX-EBUSB
+
  vendor.id		usb 0x4348
 +vendor.name		WinChipHead
 
  vendor.id		usb 0x4348
 &device.id		usb 0x5523
-+device.name		USB->RS 232 adapter with Prolifec PL 2303 chipset
++device.name		USB->RS 232 adapter with Prolific PL 2303 chipset
 
  vendor.id		usb 0x4348
 &device.id		usb 0x5537
@@ -76528,6 +87772,9 @@
  vendor.id		usb 0x4670
 &device.id		usb 0x9394
 +device.name		Game Cube USB Memory Adaptor 64M
+
+ vendor.id		usb 0x46f4
++vendor.name		QEMU
 
  vendor.id		usb 0x4752
 +vendor.name		Miditech
@@ -76565,12 +87812,52 @@
 +vendor.name		SimpleTech
 
  vendor.id		usb 0x4971
+&device.id		usb 0x1004
++device.name		Hitachi LifeStudio Desk (3.5" HDD) [w/o flash key]
+
+ vendor.id		usb 0x4971
+&device.id		usb 0x1013
++device.name		Touro Desk Pro
+
+ vendor.id		usb 0x4971
+&device.id		usb 0x1015
++device.name		Touro Desk 3.0
+
+ vendor.id		usb 0x4971
+&device.id		usb 0x8001
++device.name		G-Tech G-DRIVE Mobile
+
+ vendor.id		usb 0x4971
 &device.id		usb 0xcb01
 +device.name		SP-U25/120G
 
  vendor.id		usb 0x4971
+&device.id		usb 0xcd15
++device.name		Simple Drive Mini (2.5" HDD)
+
+ vendor.id		usb 0x4971
+&device.id		usb 0xce07
++device.name		SimpleDrive (3.5" HDD)
+
+ vendor.id		usb 0x4971
+&device.id		usb 0xce12
++device.name		FV-U35
+
+ vendor.id		usb 0x4971
 &device.id		usb 0xce17
 +device.name		1TB SimpleDrive II USB External Hard Drive
+
+ vendor.id		usb 0x4971
+&device.id		usb 0xce18
++device.name		(re)Drive
+
+ vendor.id		usb 0x4971
+&device.id		usb 0xce21
++device.name		JMicron JM20329 SATA Bridge [eg. HITACHI SimpleDrive mini]
+
+ vendor.id		usb 0x4971
+&device.id		usb 0xce22
++device.name		Hitachi SimpleTough (3.5" HDD)
 
  vendor.id		usb 0x4d46
 +vendor.name		Musical Fidelity
@@ -76602,23 +87889,19 @@
 &device.id		usb 0x0fa1
 +device.name		Grandtec USB1.1 DVB-T (warm)
 
- vendor.id		usb 0x5041
-+vendor.name		Linksys (?)
-
- vendor.id		usb 0x5041
-&device.id		usb 0x2234
-+device.name		WUSB54G v1 802.11g Adapter [Intersil ISL3886]
-
- vendor.id		usb 0x5041
-&device.id		usb 0x2235
-+device.name		WUSB54GP v1 802.11g Adapter [Intersil ISL3886]
-
  vendor.id		usb 0x50c2
 +vendor.name		Averatec (?)
 
  vendor.id		usb 0x50c2
 &device.id		usb 0x4013
 +device.name		WLAN Adapter
+
+ vendor.id		usb 0x5131
++vendor.name		MSR
+
+ vendor.id		usb 0x5131
+&device.id		usb 0x2007
++device.name		MSR-101U Mini HID magnetic card reader
 
  vendor.id		usb 0x5173
 +vendor.name		Sweex
@@ -76634,6 +87917,13 @@
 &device.id		usb 0x1001
 +device.name		Cetus CDC Device
 
+ vendor.id		usb 0x5332
++vendor.name		Clearly Superior Technologies, Inc.
+
+ vendor.id		usb 0x5332
+&device.id		usb 0x1300
++device.name		CST2545-5W (L-Trac)
+
  vendor.id		usb 0x5345
 +vendor.name		Owon
 
@@ -76647,6 +87937,21 @@
  vendor.id		usb 0x534c
 &device.id		usb 0x0001
 +device.name		Bitcoin Wallet [TREZOR]
+
+ vendor.id		usb 0x534c
+&device.id		usb 0x0002
++device.name		Bitcoin Wallet [TREZOR v2]
+
+ vendor.id		usb 0x534d
++vendor.name		MacroSilicon
+
+ vendor.id		usb 0x534d
+&device.id		usb 0x0021
++device.name		MS210x Video Grabber [EasierCAP]
+
+ vendor.id		usb 0x534d
+&device.id		usb 0x6021
++device.name		VGA Display Adapter
 
  vendor.id		usb 0x5354
 +vendor.name		Meyer Instruments (MIS)
@@ -76686,8 +87991,20 @@
 +device.name		Tablet PF1209
 
  vendor.id		usb 0x5543
+&device.id		usb 0x004a
++device.name		XP-Pen Artist 10S tablet
+
+ vendor.id		usb 0x5543
+&device.id		usb 0x004d
++device.name		Tablet Monitor MSP19U
+
+ vendor.id		usb 0x5543
 &device.id		usb 0x0064
 +device.name		Aiptek HyperPen 10000U
+
+ vendor.id		usb 0x5543
+&device.id		usb 0x3031
++device.name		Graphics tablet [DrawImage G3, Ugee G3]
 
  vendor.id		usb 0x5555
 +vendor.name		Epiphan Systems Inc.
@@ -76727,6 +88044,22 @@
  vendor.id		usb 0x5555
 &device.id		usb 0x3422
 +device.name		DVI2USB Duo
+
+ vendor.id		usb 0x5555
+&device.id		usb 0x3500
++device.name		DVI2USB3
+
+ vendor.id		usb 0x5555
+&device.id		usb 0x3501
++device.name		DVI2USB3 Rev3
+
+ vendor.id		usb 0x5555
+&device.id		usb 0x3510
++device.name		DVI2USB3_ET
+
+ vendor.id		usb 0x5555
+&device.id		usb 0x3520
++device.name		SDI2USB3
 
  vendor.id		usb 0x55aa
 +vendor.name		OnSpec Electronic, Inc.
@@ -76824,6 +88157,22 @@
 +device.name		Crystal Eye Webcam
 
  vendor.id		usb 0x5986
+&device.id		usb 0x0137
++device.name		HP Webcam
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0141
++device.name		BisonCam, NB Pro
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0149
++device.name		HP Webcam-101
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x014c
++device.name		MSI Integrated Webcam
+
+ vendor.id		usb 0x5986
 &device.id		usb 0x01a6
 +device.name		Lenovo Integrated Webcam
 
@@ -76840,20 +88189,112 @@
 +device.name		OrbiCam
 
  vendor.id		usb 0x5986
+&device.id		usb 0x0202
++device.name		Fujitsu Webcam
+
+ vendor.id		usb 0x5986
 &device.id		usb 0x0203
 +device.name		BisonCam NB Pro 1300
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0205
++device.name		Lenovo EasyCamera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0217
++device.name		Integrated Webcam
 
  vendor.id		usb 0x5986
 &device.id		usb 0x0241
 +device.name		BisonCam, NB Pro
 
  vendor.id		usb 0x5986
+&device.id		usb 0x0268
++device.name		SunplusIT INC. Integrated Camera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x026a
++device.name		Integrated Camera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0292
++device.name		Lenovo Integrated Webcam
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0294
++device.name		Lenovo Integrated Webcam
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0295
++device.name		Lenovo Integrated Webcam
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0299
++device.name		Lenovo Integrated Webcam
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x029c
++device.name		Lenovo EasyCamera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x02ac
++device.name		HP TrueVision HD Webcam
+
+ vendor.id		usb 0x5986
 &device.id		usb 0x02d0
 +device.name		Lenovo Integrated Webcam [R5U877]
 
  vendor.id		usb 0x5986
+&device.id		usb 0x02d2
++device.name		ThinkPad Integrated Camera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x02d5
++device.name		Integrated Camera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x03b3
++device.name		Lenovo Integrated Webcam
+
+ vendor.id		usb 0x5986
 &device.id		usb 0x03d0
 +device.name		Lenovo Integrated Webcam [R5U877]
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0400
++device.name		BisonCam, NB Pro
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0535
++device.name		Lenovo EasyCamera integrated webcam
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x055a
++device.name		Lenovo Integrated Webcam
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0652
++device.name		Lenovo EasyCamera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0670
++device.name		Lenovo EasyCamera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0671
++device.name		Lenovo EasyCamera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x0706
++device.name		ThinkPad P50 Integrated Camera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0x2113
++device.name		SunplusIT Integrated Camera
+
+ vendor.id		usb 0x5986
+&device.id		usb 0xa002
++device.name		Lenovo EasyCamera Integrated Webcam
 
  vendor.id		usb 0x59e3
 +vendor.name		Nonolith Labs
@@ -76883,7 +88324,7 @@
 
  vendor.id		usb 0x5a57
 &device.id		usb 0x0290
-+device.name		ZW-N290 802.11n [Realtek RTL8192SU]
++device.name		ZW-N290 802.11n [Realtek RTL8192U]
 
  vendor.id		usb 0x5a57
 &device.id		usb 0x5257
@@ -76891,6 +88332,10 @@
 
  vendor.id		usb 0x6000
 +vendor.name		Beholder International Ltd.
+
+ vendor.id		usb 0x6000
+&device.id		usb 0x0001
++device.name		Trident TVBOX Video Grabber
 
  vendor.id		usb 0x6000
 &device.id		usb 0xdec0
@@ -76907,12 +88352,23 @@
 &device.id		usb 0x4740
 +device.name		XBurst Jz4740 boot mode
 
+ vendor.id		usb 0x601a
+&device.id		usb 0x4760
++device.name		JZ4760 Boot Device
+
+ vendor.id		usb 0x6022
++vendor.name		Xektek
+
+ vendor.id		usb 0x6022
+&device.id		usb 0x0500
++device.name		SuperPro Universal Device Programmer
+
  vendor.id		usb 0x6189
 +vendor.name		Sitecom
 
  vendor.id		usb 0x6189
 &device.id		usb 0x182d
-+device.name		USB 2.0 Ethernet
++device.name		LN-029 10/100 Ethernet Adapter
 
  vendor.id		usb 0x6189
 &device.id		usb 0x2068
@@ -77033,6 +88489,62 @@
 &device.id		usb 0x0501
 +device.name		Touch Sensitive Intelligent Control Keypad STICK2B
 
+ vendor.id		usb 0x6244
+&device.id		usb 0x0520
++device.name		Touch Sensitive Intelligent Control Keypad (STICK2C Firmware download, 32/64bits
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0521
++device.name		Touch Sensitive Intelligent Control Keypad (STICK2C, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0540
++device.name		Sunlite Universal Smart Handy Interface (SUSHI1A Firmware download, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0541
++device.name		Sunlite Universal Smart Handy Interface (SUSHI1A, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0570
++device.name		Touch Sensitive Intelligent Control Keypad (STICK4A Firmware download, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0571
++device.name		Touch Sensitive Intelligent Control Keypad (STICK4A, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0580
++device.name		Touch Sensitive Intelligent Control Keypad (STICK5A Firmware download, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0581
++device.name		Touch Sensitive Intelligent Control Keypad (STICK5A, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0590
++device.name		Intelligent Dmx Interface (SIUDI9S Firmware Download, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0591
++device.name		Intelligent Dmx Interface (SIUDI9S, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0600
++device.name		Intelligent Dmx Interface (SIUDI9M Firmware Download, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0601
++device.name		Intelligent Dmx Interface (SIUDI9M, 32/64bits)
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0610
++device.name		Intelligent Dmx Interface SIUDI10A Firmware Download
+
+ vendor.id		usb 0x6244
+&device.id		usb 0x0611
++device.name		Intelligent Dmx Interface SIUDI10A
+
  vendor.id		usb 0x6253
 +vendor.name		TwinHan Technology Co., Ltd
 
@@ -77044,7 +88556,7 @@
 +vendor.name		CoreLogic, Inc.
 
  vendor.id		usb 0x6472
-+vendor.name		Unknown (Sony?)
++vendor.name		Sony Corp.
 
  vendor.id		usb 0x6472
 &device.id		usb 0x01c8
@@ -77057,6 +88569,17 @@
 &device.id		usb 0x0232
 +device.name		ARK3116 Serial
 
+ vendor.id		usb 0x6557
++vendor.name		Emtec
+
+ vendor.id		usb 0x6557
+&device.id		usb 0x5500
++device.name		Mass Storage Device
+
+ vendor.id		usb 0x6557
+&device.id		usb 0x8005
++device.name		Car Key
+
  vendor.id		usb 0x6615
 +vendor.name		IRTOUCHSYSTEMS Co. Ltd.
 
@@ -77064,12 +88587,28 @@
 &device.id		usb 0x0001
 +device.name		Touchscreen
 
+ vendor.id		usb 0x6615
+&device.id		usb 0x0020
++device.name		IRTOUCH InfraRed TouchScreen
+
+ vendor.id		usb 0x6615
+&device.id		usb 0x0081
++device.name		TouchScreen
+
  vendor.id		usb 0x6666
 +vendor.name		Prototype product Vendor ID
 
  vendor.id		usb 0x6666
 &device.id		usb 0x0667
 +device.name		WiseGroup Smart Joy PSX, PS-PC Smart JoyPad
+
+ vendor.id		usb 0x6666
+&device.id		usb 0x1c40
++device.name		TELEMIC 802.15.4 Sensor node (Bootloader)
+
+ vendor.id		usb 0x6666
+&device.id		usb 0x1c41
++device.name		TELEMIC 802.15.4 Sensor node
 
  vendor.id		usb 0x6666
 &device.id		usb 0x2667
@@ -77093,6 +88632,13 @@
  vendor.id		usb 0x6677
 &device.id		usb 0x8811
 +device.name		Deluxe Dance Mat
+
+ vendor.id		usb 0x675d
++vendor.name		Humanscale
+
+ vendor.id		usb 0x675d
+&device.id		usb 0x062a
++device.name		Switch Mouse
 
  vendor.id		usb 0x6891
 +vendor.name		3Com
@@ -77132,6 +88678,13 @@
 &device.id		usb 0x2149
 +device.name		EntropyKing Random Number Generator
 
+ vendor.id		usb 0x7302
++vendor.name		Solinftec
+
+ vendor.id		usb 0x7302
+&device.id		usb 0x0001
++device.name		HUB 4X232
+
  vendor.id		usb 0x734c
 +vendor.name		TBS Technologies China
 
@@ -77155,11 +88708,11 @@
 
  vendor.id		usb 0x7392
 &device.id		usb 0x7711
-+device.name		EW-7711UTn nLite Wireless Adapter [Ralink RT2870]
++device.name		EW-7711UTn nLite Wireless Adapter [Ralink RT3070]
 
  vendor.id		usb 0x7392
 &device.id		usb 0x7717
-+device.name		EW-7717UN 802.11n Wireless Adapter [Ralink RT2870]
++device.name		EW-7717UN 802.11n Wireless Adapter [Ralink RT2770]
 
  vendor.id		usb 0x7392
 &device.id		usb 0x7718
@@ -77167,11 +88720,119 @@
 
  vendor.id		usb 0x7392
 &device.id		usb 0x7722
-+device.name		EW-7722UTn 802.11n Wireless Adapter [Ralink RT307x]
++device.name		EW-7722UTn 802.11n Wireless Adapter [Ralink RT3072]
+
+ vendor.id		usb 0x7392
+&device.id		usb 0x7733
++device.name		EW-7733UnD 802.11abgn 3x3:3 [Ralink RT3573]
 
  vendor.id		usb 0x7392
 &device.id		usb 0x7811
 +device.name		EW-7811Un 802.11n Wireless Adapter [Realtek RTL8188CUS]
+
+ vendor.id		usb 0x7392
+&device.id		usb 0x7822
++device.name		EW-7612UAn V2 802.11n Wireless Adapter [Realtek RTL8192CU]
+
+ vendor.id		usb 0x7392
+&device.id		usb 0xa611
++device.name		EW-7611ULB 802.11b/g/n and Bluetooth 4.0 Adapter
+
+ vendor.id		usb 0x7392
+&device.id		usb 0xa711
++device.name		EW-7711MAC 802.11ac Wireless Adapter
+
+ vendor.id		usb 0x7392
+&device.id		usb 0xa811
++device.name		EW-7811UTC 802.11ac Wireless Adapter
+
+ vendor.id		usb 0x7392
+&device.id		usb 0xb711
++device.name		EW-7722UAC 802.11a/b/g/n/ac (2x2) Wireless Adapter [MediaTek MT7612U]
+
+ vendor.id		usb 0x7392
+&device.id		usb 0xb822
++device.name		EW-7822ULC 802.11ac Wireless Adapter [Realtek RTL8812AU]
+
+ vendor.id		usb 0x73d8
++vendor.name		Progeny Dental Equipment Specialists
+
+ vendor.id		usb 0x73d8
+&device.id		usb 0x0104
++device.name		VetPro DR, Size 1
+
+ vendor.id		usb 0x73d8
+&device.id		usb 0x0105
++device.name		VetPro DR, Size 2
+
+ vendor.id		usb 0x7669
++vendor.name		Venable Instruments
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x350c
++device.name		Model 350c, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x5140
++device.name		Model 5140, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x6305
++device.name		Model 6305, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x6320
++device.name		Model 6320, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x6340
++device.name		Model 6340, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x7405
++device.name		Model 7405, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x7420
++device.name		Model 7420, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x7440
++device.name		Model 7440, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x8805
++device.name		Model 8805, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x8820
++device.name		Model 8820, Frequency Response Analyzer
+
+ vendor.id		usb 0x7669
+&device.id		usb 0x8840
++device.name		Model 8840, Frequency Response Analyzer
+
+ vendor.id		usb 0x7825
++vendor.name		Other World Computing
+
+ vendor.id		usb 0x7825
+&device.id		usb 0xa2a4
++device.name		External SATA Hard Drive Adapter cable PA023U3
+
+ vendor.id		usb 0x7825
+&device.id		usb 0xb0b3
++device.name		miniStack MAX
+
+ vendor.id		usb 0x8070
++vendor.name		ACCES I/O Products, Inc.
+
+ vendor.id		usb 0x8070
+&device.id		usb 0x8003
++device.name		USB-DIO-96
+
+ vendor.id		usb 0x8070
+&device.id		usb 0x8070
++device.name		USB-AO16-16A
 
  vendor.id		usb 0x8086
 +vendor.name		Intel Corp.
@@ -77225,12 +88886,16 @@
 +device.name		WiMAX Connection 2400m
 
  vendor.id		usb 0x8086
+&device.id		usb 0x0189
++device.name		Centrino Advanced-N 6230 Bluetooth adapter
+
+ vendor.id		usb 0x8086
 &device.id		usb 0x0200
 +device.name		AnyPoint(TM) Wireless II Network 11Mbps Adapter [Atmel AT76C503A]
 
  vendor.id		usb 0x8086
 &device.id		usb 0x0431
-+device.name		Intel Pro Video PC Camera
++device.name		Pro Video PC Camera
 
  vendor.id		usb 0x8086
 &device.id		usb 0x0510
@@ -77247,6 +88912,14 @@
  vendor.id		usb 0x8086
 &device.id		usb 0x07d3
 +device.name		BLOB boot loader firmware
+
+ vendor.id		usb 0x8086
+&device.id		usb 0x07dc
++device.name		Bluetooth 4.0* Smart Ready (low energy)
+
+ vendor.id		usb 0x8086
+&device.id		usb 0x0b07
++device.name		RealSense D435
 
  vendor.id		usb 0x8086
 &device.id		usb 0x0dad
@@ -77271,6 +88944,10 @@
  vendor.id		usb 0x8086
 &device.id		usb 0x1111
 +device.name		PRO/Wireless 2011B 802.11b Adapter [Intersil PRISM 2.5]
+
+ vendor.id		usb 0x8086
+&device.id		usb 0x1122
++device.name		Integrated Hub
 
  vendor.id		usb 0x8086
 &device.id		usb 0x1134
@@ -77321,8 +88998,20 @@
 +device.name		Miniature Card Slot
 
  vendor.id		usb 0x8086
+&device.id		usb 0x8c26
++device.name		8 Series/C220 Series  EHCI #1
+
+ vendor.id		usb 0x8086
+&device.id		usb 0x8c2d
++device.name		8 Series/C220 Series EHCI #2
+
+ vendor.id		usb 0x8086
+&device.id		usb 0x8c31
++device.name		eXtensible Host Controller
+
+ vendor.id		usb 0x8086
 &device.id		usb 0x9303
-+device.name		Intel 8x930Hx Hub
++device.name		8x930Hx Hub
 
  vendor.id		usb 0x8086
 &device.id		usb 0x9500
@@ -77339,6 +89028,10 @@
  vendor.id		usb 0x8086
 &device.id		usb 0xc013
 +device.name		Wireless HID Station
+
+ vendor.id		usb 0x8086
+&device.id		usb 0xdead
++device.name		Galileo
 
  vendor.id		usb 0x8086
 &device.id		usb 0xf001
@@ -77359,12 +89052,84 @@
 &device.id		usb 0x0024
 +device.name		Integrated Rate Matching Hub
 
+ vendor.id		usb 0x8087
+&device.id		usb 0x0025
++device.name		Wireless-AC 9260 Bluetooth Adapter
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0029
++device.name		AX200 Bluetooth
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0716
++device.name		Modem Flashloader
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x07da
++device.name		Centrino Bluetooth Wireless Transceiver
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x07dc
++device.name		Bluetooth wireless interface
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x07eb
++device.name		Oaktrail tablet
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0a2a
++device.name		Bluetooth wireless interface
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0a2b
++device.name		Bluetooth wireless interface
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0a9e
++device.name		Edison
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0aa7
++device.name		Wireless-AC 3168 Bluetooth
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0aaa
++device.name		Bluetooth 9460/9560 Jefferson Peak (JfP)
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x0fff
++device.name		Intel Android Bootloader Interface
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x8000
++device.name		Integrated Rate Matching Hub
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x8001
++device.name		Integrated Hub
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x8002
++device.name		8 channel internal hub
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x8008
++device.name		Integrated Rate Matching Hub
+
+ vendor.id		usb 0x8087
+&device.id		usb 0x800a
++device.name		Hub
+
  vendor.id		usb 0x80ee
 +vendor.name		VirtualBox
 
  vendor.id		usb 0x80ee
 &device.id		usb 0x0021
 +device.name		USB Tablet
+
+ vendor.id		usb 0x80ee
+&device.id		usb 0x0022
++device.name		multitouch tablet
 
  vendor.id		usb 0x8282
 +vendor.name		Keio
@@ -77376,6 +89141,13 @@
  vendor.id		usb 0x8282
 &device.id		usb 0x3301
 +device.name		Retro Adapter Mouse
+
+ vendor.id		usb 0x8301
++vendor.name		Hapurs
+
+ vendor.id		usb 0x8301
+&device.id		usb 0x0089
++device.name		HPBT05R 2.4 G Mini Wireless Touchpad Keyboard
 
  vendor.id		usb 0x8341
 +vendor.name		EGO Systems, Inc.
@@ -77393,7 +89165,19 @@
 
  vendor.id		usb 0x8564
 &device.id		usb 0x4000
-+device.name		RDF8
++device.name		microSD/SD/CF UHS-II Card Reader [RDF8, RDF9]
+
+ vendor.id		usb 0x8564
+&device.id		usb 0x6000
++device.name		digital photo frame PF830
+
+ vendor.id		usb 0x8564
+&device.id		usb 0x6002
++device.name		digital photo frame PF830
+
+ vendor.id		usb 0x8564
+&device.id		usb 0x7000
++device.name		StoreJet 25H3
 
  vendor.id		usb 0x8644
 +vendor.name		Intenso GmbG
@@ -77412,6 +89196,13 @@
  vendor.id		usb 0x8e06
 &device.id		usb 0xf700
 +device.name		DT225 Trackball
+
+ vendor.id		usb 0x8ea3
++vendor.name		Doosl
+
+ vendor.id		usb 0x8ea3
+&device.id		usb 0xa02c
++device.name		Wireless Presenter Receiver
 
  vendor.id		usb 0x9016
 +vendor.name		Sitecom
@@ -77441,6 +89232,9 @@
  vendor.id		usb 0x9148
 &device.id		usb 0x0004
 +device.name		R3 Compatible Device
+
+ vendor.id		usb 0x9516
++vendor.name		Studiologic
 
  vendor.id		usb 0x9710
 +vendor.name		MosChip Semiconductor
@@ -77474,6 +89268,18 @@
 +device.name		MCS7780 4Mbps Fast IrDA Adapter
 
  vendor.id		usb 0x9710
+&device.id		usb 0x7784
++device.name		MCS7784 115.2Kb IrDA Adapter
+
+ vendor.id		usb 0x9710
+&device.id		usb 0x7810
++device.name		MCS7810 Serial Port Adapter
+
+ vendor.id		usb 0x9710
+&device.id		usb 0x7820
++device.name		MCS7820 Dual Serial Port Adapter
+
+ vendor.id		usb 0x9710
 &device.id		usb 0x7830
 +device.name		MCS7830 10/100 Mbps Ethernet adapter
 
@@ -77485,12 +89291,23 @@
 &device.id		usb 0x7840
 +device.name		MCS7820/MCS7840 2/4 port serial adapter
 
+ vendor.id		usb 0x9710
+&device.id		usb 0x9990
++device.name		MCS9990 PCIe Host Controller
+
  vendor.id		usb 0x9849
 +vendor.name		Bestmedia CD Recordable GmbH & Co. KG
 
  vendor.id		usb 0x9849
 &device.id		usb 0x0701
 +device.name		Platinum MyDrive HP
+
+ vendor.id		usb 0x9886
++vendor.name		Astro Gaming
+
+ vendor.id		usb 0x9886
+&device.id		usb 0x0015
++device.name		A50
 
  vendor.id		usb 0x9999
 +vendor.name		Odeon
@@ -77519,6 +89336,24 @@
  vendor.id		usb 0x9e88
 &device.id		usb 0x9e8f
 +device.name		Plug Computer Basic [SheevaPlug]
+
+ vendor.id		usb 0xa014
++vendor.name		Insignia (Best Buy)
+
+ vendor.id		usb 0xa014
+&device.id		usb 0xb014
++device.name		Desktop Microphone NS-PAUM50
+
+ vendor.id		usb 0xa108
++vendor.name		Ingenic Semiconductor Co.,Ltd
+
+ vendor.id		usb 0xa108
+&device.id		usb 0x1000
++device.name		X1000
+
+ vendor.id		usb 0xa108
+&device.id		usb 0x4775
++device.name		JZ4775 Boot Device
 
  vendor.id		usb 0xa128
 +vendor.name		AnMo Electronics Corp. / Dino-Lite (?)
@@ -77590,12 +89425,63 @@
 &device.id		usb 0x0618
 +device.name		Dino-Lite Digital Microscope
 
+ vendor.id		usb 0xa466
++vendor.name		Haikou Xingong Electronics Co.,Ltd
+
+ vendor.id		usb 0xa466
+&device.id		usb 0x0a53
++device.name		TL866II Plus Device Programmer [MiniPRO]
+
  vendor.id		usb 0xa600
-+vendor.name		Asix
++vendor.name		ASIX s.r.o.
+
+ vendor.id		usb 0xa600
+&device.id		usb 0x5500
++device.name		zuban H2OPS - GPS for canoeing
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xa000
++device.name		SIGMA Logic Analyzer
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xa002
++device.name		EMUSB interface pro MU Beta
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xc000
++device.name		MREL Data Trap II
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xc001
++device.name		VUTS DMU4
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xc002
++device.name		Electrone MASH
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xc005
++device.name		MREL HTU HandiTrap cable
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xc006
++device.name		JRC COmeter
 
  vendor.id		usb 0xa600
 &device.id		usb 0xe110
 +device.name		OK1ZIA Davac 4.x
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xe112
++device.name		OK1ZIA Antenna rotator
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xe113
++device.name		OK1ZIA GPIO
+
+ vendor.id		usb 0xa600
+&device.id		usb 0xe114
++device.name		OK1ZIA HD&Keyb
 
  vendor.id		usb 0xa727
 +vendor.name		3Com
@@ -77612,6 +89498,13 @@
 &device.id		usb 0x6897
 +device.name		AR5523
 
+ vendor.id		usb 0xa88a
++vendor.name		Clas Ohlsson
+
+ vendor.id		usb 0xa88a
+&device.id		usb 0x3003
++device.name		PCFree Multimedia Remote Control PC
+
  vendor.id		usb 0xaaaa
 +vendor.name		MXT
 
@@ -77619,8 +89512,27 @@
 &device.id		usb 0x8815
 +device.name		microSD CardReader
 
+ vendor.id		usb 0xaaaa
+&device.id		usb 0x8816
++device.name		microSD CardReader
+
+ vendor.id		usb 0xab12
++vendor.name		aplic
+
+ vendor.id		usb 0xab12
+&device.id		usb 0x34cd
++device.name		JMICRON JMS578 SATA 6Gb/s bridge
+
  vendor.id		usb 0xabcd
-+vendor.name		Unknown
++vendor.name		LogiLink
+
+ vendor.id		usb 0xabcd
+&device.id		usb 0x1234
++device.name		UDisk flash drive
+
+ vendor.id		usb 0xabcd
+&device.id		usb 0x6104
++device.name		PCCloneEX Lite+ SATA docking station [QP0017]
 
  vendor.id		usb 0xabcd
 &device.id		usb 0xcdee
@@ -77633,6 +89545,13 @@
 &device.id		usb 0x9e84
 +device.name		Yeti Stereo Microphone
 
+ vendor.id		usb 0xba77
++vendor.name		Clockmaker
+
+ vendor.id		usb 0xba77
+&device.id		usb 0x7147
++device.name		Agterbosch
+
  vendor.id		usb 0xc216
 +vendor.name		Card Device Expert Co., LTD
 
@@ -77644,8 +89563,23 @@
 +vendor.name		Keil Software, Inc.
 
  vendor.id		usb 0xc251
+&device.id		usb 0x1705
++device.name		MCB2300
+
+ vendor.id		usb 0xc251
 &device.id		usb 0x2710
 +device.name		ULink
+
+ vendor.id		usb 0xc251
+&device.id		usb 0x2723
++device.name		ULink-ME
+
+ vendor.id		usb 0xc502
++vendor.name		AGPTek
+
+ vendor.id		usb 0xc502
+&device.id		usb 0x0029
++device.name		Rocker
 
  vendor.id		usb 0xcace
 +vendor.name		CACE Technologies Inc.
@@ -77656,7 +89590,7 @@
 
  vendor.id		usb 0xcace
 &device.id		usb 0x0300
-+device.name		AirPcap NX [Atheros AR9001U-(2)NG]
++device.name		AirPcap NX [Atheros AR9170+AR9104]
 
  vendor.id		usb 0xcd12
 +vendor.name		SMART TECHNOLOGY INDUSTRIAL LTD.
@@ -77679,12 +89613,27 @@
 &device.id		usb 0x0501
 +device.name		Ultra-Stik Ultimarc Ultra-Stik Player 1
 
+ vendor.id		usb 0xd209
+&device.id		usb 0x1571
++device.name		A-PAC Arcade Control Interface
+
  vendor.id		usb 0xd904
 +vendor.name		LogiLink
 
  vendor.id		usb 0xd904
 &device.id		usb 0x0003
 +device.name		Laser Mouse (ID0009A)
+
+ vendor.id		usb 0xe2b7
++vendor.name		Jie Li
+
+ vendor.id		usb 0xe2b7
+&device.id		usb 0x0811
++device.name		CD002
+
+ vendor.id		usb 0xe2b7
+&device.id		usb 0x0812
++device.name		CD005 MP3 Player
 
  vendor.id		usb 0xe4e4
 +vendor.name		Xorcom Ltd.
@@ -77777,11 +89726,31 @@
 
  vendor.id		usb 0xeb1a
 &device.id		usb 0x2800
-+device.name		Terratec Cinergy 200
++device.name		EM2800 Video Capture
 
  vendor.id		usb 0xeb1a
 &device.id		usb 0x2801
-+device.name		GrabBeeX+ Video Encoder
++device.name		EM2801 Video Capture
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0x2820
++device.name		EM2820 Video Capture
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0x2821
++device.name		EM2820 Video Capture
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0x2840
++device.name		EM2840 Video Capture
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0x2841
++device.name		EM2840 Video Capture
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0x2861
++device.name		EasyCAP DC60+ [EM2861]
 
  vendor.id		usb 0xeb1a
 &device.id		usb 0x2863
@@ -77804,6 +89773,22 @@
 +device.name		Gadmei UTV330 TV Box
 
  vendor.id		usb 0xeb1a
+&device.id		usb 0x5166
++device.name		video grabber 28282
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0x5184
++device.name		VIDBOX NW06 [EM28281]
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0x8179
++device.name		Terratec Cinergy T2 Stick HD
+
+ vendor.id		usb 0xeb1a
+&device.id		usb 0xe305
++device.name		KWorld PlusTV Analog Stick
+
+ vendor.id		usb 0xeb1a
 &device.id		usb 0xe355
 +device.name		KWorld DVB-T 355U Digital TV Dongle
 
@@ -77820,12 +89805,42 @@
 &device.id		usb 0x6002
 +device.name		PhotoSmart C500
 
+ vendor.id		usb 0xf007
++vendor.name		Teslong
+
+ vendor.id		usb 0xf007
+&device.id		usb 0xa999
++device.name		Endoscope Camera
+
+ vendor.id		usb 0xf007
+&device.id		usb 0xb999
++device.name		Otoscope Camera
+
  vendor.id		usb 0xf182
 +vendor.name		Leap Motion
 
  vendor.id		usb 0xf182
 &device.id		usb 0x0003
 +device.name		Controller
+
+ vendor.id		usb 0xf3f0
++vendor.name		CCT, Inc
+
+ vendor.id		usb 0xf3f0
+&device.id		usb 0x0740
++device.name		multi-function device
+
+ vendor.id		usb 0xf3f0
+&device.id		usb 0x1340
++device.name		multi-function printer
+
+ vendor.id		usb 0xf3f0
+&device.id		usb 0x1440
++device.name		printer device
+
+ vendor.id		usb 0xf3f0
+&device.id		usb 0x1921
++device.name		printer
 
  vendor.id		usb 0xf4ec
 +vendor.name		Atten Electronics / Siglent Technologies
@@ -77852,12 +89867,22 @@
 &device.id		usb 0x0001
 +device.name		PC-Gamepad "Greystorm"
 
+ vendor.id		usb 0xfa11
++vendor.name		DyingLight
+
+ vendor.id		usb 0xfa11
+&device.id		usb 0x5afe
++device.name		DyingLight
+
  vendor.id		usb 0xfc08
 +vendor.name		Conrad Electronic SE
 
  vendor.id		usb 0xfc08
 &device.id		usb 0x0101
 +device.name		MIDI Cable UA0037
+
+ vendor.id		usb 0xff00
++vendor.name		Power Delivery
 
  vendor.id		usb 0xffee
 +vendor.name		FNK Tech


### PR DESCRIPTION
## Task

Update PCI and USB id list using the [update_pci_usb](https://github.com/openSUSE/hwinfo/blob/master/src/ids/update_pci_usb) script.

## See also

This replaces https://github.com/openSUSE/hwinfo/pull/97.