### PR TITLE
Fix timezone issue in SOURCE_DATE_EPOCH code

### DIFF
--- a/src/isdn/cdb/mk_isdnhwdb.c
+++ b/src/isdn/cdb/mk_isdnhwdb.c
@@ -272,7 +272,7 @@ char **argv;
 	fprintf(stdout,"$%02d %d\n", IWHREC_TYPE_VERSION, CDB_DATAVERSION + 1);
 	if ((source_date_epoch = getenv("SOURCE_DATE_EPOCH")) == NULL || (tim = (time_t)strtol(source_date_epoch, NULL, 10)) <= 0)
 		time(&tim);
-	strcpy(line,ctime(&tim));
+	strcpy(line,asctime(gmtime(&tim)));
 	l = strlen(line);
 	if (l)
 		line[l-1] = 0;


### PR DESCRIPTION
This was flagged by an [Arch Linux rebuilder](https://reproducible.archlinux.org/api/v0/builds/137733/diffoscope):
```
│ │  ! file is build with mk_isdnhwdb
│ │  ! Do not change this file !!!
│ │  $01 258
│ │ -$02 Mon Jul  5 15:41:55 2021
│ │ +$02 Mon Jul  5 13:41:55 2021
│ │  ! name data
│ │  $03 5465
│ │  $05 Billion
│ │  $05 B009
│ │  $05 Billion B009
│ │  $05 ISDN Single Basic Rate
│ │  $05 PCI
```
Thanks!

cc: @bmwiedemann 