### PR TITLE
do not overdo usb device de-duplication (bsc#1239663)

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -280,8 +280,8 @@ static pr_flags_t pr_flags[] = {
   { pr_s390,          0,            8|4|2|1, "s390",         p_bool },
   { pr_s390disks,     0,                  0, "s390disks",    p_bool },
   { pr_isapnp,        0,              4|2|1, "isapnp",       p_bool },
-  { pr_isapnp_old,    pr_isapnp,          0, "isapnp.old",   p_bool },
-  { pr_isapnp_new,    pr_isapnp,          0, "isapnp.new",   p_bool },
+  { pr_no_remove,     0,                  0, "no.remove",    p_bool },	// replace unused pr_isapnp_old
+  { pr_loose_match,   0,                  0, "loose.match",  p_bool },	// replace unused pr_isapnp_new
   { pr_isapnp_mod,    0,              4    , "isapnp.mod",   p_bool },
   { pr_isapnp,        0,                  0, "pnpdump",      p_bool },	/* alias for isapnp */
   { pr_net,           0,            8|4|2|1, "net",          p_bool },
@@ -2810,6 +2810,8 @@ void remove_hd_entries(hd_data_t *hd_data)
 void remove_tagged_hd_entries(hd_data_t *hd_data)
 {
   hd_t *hd, **prev, **h;
+
+  if(hd_probe_feature(hd_data, pr_no_remove)) return;
 
   for(hd = *(prev = &hd_data->hd); hd;) {
     if(hd->tag.remove) {

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -116,7 +116,7 @@ typedef enum probe_feature {
   pr_modem_usb, pr_parallel, pr_parallel_lp, pr_parallel_zip, pr_isa,
   pr_isa_isdn, pr_isdn, pr_kbd, pr_prom, pr_sbus, pr_int, pr_braille,
   pr_braille_alva, pr_braille_fhp, pr_braille_ht, pr_ignx11, pr_sys,
-  pr_bios_vbe, pr_isapnp_old, pr_isapnp_new, pr_isapnp_mod, pr_braille_baum,
+  pr_bios_vbe, pr_no_remove, pr_loose_match, pr_isapnp_mod, pr_braille_baum,
   pr_manual, pr_fb, pr_veth, pr_pppoe, pr_scan, pr_pcmcia, pr_fork,
   pr_parallel_imm, pr_s390, pr_cpuemu, pr_sysfs, pr_s390disks, pr_udev,
   pr_block, pr_block_cdrom, pr_block_part, pr_edd, pr_edd_mod, pr_bios_ddc,

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -501,12 +501,13 @@ void dump_normal(hd_data_t *hd_data, hd_t *h, FILE *f)
 #endif
   }
 
-  if(h->tag.skip_mouse || h->tag.skip_modem || h->tag.skip_braille) {
+  if(h->tag.skip_mouse || h->tag.skip_modem || h->tag.skip_braille || h->tag.remove) {
     dump_line_str("Tags:");
     i = 0;
     if(h->tag.skip_mouse) dump_line0("%s mouse", i++ ? "," : "");
     if(h->tag.skip_modem) dump_line0("%s modem", i++ ? "," : "");
     if(h->tag.skip_braille) dump_line0("%s braille", i++ ? "," : "");
+    if(h->tag.remove) dump_line0("%s removed", i++ ? "," : "");
     dump_line0("\n");
   }
 

--- a/src/hd/usb.c
+++ b/src/hd/usb.c
@@ -91,6 +91,8 @@ void get_usb_devs(hd_data_t *hd_data)
   str_list_t *sf_bus, *sf_bus_e;
   char *sf_dev, *sf_dev_2;
 
+  int loose_match = hd_probe_feature(hd_data, pr_loose_match);
+
   sf_bus = read_dir("/sys/bus/usb/devices", 'l');
 
   if(!sf_bus) {
@@ -342,9 +344,9 @@ void get_usb_devs(hd_data_t *hd_data)
           if(t) *t = 0;
 
           /* same usb device */
-          if(!strcmp(s, s1)) {
+          if(loose_match ? !strcmp(s, s1) : !strcmp(hd->sysfs_id, hd1->sysfs_id)) {
             hd1->tag.remove = 1;
-            ADD2LOG("removed: %s\n", hd1->sysfs_id);
+            ADD2LOG("usb removed: #%d (sysfs id %s), kept #%d\n", hd1->idx, hd1->sysfs_id, hd->idx);
           }
 
           s1 = free_mem(s1);


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1239663

libhd removes usb device entries it considers duplicates of others.

The logic behind this was overly aggressive and could lead to the removal of legitimate device entries.

To restore the old behavior, use `hwprobe=loose.match`.

To aid future debugging, there is the `hwprobe=no.remove` option that keeps all entries. This option is solely for debugging!