### PR TITLE
Display numerical 32bit serial number for monitors without serial number display descriptor

### DIFF
--- a/src/hd/monitor.c
+++ b/src/hd/monitor.c
@@ -330,6 +330,9 @@ void add_edid_info(hd_data_t *hd_data, hd_t *hd, unsigned char *edid)
     if((u >> 8) == bc_monitor) hd->sub_class.id = u & 0xff;
   }
 
+  u = edid[12] + (edid[13] << 8) + (edid[14] << 16) + (edid[15] << 24);
+  str_printf(&serial, -1, "%u", u);
+
   if(edid[0x15] > 0 && edid[0x16] > 0) {
     width_mm = edid[0x15] * 10;
     height_mm = edid[0x16] * 10;
@@ -414,7 +417,8 @@ void add_edid_info(hd_data_t *hd_data, hd_t *hd, unsigned char *edid)
         break;
 
       case 0xff:
-        if(!serial && edid[i + 5]) {
+        if(edid[i + 5]) {
+          free_mem(serial);
           serial = canon_str(edid + i + 5, 0xd);
           for(s = serial; *s; s++) if(*s < ' ') *s = ' ';
         }


### PR DESCRIPTION
Some monitors don't provide a serial number display descriptor and only set the numerical 32bit serial in the EDID header.

For example this Eizo monitor:
```
28: None 00.0: 10002 LCD Monitor                                
  [Created at monitor.125]
  Unique ID: rdCR.aA2tqrpv7jB
  Parent ID: _Znp.iuhPOFu3DbD
  Hardware Class: monitor
  Model: "EIZO EV2456"
  Vendor: ENC "EIZO"
  Device: eisa 0x2796 "EV2456"
  Resolution: 720x400@70Hz
  Resolution: 640x480@60Hz
  Resolution: 800x600@60Hz
  Resolution: 1024x768@60Hz
  Resolution: 1600x1200@60Hz
  Resolution: 1280x1024@60Hz
  Resolution: 1600x900@60Hz
  Resolution: 1920x1080@60Hz
  Resolution: 1920x1200@60Hz
  Size: 519x324 mm
  Year of Manufacture: 2020
  Week of Manufacture: 52
  Detailed Timings #0:
     Resolution: 1920x1200
     Horizontal: 1920 1968 2000 2080 (+48 +80 +160) -hsync
       Vertical: 1200 1203 1209 1235 (+3 +9 +35) +vsync
    Frequencies: 154.00 MHz, 74.04 kHz, 59.95 Hz
  Year of Manufacture: 2020
  Week of Manufacture: 52
  Detailed Timings #1:
     Resolution: 1920x1080
     Horizontal: 1920 2008 2052 2200 (+88 +132 +280) +hsync
       Vertical: 1080 1084 1089 1125 (+4 +9 +45) +vsync
    Frequencies: 148.50 MHz, 67.50 kHz, 60.00 Hz
  Driver Info #0:
    Max. Resolution: 1920x1200
    Vert. Sync Range: 59-61 Hz
    Hor. Sync Range: 31-76 kHz
    Bandwidth: 154 MHz
  Config Status: cfg=new, avail=yes, need=no, active=unknown
  Attached to: #25 (VGA compatible controller)
```
```
EDID:                                                                                                                                                                                                                                  
        00ffffffffffff0015c39627d819ea05                                                                                                                                                                                               
        341e0104a5342178fa3a05a9544c9c26                                                                                                                                                                                               
        115054a10800a9408180b300a9c081c0                                                                                                                                                                                               
        810001010101283c80a070b023403020                                                                                                                                                                                               
        360007442100001a023a801871382d40                                                                                                                                                                                               
        582c450007442100001e000000fd003b                                                                                                                                                                                               
        3d1f4c11000a202020202020000000fc                                                                                                                                                                                               
        004556323435360a202020202020011c                                                                                                                                                                                               
        020312f145100403020123091f078301                                                                                                                                                                                               
        0000023a801871382d40582c45000744                                                                                                                                                                                               
        2100001e011d007251d01e206e285500                                                                                                                                                                                               
        07442100001e8f0ad08a20e02d10103e                                                                                                                                                                                               
        96000744210000188c0ad08a20e02d10                                                                                                                                                                                               
        103e9600074421000018d50980a020e0                                                                                                                                                                                               
        2d101060a20007442100001800000000                                                                                                                                                                                               
        00000000000000000000000000000024     
```

I propose to display the numerical serial number if no serial number display descriptor is available. My patch always reads the numerical serial number and replaces it with the display descriptor data if available.