### PR TITLE
fix build with glibc-2.36

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -21,9 +21,6 @@
 #include <sys/mman.h>
 #include <linux/pci.h>
 #include <linux/hdreg.h>
-#define _LINUX_AUDIT_H_
-#define _LINUX_PRIO_TREE_H
-#include <linux/fs.h>
 
 /**
  * @defgroup libhdBUSint Bus scanning code


### PR DESCRIPTION
See section 2.1 of https://sourceware.org/glibc/wiki/Release/2.36
("Usage of <linux/mount.h> and <sys/mount.h>") for details.

Also, remove a couple of ancient hacks that are no longer relevant after
the removal of <linux/fs.h> inclusion.

Signed-off-by: WANG Xuerui <xen0n@gentoo.org>