### PR TITLE
improve treatment of NVME devices (bsc#1200975)

### DIFF
--- a/hwinfo.c
+++ b/hwinfo.c
@@ -144,6 +144,7 @@ struct option options[] = {
   { "pci", 0, NULL, 1000 + hw_pci },
   { "isapnp", 0, NULL, 1000 + hw_isapnp },
   { "scsi", 0, NULL, 1000 + hw_scsi },
+  { "nvme", 0, NULL, 1000 + hw_nvme },
   { "ide", 0, NULL, 1000 + hw_ide },
   { "bridge", 0, NULL, 1000 + hw_bridge },
   { "hub", 0, NULL, 1000 + hw_hub },
@@ -815,8 +816,8 @@ void help()
     "        all, arch, bios, block, bluetooth, braille, bridge, camera,\n"
     "        cdrom, chipcard, cpu, disk, dsl, dvb, fingerprint, floppy,\n"
     "        framebuffer, gfxcard, hub, ide, isapnp, isdn, joystick, keyboard,\n"
-    "        memory, mmc-ctrl, modem, monitor, mouse, netcard, network, partition,\n"
-    "        pci, pcmcia, pcmcia-ctrl, pppoe, printer, redasd,\n"
+    "        memory, mmc-ctrl, modem, monitor, mouse, netcard, network, nvme,\n"
+    "        partition, pci, pcmcia, pcmcia-ctrl, pppoe, printer, redasd,\n"
     "        reallyall, scanner, scsi, smp, sound, storage-ctrl, sys, tape,\n"
     "        tv, uml, usb, usb-ctrl, vbe, wlan, xen, zip\n"
     "    --short\n"

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -910,6 +910,7 @@ void hd_set_probe_feature_hw(hd_data_t *hd_data, hd_hw_item_t item)
       break;
 
     case hw_scsi:
+    case hw_nvme:
     case hw_tape:
       hd_set_probe_feature(hd_data, pr_pci);
       hd_set_probe_feature(hd_data, pr_block);
@@ -4739,6 +4740,7 @@ void assign_hw_class(hd_data_t *hd_data, hd_t *hd)
         case hw_pci:
         case hw_isapnp:
         case hw_scsi:
+        case hw_nvme:
         case hw_ide:
 
         case hw_pcmcia:		/* special */
@@ -4804,6 +4806,9 @@ void assign_hw_class(hd_data_t *hd_data, hd_t *hd)
   }
   else if(hd->bus.id == bus_scsi) {
     hd_set_hw_class(hd, hw_scsi);
+  }
+  else if(hd->bus.id == bus_nvme) {
+    hd_set_hw_class(hd, hw_nvme);
   }
   else if(hd->bus.id == bus_ide) {
     hd_set_hw_class(hd, hw_ide);

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -300,7 +300,8 @@ typedef enum bus_types {
   /** outside the range of the PCI values */
   bus_ps2 = 0x80, bus_serial, bus_parallel, bus_floppy, bus_scsi, bus_ide, bus_usb,
   bus_adb, bus_raid, bus_sbus, bus_i2o, bus_vio, bus_ccw, bus_iucv, bus_ps3_system_bus,
-  bus_virtio, bus_ibmebus, bus_gameport, bus_uisvirtpci, bus_mmc, bus_sdio, bus_nd
+  bus_virtio, bus_ibmebus, bus_gameport, bus_uisvirtpci, bus_mmc, bus_sdio, bus_nd,
+  bus_nvme,
 } hd_bus_types_t;
 
 /** @} */

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -145,7 +145,7 @@ typedef enum hw_item {
   hw_isapnp, hw_bridge, hw_hub, hw_scsi, hw_ide, hw_memory, hw_dvb,
   hw_pcmcia, hw_pcmcia_ctrl, hw_ieee1394, hw_ieee1394_ctrl, hw_hotplug,
   hw_hotplug_ctrl, hw_zip, hw_pppoe, hw_wlan, hw_redasd, hw_dsl, hw_block,
-  hw_tape, hw_vbe, hw_bluetooth, hw_fingerprint, hw_mmc_ctrl,
+  hw_tape, hw_vbe, hw_bluetooth, hw_fingerprint, hw_mmc_ctrl, hw_nvme,
   /** append new entries here */
   hw_unknown, hw_all				/**< hw_all must be last */
 } hd_hw_item_t;

--- a/src/hd/hwclass_names.h
+++ b/src/hd/hwclass_names.h
@@ -59,6 +59,7 @@ static hash_t hw_items[] = {
   { hw_tape,          "tape"                },
   { hw_vbe,           "vesa bios"           },
   { hw_bluetooth,     "bluetooth"           },
+  { hw_nvme,          "nvme"                },
   { hw_unknown,       "unknown"             },
   { 0,                NULL                  }
 };

--- a/src/hd/int.c
+++ b/src/hd/int.c
@@ -1230,8 +1230,6 @@ void int_legacy_geo(hd_data_t *hd_data)
   char *s;
   edd_info_t *ei;
 
-  if(!hd_data->edd) return;
-
   for(hd = hd_data->hd; hd; hd = hd->next) {
     if(
       hd->base_class.id == bc_storage_device &&

--- a/src/hd/net.c
+++ b/src/hd/net.c
@@ -619,7 +619,7 @@ hd_res_t *get_phwaddr(hd_data_t *hd_data, hd_t *hd)
       addr[3 * i - 1] = 0;
     }
 
-    ADD2LOG("  %s: ethtool permanent hw address[%d]: %s\n", hd->unix_dev_name, phwaddr->size, addr);
+    ADD2LOG("  %s: ethtool permanent hw address[%d]: %s\n", hd->unix_dev_name, phwaddr->size, addr ?: "");
 
     if(addr && strspn(addr, "0:") != strlen(addr)) {
       res = new_mem(sizeof *res);

--- a/src/hd/pci.c
+++ b/src/hd/pci.c
@@ -1612,7 +1612,7 @@ void hd_read_vm(hd_data_t *hd_data)
       if(drv_name) drv_name++;
     }
 
-    ADD2LOG("    driver = \"%s\"\n", drv_name);
+    ADD2LOG("    driver = \"%s\"\n", drv_name ?: "");
 
     if(
       drv_name &&

--- a/src/ids/check_hd.c
+++ b/src/ids/check_hd.c
@@ -19,7 +19,7 @@ typedef enum hw_item {
   hw_isapnp, hw_bridge, hw_hub, hw_scsi, hw_ide, hw_memory, hw_dvb,
   hw_pcmcia, hw_pcmcia_ctrl, hw_ieee1394, hw_ieee1394_ctrl, hw_hotplug,
   hw_hotplug_ctrl, hw_zip, hw_pppoe, hw_wlan, hw_redasd, hw_dsl, hw_block,
-  hw_tape, hw_vbe, hw_bluetooth,
+  hw_tape, hw_vbe, hw_bluetooth, hw_nvme,
   /* append new entries here */
   hw_unknown, hw_all                                    /* hw_all must be last */
 } hd_hw_item_t;

--- a/src/ids/src/bus
+++ b/src/ids/src/bus
@@ -100,3 +100,5 @@
  bus.id			0x95
 +bus.name		ND
 
+ bus.id			0x96
++bus.name		NVME


### PR DESCRIPTION
## Task

- https://trello.com/c/JIiwsD3g
- https://bugzilla.suse.com/show_bug.cgi?id=1200975

NVME devices that are not directly attached to PCI are not shown properly.

## Solution

Treat NVME devices as their own device class.