### PR TITLE
Add support for installing to prefixes other than /usr with INSTALL_PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,14 @@ PREFIX  := hwinfo-$(VERSION)
 
 include Makefile.common
 
+INSTALL_PREFIX = /usr
+
 ifeq "$(ARCH)" "x86_64"
-LIBDIR		?= /usr/lib64
+LIBDIR		?= $(INSTALL_PREFIX)/lib64
 else ifeq "$(ARCH)" "loongarch64"
-LIBDIR		?= /usr/lib64
+LIBDIR		?= $(INSTALL_PREFIX)/lib64
 else
-LIBDIR		?= /usr/lib
+LIBDIR		?= $(INSTALL_PREFIX)/lib
 endif
 ULIBDIR		= $(LIBDIR)
 
@@ -104,11 +106,11 @@ doc:
 	@cd doc ; doxygen libhd.doxy
 
 install:
-	install -d -m 755 $(DESTDIR)/sbin $(DESTDIR)/usr/sbin $(DESTDIR)$(ULIBDIR) \
-		$(DESTDIR)$(ULIBDIR)/pkgconfig $(DESTDIR)/usr/include
-	install -m 755 hwinfo $(DESTDIR)/usr/sbin
-	install -m 755 src/ids/check_hd $(DESTDIR)/usr/sbin
-	install -m 755 src/ids/convert_hd $(DESTDIR)/usr/sbin
+	install -d -m 755 $(DESTDIR)/sbin $(DESTDIR)$(INSTALL_PREFIX)/sbin $(DESTDIR)$(ULIBDIR) \
+		$(DESTDIR)$(ULIBDIR)/pkgconfig $(DESTDIR)$(INSTALL_PREFIX)/include
+	install -m 755 hwinfo $(DESTDIR)$(INSTALL_PREFIX)/sbin
+	install -m 755 src/ids/check_hd $(DESTDIR)$(INSTALL_PREFIX)/sbin
+	install -m 755 src/ids/convert_hd $(DESTDIR)$(INSTALL_PREFIX)/sbin
 	if [ -f $(LIBHD_SO) ] ; then \
 		install $(LIBHD_SO) $(DESTDIR)$(ULIBDIR) ; \
 		ln -snf $(LIBHD_NAME) $(DESTDIR)$(ULIBDIR)/$(LIBHD_SONAME) ; \
@@ -117,15 +119,15 @@ install:
 		install -m 644 $(LIBHD) $(DESTDIR)$(ULIBDIR) ; \
 	fi
 	install -m 644 hwinfo.pc $(DESTDIR)$(ULIBDIR)/pkgconfig
-	install -m 644 src/hd/hd.h $(DESTDIR)/usr/include
-	perl -pi -e "s/define\s+HD_VERSION\b.*/define HD_VERSION\t\t$(LIBHD_MAJOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
-	perl -pi -e "s/define\s+HD_MINOR_VERSION\b.*/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $(DESTDIR)/usr/include/hd.h
-	install -m 755 getsysinfo $(DESTDIR)/usr/sbin
-	install -m 755 src/isdn/cdb/mk_isdnhwdb $(DESTDIR)/usr/sbin
-	install -d -m 755 $(DESTDIR)/usr/share/hwinfo
+	install -m 644 src/hd/hd.h $(DESTDIR)$(INSTALL_PREFIX)/include
+	perl -pi -e "s/define\s+HD_VERSION\b.*/define HD_VERSION\t\t$(LIBHD_MAJOR_VERSION)/" $(DESTDIR)$(INSTALL_PREFIX)/include/hd.h
+	perl -pi -e "s/define\s+HD_MINOR_VERSION\b.*/define HD_MINOR_VERSION\t$(LIBHD_MINOR_VERSION)/" $(DESTDIR)$(INSTALL_PREFIX)/include/hd.h
+	install -m 755 getsysinfo $(DESTDIR)$(INSTALL_PREFIX)/sbin
+	install -m 755 src/isdn/cdb/mk_isdnhwdb $(DESTDIR)$(INSTALL_PREFIX)/sbin
+	install -d -m 755 $(DESTDIR)$(INSTALL_PREFIX)/share/hwinfo
 	install -d -m 755 $(DESTDIR)/var/lib/hardware/udi
-	install -m 644 src/isdn/cdb/ISDN.CDB.txt $(DESTDIR)/usr/share/hwinfo
-	install -m 644 src/isdn/cdb/ISDN.CDB.hwdb $(DESTDIR)/usr/share/hwinfo
+	install -m 644 src/isdn/cdb/ISDN.CDB.txt $(DESTDIR)$(INSTALL_PREFIX)/share/hwinfo
+	install -m 644 src/isdn/cdb/ISDN.CDB.hwdb $(DESTDIR)$(INSTALL_PREFIX)/share/hwinfo
 
 archive: changelog
 	@if [ ! -d .git ] ; then echo no git repo ; false ; fi


### PR DESCRIPTION
The default behavior remains the same, but if you pass `INSTALL_PREFIX` you can install into, say, `/usr/local`.

`make install` is still hardcoded to create `/var/lib/hardware/udi`, and a lot of other places in the code expect that, so I haven't changed that in this PR.