### PR TITLE
feat: add SW64 architecture support

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -162,6 +162,10 @@
 #define HD_ARCH "loongarch"
 #endif
 
+#ifdef __sw_64__
+#define HD_ARCH "sw_64"
+#endif
+
 typedef struct disk_s {
   struct disk_s *next;
   unsigned crc;


### PR DESCRIPTION
Add SW64 (Sunway) architecture detection by defining HD_ARCH when __sw_64__ is defined.