### PR TITLE
glibc 2.36+ includes fsconfig itself, make linux/fs.h inclusion conditional (bsc#1202213)

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -23,7 +23,9 @@
 #include <linux/hdreg.h>
 #define _LINUX_AUDIT_H_
 #define _LINUX_PRIO_TREE_H
+#ifndef FSCONFIG_SET_FLAG
 #include <linux/fs.h>
+#endif
 
 /**
  * @defgroup libhdBUSint Bus scanning code


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1202213

Compiling with glibc 2.36 fails with:

```
/usr/include/linux/mount.h:95:6: error: redeclaration of 'enum fsconfig_command'
   95 | enum fsconfig_command {
      |      ^~~~~~~~~~~~~~~~
In file included from hd.c:18:
/usr/include/sys/mount.h:189:6: note: originally defined here
  189 | enum fsconfig_command
      |      ^~~~~~~~~~~~~~~~
```
glibc 2.36 changelog says:
```
  * On Linux, the fsopen, fsmount, move_mount, fsconfig, fspick, open_tree,
    and mount_setattr have been added
```

## Solution

Make `linux/fs.h` inclusion conditional.