### PR TITLE
improve treatment of NVME devices (bsc#1200975)

### DIFF
--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -300,7 +300,8 @@ typedef enum bus_types {
   /** outside the range of the PCI values */
   bus_ps2 = 0x80, bus_serial, bus_parallel, bus_floppy, bus_scsi, bus_ide, bus_usb,
   bus_adb, bus_raid, bus_sbus, bus_i2o, bus_vio, bus_ccw, bus_iucv, bus_ps3_system_bus,
-  bus_virtio, bus_ibmebus, bus_gameport, bus_uisvirtpci, bus_mmc, bus_sdio, bus_nd
+  bus_virtio, bus_ibmebus, bus_gameport, bus_uisvirtpci, bus_mmc, bus_sdio, bus_nd,
+  bus_nvme,
 } hd_bus_types_t;
 
 /** @} */

--- a/src/hd/int.c
+++ b/src/hd/int.c
@@ -1230,8 +1230,6 @@ void int_legacy_geo(hd_data_t *hd_data)
   char *s;
   edd_info_t *ei;
 
-  if(!hd_data->edd) return;
-
   for(hd = hd_data->hd; hd; hd = hd->next) {
     if(
       hd->base_class.id == bc_storage_device &&

--- a/src/hd/net.c
+++ b/src/hd/net.c
@@ -619,7 +619,7 @@ hd_res_t *get_phwaddr(hd_data_t *hd_data, hd_t *hd)
       addr[3 * i - 1] = 0;
     }
 
-    ADD2LOG("  %s: ethtool permanent hw address[%d]: %s\n", hd->unix_dev_name, phwaddr->size, addr);
+    ADD2LOG("  %s: ethtool permanent hw address[%d]: %s\n", hd->unix_dev_name, phwaddr->size, addr ?: "");
 
     if(addr && strspn(addr, "0:") != strlen(addr)) {
       res = new_mem(sizeof *res);

--- a/src/hd/pci.c
+++ b/src/hd/pci.c
@@ -1612,7 +1612,7 @@ void hd_read_vm(hd_data_t *hd_data)
       if(drv_name) drv_name++;
     }
 
-    ADD2LOG("    driver = \"%s\"\n", drv_name);
+    ADD2LOG("    driver = \"%s\"\n", drv_name ?: "");
 
     if(
       drv_name &&

--- a/src/ids/src/bus
+++ b/src/ids/src/bus
@@ -100,3 +100,5 @@
  bus.id			0x95
 +bus.name		ND
 
+ bus.id			0x96
++bus.name		NVME


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/hwinfo/pull/114 to SLE15-SP4.

## Note

In contrast to https://github.com/openSUSE/hwinfo/pull/114 this version leaves out the `--nvme`option to hwinfo as this requires an incompatible library change which is not doable within a service pack.

## Original task

- https://trello.com/c/JIiwsD3g
- https://bugzilla.suse.com/show_bug.cgi?id=1200975

NVME devices that are not directly attached to PCI are not shown properly.

## Solution

Treat NVME devices as their own device class.