### PR TITLE
remove malloc.h headers usage

### DIFF
--- a/src/isdn/cdb/cdb_read.h
+++ b/src/isdn/cdb/cdb_read.h
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <time.h>
 #include "isdn_cdb_def.h"

--- a/src/isdn/cdb/isdn_cdb.c
+++ b/src/isdn/cdb/isdn_cdb.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <time.h>
 #include "lex.yy.c"

--- a/src/isdn/cdb/mk_isdnhwdb.c
+++ b/src/isdn/cdb/mk_isdnhwdb.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <time.h>
 #include "lex.yy.c"


### PR DESCRIPTION
malloc.h was deprecated many years ago, stdlib.h should be used
(stdlib.h is already used)

This patch removes malloc.h usage to build host-tools (isdn_cdb,
mk_isdnhwdb) on systems without malloc.h header

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>