### PR TITLE
Add support for loongarch cpu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ include Makefile.common
 
 ifeq "$(ARCH)" "x86_64"
 LIBDIR		?= /usr/lib64
+else ifeq "$(ARCH)" "loongarch64"
+LIBDIR		?= /usr/lib64
 else
 LIBDIR		?= /usr/lib
 endif

--- a/hwinfo.c
+++ b/hwinfo.c
@@ -635,6 +635,9 @@ void do_hw(hd_data_t *hd_data, FILE *f, int hw_item)
       case arch_aarch64:
         s = "AArch64";
         break;
+      case arch_loongarch:
+        s = "LoongArch";
+        break;
       case arch_riscv:
         s = "RISC-V";
         break;

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -3148,6 +3148,9 @@ enum cpu_arch hd_cpu_arch(hd_data_t *hd_data)
 #ifdef __arm__
   return arch_arm;
 #else
+#ifdef __loongarch__
+  return arch_loongarch;
+#else
 #ifdef __aarch64__
   return arch_aarch64;
 #elif defined __m68k__
@@ -3156,6 +3159,7 @@ enum cpu_arch hd_cpu_arch(hd_data_t *hd_data)
   return arch_riscv;
 #else
   return arch_unknown;
+#endif
 #endif
 #endif
 #endif

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -1448,6 +1448,7 @@ typedef enum cpu_arch {
   arch_mips,
   arch_x86_64,
   arch_aarch64,
+  arch_loongarch,
   arch_riscv
 } hd_cpu_arch_t;
 

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -1117,6 +1117,9 @@ void dump_cpu(hd_data_t *hd_data, hd_t *hd, FILE *f)
       case arch_aarch64:
 	dump_line0 ("AArch64\n");
 	break;
+      case arch_loongarch:
+	dump_line0 ("LoongArch\n");
+	break;
       case arch_riscv:
 	dump_line0 ("RISC-V\n");
 	break;


### PR DESCRIPTION
Add ```loongarch``` support, the new architecture launched by China's ```Loongson```. It can be compiled and run normally under ```loongarch``` architecture. [loongarch cpuinfo](https://github.com/torvalds/linux/blob/master/arch/loongarch/kernel/proc.c#L49-L64)