### PR TITLE
restrict libhd exported symbols to the documented API (bsc#1212756)

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -23,7 +23,7 @@ RPM_OPT_FLAGS	?= -O2
 CC	?= gcc
 LD	= ld
 CFLAGS += $(RPM_OPT_FLAGS) -Wall -Wno-pointer-sign -pipe -g $(SHARED_FLAGS) $(EXTRA_FLAGS) -I$(TOPDIR)/src/hd
-SHARED_FLAGS	= -fPIC
+SHARED_FLAGS	= -fPIC -fvisibility=hidden
 
 LDFLAGS	+= -Lsrc
 

--- a/hwinfo.c
+++ b/hwinfo.c
@@ -29,12 +29,6 @@ typedef struct {
 static int get_probe_flags(int, char **, hd_data_t *);
 static void progress2(char *, char *);
 
-// ##### temporary solution, fix it later!
-str_list_t *read_file(char *file_name, unsigned start_line, unsigned lines);
-str_list_t *search_str_list(str_list_t *sl, char *str);
-str_list_t *add_str_list(str_list_t **sl, char *str);
-char *new_str(const char *);
-
 static unsigned deb = 0;
 static char *log_file = "";
 static char *list = NULL;
@@ -1272,8 +1266,8 @@ void dump_packages(hd_data_t *hd_data)
   sl = hddb_get_packages(hd_data);
 
   for(i = 0; xserver3map[i]; i += 2) {
-    if (!search_str_list(sl, xserver3map[i + 1]))
-      add_str_list(&sl, new_str(xserver3map[i + 1]));
+    if(xserver3map[i + 1] && !search_str_list(sl, xserver3map[i + 1]))
+      add_str_list(&sl, strdup(xserver3map[i + 1]));
   }
 
   for(; sl; sl = sl->next) {
@@ -1433,7 +1427,7 @@ void ask_db(hd_data_t *hd_data, char *query)
     }
 
     if(sscanf(sl->str, "vendor=%3s%n", buf, &cnt) >= 1 && !sl->str[cnt]) {
-      u = name2eisa_id(buf);
+      u = hd_name2eisa_id(buf);
       if(u) hd->vendor.id = u;
       tag = TAG_EISA;
       continue;
@@ -1450,7 +1444,7 @@ void ask_db(hd_data_t *hd_data, char *query)
     }
 
     if(sscanf(sl->str, "subvendor=%3s%n", buf, &cnt) >= 1 && !sl->str[cnt]) {
-      u = name2eisa_id(buf);
+      u = hd_name2eisa_id(buf);
       if(u) hd->sub_vendor.id = u;
       tag = TAG_EISA;
       continue;
@@ -1467,7 +1461,7 @@ void ask_db(hd_data_t *hd_data, char *query)
     }
 
     if(sscanf(sl->str, "serial=%255s%n", buf, &cnt) >= 1 && !sl->str[cnt]) {
-      hd->serial = new_str(buf);
+      hd->serial = strdup(buf);
       continue;
     }
 

--- a/src/hd/block.c
+++ b/src/hd/block.c
@@ -1295,7 +1295,7 @@ void read_partitions(hd_data_t *hd_data)
  * Read iso9660/el torito info, if there is a CD inserted.
  * Returns NULL if nothing was found
  */
-cdrom_info_t *hd_read_cdrom_info(hd_data_t *hd_data, hd_t *hd)
+API_SYM cdrom_info_t *hd_read_cdrom_info(hd_data_t *hd_data, hd_t *hd)
 {
   int fd;
   char *s;

--- a/src/hd/hal.c
+++ b/src/hd/hal.c
@@ -498,7 +498,7 @@ int check_udi(const char *udi)
 }
 
 
-int hd_write_properties(const char *udi, hal_prop_t *prop)
+API_SYM int hd_write_properties(const char *udi, hal_prop_t *prop)
 {
   FILE *f;
   char *s;
@@ -519,7 +519,7 @@ int hd_write_properties(const char *udi, hal_prop_t *prop)
 }
 
 
-hal_prop_t *hd_read_properties(const char *udi)
+API_SYM hal_prop_t *hd_read_properties(const char *udi)
 {
   char *path = NULL;
   str_list_t *sl0, *sl;

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -535,7 +535,7 @@ void set_probe_feature(hd_data_t *hd_data, enum probe_feature feature, unsigned 
 }
 
 
-void hd_set_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
+API_SYM void hd_set_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
 {
   unsigned ofs, bit, mask;
   int i;
@@ -563,7 +563,7 @@ void hd_set_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
 }
 
 
-void hd_clear_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
+API_SYM void hd_clear_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
 {
   unsigned ofs, bit, mask;
   int i;
@@ -586,7 +586,7 @@ void hd_clear_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
 }
 
 
-int hd_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
+API_SYM int hd_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
 {
   if(feature < 0 || feature >= pr_default) return 0;
 
@@ -594,7 +594,7 @@ int hd_probe_feature(hd_data_t *hd_data, enum probe_feature feature)
 }
 
 
-void hd_set_probe_feature_hw(hd_data_t *hd_data, hd_hw_item_t item)
+API_SYM void hd_set_probe_feature_hw(hd_data_t *hd_data, hd_hw_item_t item)
 {
   hd_set_probe_feature(hd_data, pr_int);
 //  hd_set_probe_feature(hd_data, pr_manual);
@@ -978,7 +978,7 @@ void hd_set_probe_feature_hw(hd_data_t *hd_data, hd_hw_item_t item)
 /*
  * Free all data associated with a hd_data_t struct. *Not* the struct itself.
  */
-hd_data_t *hd_free_hd_data(hd_data_t *hd_data)
+API_SYM hd_data_t *hd_free_hd_data(hd_data_t *hd_data)
 {
   modinfo_t *p;
   unsigned u;
@@ -1077,7 +1077,7 @@ hd_data_t *hd_free_hd_data(hd_data_t *hd_data)
 /*
  * Free HAL property data.
  */
-hal_prop_t *hd_free_hal_properties(hal_prop_t *prop)
+API_SYM hal_prop_t *hd_free_hal_properties(hal_prop_t *prop)
 {
   hal_prop_t *next;
 
@@ -1204,7 +1204,7 @@ int exists_hd_entry(hd_data_t *hd_data, hd_t *old_hd, hd_t *hd_ex)
 /*!
  * \note This may not free it.
  */
-hd_t *hd_free_hd_list(hd_t *hd)
+API_SYM hd_t *hd_free_hd_list(hd_t *hd)
 {
   hd_t *h;
 
@@ -1517,7 +1517,7 @@ scsi_t *free_scsi(scsi_t *scsi, int free_all)
 
 
 // FIXME: obsolete
-hd_manual_t *hd_free_manual(hd_manual_t *manual)
+API_SYM hd_manual_t *hd_free_manual(hd_manual_t *manual)
 {
   return NULL;
 }
@@ -1786,7 +1786,7 @@ hd_res_t *add_res_entry(hd_res_t **res, hd_res_t *new_res)
 }
 
 
-hd_t *add_hd_entry(hd_data_t *hd_data, unsigned line, unsigned count)
+API_SYM hd_t *hd_add_hd_entry(hd_data_t *hd_data, unsigned line, unsigned count)
 {
   hd_t *hd;
 
@@ -1809,7 +1809,7 @@ hd_t *add_hd_entry2(hd_t **hd, hd_t *new_hd)
 }
 
 
-void hd_scan(hd_data_t *hd_data)
+API_SYM void hd_scan(hd_data_t *hd_data)
 {
   char *s = NULL;
   int i, j;
@@ -2179,7 +2179,7 @@ char *eisa_vendor_str(unsigned v)
 /*
  *  Must _not_ check that s is exactly 3 chars.
  */
-unsigned name2eisa_id(char *s)
+API_SYM unsigned hd_name2eisa_id(char *s)
 {
   int i;
   unsigned u = 0;
@@ -2299,7 +2299,7 @@ char *float2str(int f, int n)
 /*
  * find hardware entry with given index
  */
-hd_t *hd_get_device_by_idx(hd_data_t *hd_data, unsigned idx)
+API_SYM hd_t *hd_get_device_by_idx(hd_data_t *hd_data, unsigned idx)
 {
   hd_t *hd;
 
@@ -2370,7 +2370,7 @@ void hd_log(hd_data_t *hd_data, char *buf, ssize_t len)
 }
 
 
-void hd_log_printf(hd_data_t *hd_data, char *format, ...)
+API_SYM void hd_log_printf(hd_data_t *hd_data, char *format, ...)
 {
   ssize_t l;
   char *s = NULL;
@@ -2473,7 +2473,7 @@ void hexdump(char **buf, int with_ascii, unsigned data_len, unsigned char *data)
 /** \relates s_str_list_t
  * Search a string list for a string.
  */
-str_list_t *search_str_list(str_list_t *sl, char *str)
+API_SYM str_list_t *hd_search_str_list(str_list_t *sl, char *str)
 {
   if(!str) return NULL;
 
@@ -2488,7 +2488,7 @@ str_list_t *search_str_list(str_list_t *sl, char *str)
  *
  * The new string (str) will be *copied*!
  */
-str_list_t *add_str_list(str_list_t **sl, char *str)
+API_SYM str_list_t *hd_add_str_list(str_list_t **sl, char *str)
 {
   while(*sl) sl = &(*sl)->next;
 
@@ -2502,7 +2502,7 @@ str_list_t *add_str_list(str_list_t **sl, char *str)
 /** \relates s_str_list_t
  * Free the memory allocated by a string list.
  */
-str_list_t *free_str_list(str_list_t *list)
+API_SYM str_list_t *hd_free_str_list(str_list_t *list)
 {
   str_list_t *l;
 
@@ -2517,7 +2517,7 @@ str_list_t *free_str_list(str_list_t *list)
 /** \relates s_str_list_t
  * Reverse string list.
  */
-str_list_t *reverse_str_list(str_list_t *list)
+API_SYM str_list_t *hd_reverse_str_list(str_list_t *list)
 {
   str_list_t *sl, *sl_new = NULL, *next;
 
@@ -2536,7 +2536,7 @@ str_list_t *reverse_str_list(str_list_t *list)
  *
  * start_line is zero-based; lines == 0 -> all lines
  */
-str_list_t *read_file(char *file_name, unsigned start_line, unsigned lines)
+API_SYM str_list_t *hd_read_file(char *file_name, unsigned start_line, unsigned lines)
 {
   FILE *f;
   char buf[0x10000];
@@ -2761,7 +2761,7 @@ void progress(hd_data_t *hd_data, unsigned pos, unsigned count, char *msg)
  * If name is not a valid probe feature, 0 is returned.
  *
  */
-enum probe_feature hd_probe_feature_by_name(char *name)
+API_SYM enum probe_feature hd_probe_feature_by_name(char *name)
 {
   pr_flags_t *flags;
 
@@ -2775,7 +2775,7 @@ enum probe_feature hd_probe_feature_by_name(char *name)
  * Coverts a enum probe_feature to a string.
  * If it fails, NULL is returned.
  */
-char *hd_probe_feature_by_value(enum probe_feature feature)
+API_SYM char *hd_probe_feature_by_value(enum probe_feature feature)
 {
   pr_flags_t *flags;
 
@@ -2828,7 +2828,7 @@ void remove_tagged_hd_entries(hd_data_t *hd_data)
 }
 
 
-int hd_module_is_active(hd_data_t *hd_data, char *mod)
+API_SYM int hd_module_is_active(hd_data_t *hd_data, char *mod)
 {
   str_list_t *sl, *sl0 = read_kmods(hd_data);
   int active = 0;
@@ -2901,7 +2901,7 @@ int hd_module_is_active(hd_data_t *hd_data, char *mod)
 }
 
 
-int hd_has_pcmcia(hd_data_t *hd_data)
+API_SYM int hd_has_pcmcia(hd_data_t *hd_data)
 {
   hd_t *hd;
 
@@ -2933,7 +2933,7 @@ int hd_apm_enabled(hd_data_t *hd_data)
 }
 
 
-int hd_usb_support(hd_data_t *hd_data)
+API_SYM int hd_usb_support(hd_data_t *hd_data)
 {
   hd_t *hd;
   hd_res_t *res;
@@ -2951,7 +2951,7 @@ int hd_usb_support(hd_data_t *hd_data)
 }
 
 
-int hd_smp_support(hd_data_t *hd_data)
+API_SYM int hd_smp_support(hd_data_t *hd_data)
 {
   int is_smp = 0;
   unsigned u;
@@ -3013,7 +3013,7 @@ int hd_smp_support(hd_data_t *hd_data)
 }
 
 
-int hd_color(hd_data_t *hd_data)
+API_SYM int hd_color(hd_data_t *hd_data)
 {
 #if 0
   hd_t *hd;
@@ -3037,13 +3037,13 @@ int hd_color(hd_data_t *hd_data)
 }
 
 
-int hd_mac_color(hd_data_t *hd_data)
+API_SYM int hd_mac_color(hd_data_t *hd_data)
 {
   return hd_color(hd_data);
 }
 
 
-unsigned hd_display_adapter(hd_data_t *hd_data)
+API_SYM unsigned hd_display_adapter(hd_data_t *hd_data)
 {
   hd_t *hd;
   driver_info_t *di;
@@ -3105,7 +3105,7 @@ unsigned hd_display_adapter(hd_data_t *hd_data)
 }
 
 
-enum cpu_arch hd_cpu_arch(hd_data_t *hd_data)
+API_SYM enum cpu_arch hd_cpu_arch(hd_data_t *hd_data)
 {
   hd_t *hd;
 
@@ -3169,13 +3169,13 @@ enum cpu_arch hd_cpu_arch(hd_data_t *hd_data)
 }
 
 
-enum boot_arch hd_boot_arch(hd_data_t *hd_data)
+API_SYM enum boot_arch hd_boot_arch(hd_data_t *hd_data)
 {
   return hd_data->boot;
 }
 
 
-int hd_is_uml(hd_data_t *hd_data)
+API_SYM int hd_is_uml(hd_data_t *hd_data)
 {
   int is_uml = 0;
   hd_t *hd;
@@ -3218,7 +3218,7 @@ int hd_is_uml(hd_data_t *hd_data)
 }
 
 
-int hd_is_sgi_altix(hd_data_t *hd_data)
+API_SYM int hd_is_sgi_altix(hd_data_t *hd_data)
 {
   struct stat sbuf;
 
@@ -3231,7 +3231,7 @@ int hd_is_sgi_altix(hd_data_t *hd_data)
  *
  * see https://www.sandpile.org/x86/cpuid.htm#level_4000_0000h
  */
-int hd_is_xen(hd_data_t *hd_data)
+API_SYM int hd_is_xen(hd_data_t *hd_data)
 {
 #if defined(__i386__) || defined(__x86_64__)
 
@@ -3284,7 +3284,7 @@ void hd_copy(hd_t *dst, hd_t *src)
 }
 
 
-hd_t *hd_list(hd_data_t *hd_data, hd_hw_item_t item, int rescan, hd_t *hd_old)
+API_SYM hd_t *hd_list(hd_data_t *hd_data, hd_hw_item_t item, int rescan, hd_t *hd_old)
 {
   hd_t *hd, *hd1, *hd_list = NULL;
   unsigned char probe_save[sizeof hd_data->probe];
@@ -3345,7 +3345,7 @@ hd_t *hd_list(hd_data_t *hd_data, hd_hw_item_t item, int rescan, hd_t *hd_old)
 }
 
 
-hd_t *hd_list_with_status(hd_data_t *hd_data, hd_hw_item_t item, hd_status_t status)
+API_SYM hd_t *hd_list_with_status(hd_data_t *hd_data, hd_hw_item_t item, hd_status_t status)
 {
   hd_t *hd, *hd1, *hd_list = NULL;
   unsigned char probe_save[sizeof hd_data->probe];
@@ -3395,7 +3395,7 @@ int has_hw_class(hd_t *hd, hd_hw_item_t *items)
 /*
  * items must be a 0 terminated list
  */
-hd_t *hd_list2(hd_data_t *hd_data, hd_hw_item_t *items, int rescan)
+API_SYM hd_t *hd_list2(hd_data_t *hd_data, hd_hw_item_t *items, int rescan)
 {
   hd_t *hd, *hd1, *hd_list = NULL;
   unsigned char probe_save[sizeof hd_data->probe];
@@ -3463,7 +3463,7 @@ hd_t *hd_list2(hd_data_t *hd_data, hd_hw_item_t *items, int rescan)
 /*
  * items must be a 0 terminated list
  */
-hd_t *hd_list_with_status2(hd_data_t *hd_data, hd_hw_item_t *items, hd_status_t status)
+API_SYM hd_t *hd_list_with_status2(hd_data_t *hd_data, hd_hw_item_t *items, hd_status_t status)
 {
   hd_t *hd, *hd1, *hd_list = NULL;
   unsigned char probe_save[sizeof hd_data->probe];
@@ -3494,7 +3494,7 @@ hd_t *hd_list_with_status2(hd_data_t *hd_data, hd_hw_item_t *items, hd_status_t 
 }
 
 
-hd_t *hd_base_class_list(hd_data_t *hd_data, unsigned base_class)
+API_SYM hd_t *hd_base_class_list(hd_data_t *hd_data, unsigned base_class)
 {
   hd_t *hd, *hd1, *hd_list = NULL;
 //  hd_t *bridge_hd;
@@ -3517,7 +3517,7 @@ hd_t *hd_base_class_list(hd_data_t *hd_data, unsigned base_class)
   return hd_list;
 }
 
-hd_t *hd_sub_class_list(hd_data_t *hd_data, unsigned base_class, unsigned sub_class)
+API_SYM hd_t *hd_sub_class_list(hd_data_t *hd_data, unsigned base_class, unsigned sub_class)
 {
   hd_t *hd, *hd1, *hd_list = NULL;
 
@@ -3531,7 +3531,7 @@ hd_t *hd_sub_class_list(hd_data_t *hd_data, unsigned base_class, unsigned sub_cl
   return hd_list;
 }
 
-hd_t *hd_bus_list(hd_data_t *hd_data, unsigned bus)
+API_SYM hd_t *hd_bus_list(hd_data_t *hd_data, unsigned bus)
 {
   hd_t *hd, *hd1, *hd_list = NULL;
 
@@ -3546,7 +3546,7 @@ hd_t *hd_bus_list(hd_data_t *hd_data, unsigned bus)
 }
 
 /* Convert libhd bus IDs to hwcfg bus names */
-const char* hd_busid_to_hwcfg(int busid)
+API_SYM const char* hd_busid_to_hwcfg(int busid)
 {
 	const char* const ids1[]={"none","isa","eisa","mc","pci","pcmcia","nubus","cardbus","other"};
 	const char* const ids2[]={"ps2","serial","parallel","floppy","scsi","ide","usb","adb","raid","sbus","i2o","vio","ccw","iucv"};
@@ -3761,7 +3761,7 @@ int dev_name_duplicate(disk_t *dl, char *dev_name)
   return 0;
 }
 
-unsigned hd_boot_disk(hd_data_t *hd_data, int *matches)
+API_SYM unsigned hd_boot_disk(hd_data_t *hd_data, int *matches)
 {
   hd_t *hd;
   unsigned crc, hd_idx = 0;
@@ -3924,8 +3924,7 @@ int load_module_with_params(hd_data_t *hd_data, char *module, char *params)
   return i;
 }
 
-/* symbol clash with libsamba (bsc#1212756) */
-__attribute__((visibility("hidden"))) int load_module(hd_data_t *hd_data, char *module)
+int load_module(hd_data_t *hd_data, char *module)
 {
   return load_module_with_params(hd_data, module, NULL);
 }
@@ -5023,7 +5022,7 @@ void create_model_name(hd_data_t *hd_data, hd_t *hd)
 
 
 #ifndef LIBHD_TINY
-int hd_change_config_status(hd_data_t *hd_data, const char *id, hd_status_t status, const char *config_string)
+API_SYM int hd_change_config_status(hd_data_t *hd_data, const char *id, hd_status_t status, const char *config_string)
 {
   hd_t *hd;
   int i;
@@ -5051,7 +5050,7 @@ int hd_change_config_status(hd_data_t *hd_data, const char *id, hd_status_t stat
 
 
 /* wrapper for hd_change_config_status(); obsolete - do not use */
-int hd_change_status(const char *id, hd_status_t status, const char *config_string)
+API_SYM int hd_change_status(const char *id, hd_status_t status, const char *config_string)
 {
   hd_data_t *hd_data;
   int i;
@@ -5190,7 +5189,7 @@ int hd_getdisksize(hd_data_t *hd_data, char *dev, int fd, hd_res_t **geo, hd_res
 }
 
 
-str_list_t *hd_split(char del, const char *str)
+API_SYM str_list_t *hd_split(char del, const char *str)
 {
   char *t, *s, *str0;
   str_list_t *sl = NULL;
@@ -5209,7 +5208,7 @@ str_list_t *hd_split(char del, const char *str)
 }
 
 
-char *hd_join(char *del, str_list_t *str)
+API_SYM char *hd_join(char *del, str_list_t *str)
 {
   char *s;
   str_list_t *str0;
@@ -5306,7 +5305,7 @@ int is_pcmcia_ctrl(hd_data_t *hd_data, hd_t *hd)
   return 0;
 }
 
-void hd_set_hw_class(hd_t *hd, hd_hw_item_t hw_class)
+API_SYM void hd_set_hw_class(hd_t *hd, hd_hw_item_t hw_class)
 {
   unsigned ofs, bit;
 
@@ -5319,7 +5318,7 @@ void hd_set_hw_class(hd_t *hd, hd_hw_item_t hw_class)
 }
 
 
-int hd_is_hw_class(hd_t *hd, hd_hw_item_t hw_class)
+API_SYM int hd_is_hw_class(hd_t *hd, hd_hw_item_t hw_class)
 {
   unsigned ofs, bit;
 
@@ -5785,7 +5784,7 @@ void read_udevinfo(hd_data_t *hd_data)
 /*
  * Return libhd version.
  */
-char *hd_version()
+API_SYM char *hd_version()
 {
   return HD_VERSION_STRING;
 }
@@ -5962,7 +5961,7 @@ str_list_t *hd_module_list(hd_data_t *hd_data, unsigned id)
 /*
  * Read using mmap().
  */
-int hd_read_mmap(hd_data_t *hd_data, char *name, unsigned char *buf, off_t start, unsigned size)
+API_SYM int hd_read_mmap(hd_data_t *hd_data, char *name, unsigned char *buf, off_t start, unsigned size)
 {
   off_t map_start, xofs;
   int psize = getpagesize(), fd;

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -2819,6 +2819,16 @@ int hd_change_status(const char *id, hd_status_t status, const char *config_stri
 int hd_change_config_status(hd_data_t *hd_data, const char *id, hd_status_t status, const char *config_string);
 int hd_read_mmap(hd_data_t *hd_data, char *name, unsigned char *buf, off_t start, unsigned size);
 
+str_list_t *hd_read_file(char *file_name, unsigned start_line, unsigned lines);
+unsigned hd_name2eisa_id(char *);
+
+str_list_t *hd_search_str_list(str_list_t *sl, char *str);
+str_list_t *hd_add_str_list(str_list_t **sl, char *str);
+str_list_t *hd_free_str_list(str_list_t *list);
+str_list_t *hd_reverse_str_list(str_list_t *list);
+
+hd_t *hd_add_hd_entry(hd_data_t *hd_data, unsigned line, unsigned count);
+
 /* implemented in hddb.c */
 
 /**

--- a/src/hd/hd_int.h
+++ b/src/hd/hd_int.h
@@ -72,6 +72,25 @@
 #undef NUMERIC_UNIQUE_ID
 
 /*
+ * exported symbol - all others are not exported by the library
+ */
+#define API_SYM			__attribute__((visibility("default")))
+
+/*
+ * All API symbols start with 'hd_' or 'hddb_'.
+ *
+ * Add aliases for some symbols that are widespread throughout libhd sources
+ * to avoid massive code adjustments.
+ */
+#define read_file		hd_read_file
+#define name2eisa_id		hd_name2eisa_id
+#define search_str_list		hd_search_str_list
+#define add_str_list		hd_add_str_list
+#define free_str_list		hd_free_str_list
+#define reverse_str_list	hd_reverse_str_list
+#define add_hd_entry		hd_add_hd_entry
+
+/*
  * Internal probing module numbers. Use mod_name_by_idx() outside of libhd.
  */
 enum mod_idx {
@@ -103,7 +122,6 @@ void hd_add_id(hd_data_t *hd_data, hd_t *hd);
 
 char *isa_id2str(unsigned);
 char *eisa_vendor_str(unsigned);
-unsigned name2eisa_id(char *);
 char *canon_str(char *, int);
 
 int hex(char *string, int digits);
@@ -114,11 +132,6 @@ void hd_log_hex(hd_data_t *hd_data, int with_ascii, unsigned data_len, unsigned 
 
 void str_printf(char **buf, int offset, char *format, ...) __attribute__ ((format (printf, 3, 4)));
 void hexdump(char **buf, int with_ascii, unsigned data_len, unsigned char *data);
-str_list_t *search_str_list(str_list_t *sl, char *str);
-str_list_t *add_str_list(str_list_t **sl, char *str);
-str_list_t *free_str_list(str_list_t *list);
-str_list_t *reverse_str_list(str_list_t *list);
-str_list_t *read_file(char *file_name, unsigned start_line, unsigned lines);
 str_list_t *read_dir(char *dir_name, int type);
 str_list_t *read_dir_canonical(char *dir_name, int type);
 char *hd_read_sysfs_link(char *base_dir, char *link_name);

--- a/src/hd/hddb.c
+++ b/src/hd/hddb.c
@@ -1056,7 +1056,7 @@ hddb_entry_mask_t add_entry(hddb2_data_t *hddb2, tmp_entry_t *te, hddb_entry_t i
 
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void hddb_dump_raw(hddb2_data_t *hddb, FILE *f)
+API_SYM void hddb_dump_raw(hddb2_data_t *hddb, FILE *f)
 {
   int i;
   unsigned u, fl, v, t, id;
@@ -1283,7 +1283,7 @@ void hddb_dump_skey(hddb2_data_t *hddb, FILE *f, prefix_t pre, hddb_entry_mask_t
 }
 
 
-void hddb_dump(hddb2_data_t *hddb, FILE *f)
+API_SYM void hddb_dump(hddb2_data_t *hddb, FILE *f)
 {
   unsigned u;
 
@@ -1794,7 +1794,7 @@ void test_db(hd_data_t *hd_data)
 #endif
 
 
-str_list_t *hddb_get_packages(hd_data_t *hd_data)
+API_SYM str_list_t *hddb_get_packages(hd_data_t *hd_data)
 {
   return NULL;
 }
@@ -1845,7 +1845,7 @@ unsigned sub_device_class(hd_data_t *hd_data, unsigned vendor, unsigned device, 
 
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void hddb_add_info(hd_data_t *hd_data, hd_t *hd)
+API_SYM void hddb_add_info(hd_data_t *hd_data, hd_t *hd)
 {
   hddb_search_t hs = {};
   driver_info_t *new_driver_info = NULL;

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -43,7 +43,7 @@ static char *print_dev_num(hd_dev_num_t *d);
 /*
  * Dump a hardware entry to FILE *f.
  */
-void hd_dump_entry(hd_data_t *hd_data, hd_t *h, FILE *f)
+API_SYM void hd_dump_entry(hd_data_t *hd_data, hd_t *h, FILE *f)
 {
   char *s, *a0, *a1, *a2, *s1, *s2;
   char buf1[32], buf2[32];

--- a/src/hd/hwclass_names.h
+++ b/src/hd/hwclass_names.h
@@ -83,13 +83,13 @@ char *key2value(hash_t *hash, int id)
 }
 
 
-char *hd_hw_item_name(hd_hw_item_t item)
+API_SYM char *hd_hw_item_name(hd_hw_item_t item)
 {
   return key2value(hw_items, item);
 }
 
 
-hd_hw_item_t hd_hw_item_type(char *name)
+API_SYM hd_hw_item_t hd_hw_item_type(char *name)
 {
   return name ? value2key(hw_items, name) : hw_none;
 }

--- a/src/hd/int.c
+++ b/src/hd/int.c
@@ -1329,7 +1329,7 @@ void int_update_driver_data(hd_data_t *hd_data, hd_t *hd)
  *
  * Interface function, don't use internally.
  */
-void hd_add_driver_data(hd_data_t *hd_data, hd_t *hd)
+API_SYM void hd_add_driver_data(hd_data_t *hd_data, hd_t *hd)
 {
   char *s;
 

--- a/src/hd/manual.c
+++ b/src/hd/manual.c
@@ -191,7 +191,7 @@ void hd_scan_manual2(hd_data_t *hd_data)
 }
 
 
-char *hd_status_value_name(hd_status_value_t status)
+API_SYM char *hd_status_value_name(hd_status_value_t status)
 {
   return key2value(status_names, status);
 }
@@ -200,7 +200,7 @@ char *hd_status_value_name(hd_status_value_t status)
 /*
  * read an entry - obsolete
  */
-hd_manual_t *hd_manual_read_entry(hd_data_t *hd_data, const char *id)
+API_SYM hd_manual_t *hd_manual_read_entry(hd_data_t *hd_data, const char *id)
 {
   return NULL;
 }
@@ -261,7 +261,7 @@ hal_prop_t *hd_manual_read_entry_old(const char *id)
  * write an entry
  */
 
-int hd_manual_write_entry(hd_data_t *hd_data, hd_manual_t *entry)
+API_SYM int hd_manual_write_entry(hd_data_t *hd_data, hd_manual_t *entry)
 {
   return 0;
 }
@@ -888,7 +888,7 @@ hal_prop_t *read_properties(hd_data_t *hd_data, const char *udi, const char *id)
 }
 
 
-hd_t *hd_read_config(hd_data_t *hd_data, const char *id)
+API_SYM hd_t *hd_read_config(hd_data_t *hd_data, const char *id)
 {
   hd_t *hd = NULL;
   hal_prop_t *prop = NULL;
@@ -919,7 +919,7 @@ hd_t *hd_read_config(hd_data_t *hd_data, const char *id)
 }
 
 
-int hd_write_config(hd_data_t *hd_data, hd_t *hd)
+API_SYM int hd_write_config(hd_data_t *hd_data, hd_t *hd)
 {
   char *udi;
 

--- a/src/hd/pppoe.c
+++ b/src/hd/pppoe.c
@@ -86,7 +86,8 @@ typedef struct PPPoEPacketStruct {
 typedef struct PPPoETagStruct {
     unsigned int type:16;	/* tag type */
     unsigned int length:16;	/* Length of payload */
-    unsigned char payload[ETH_DATA_LEN];	/* A LOT of room to spare */
+    /* ETH_DATA_LEN - 4 as PPPoETag is expected to fit into PPPoEPacket.payload[] */
+    unsigned char payload[ETH_DATA_LEN - 4];	/* A LOT of room to spare */
 } PPPoETag;
 
 /* Header size of a PPPoE Tag */


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1212756

There was a clash of an exported symbol (`load_module`) with libsamba recently.

To avoid this kind of problems
- do not export any symbols except those needed for the documented libhd API
- all exported libhd symbols start with either `hd_` or `hddb_`