### PR TITLE
fix usb network card detection (bsc#1245950)

### DIFF
--- a/src/hd/int.c
+++ b/src/hd/int.c
@@ -689,11 +689,14 @@ void int_fix_usb_network(hd_data_t *hd_data)
 
   for(hd_net = hd_data->hd; hd_net; hd_net = hd_net->next) {
     if(
+      !hd_net->tag.remove &&
       hd_net->base_class.id == bc_network &&
       hd_net->sysfs_id
     ) {
       for(hd_usb = hd_data->hd; hd_usb; hd_usb = hd_usb->next) {
         if(
+          hd_usb != hd_net &&
+          !hd_usb->tag.remove &&
           hd_usb->bus.id == bus_usb &&
           hd_usb->sysfs_id &&
           !strcmp(hd_usb->sysfs_id, hd_net->sysfs_id)


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1245950

De-duplication code for usb network devices introduced in 23.5 was overly aggressive and removed even last remaining entry.