### PR TITLE
docs: Updates source repository URL to GitHub(#131)

### DIFF
--- a/doc/hwinfo.8
+++ b/doc/hwinfo.8
@@ -121,5 +121,5 @@ Not all hardware can be detected.
 .SH "SEE ALSO"
 More documentation in /usr/share/doc/packages/hwinfo.
 .br
-Source repository: git://git.opensuse.org/projects/hwinfo.git.
+Source repository: git@github.com:openSUSE/hwinfo.git.
 .\"


### PR DESCRIPTION
Replaces the outdated source repository URL pointing to openSUSE's Git server with the updated URL for the GitHub repository. Ensures documentation reflects the current hosting location.

Fixs: #131