### PR TITLE
avoid linking problems with libsamba (bsc#1212756)

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -3924,7 +3924,8 @@ int load_module_with_params(hd_data_t *hd_data, char *module, char *params)
   return i;
 }
 
-int load_module(hd_data_t *hd_data, char *module)
+/* symbol clash with libsamba (bsc#1212756) */
+__attribute__((visibility("hidden"))) int load_module(hd_data_t *hd_data, char *module)
 {
   return load_module_with_params(hd_data, module, NULL);
 }


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/hwinfo/pull/132 to Tumbleweed.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1212756

libsamba has also a `load_module` function. This runs into problems when linking both against libsamba and libhd.

## Solution

`load_module` is an internal function and does not need to be exported. Hide `load_module` symbol.