### PR TITLE
fix: memory leaks in pci and pppoe modules

### DIFF
--- a/src/hd/pci.c
+++ b/src/hd/pci.c
@@ -1117,7 +1117,7 @@ void hd_read_platform(hd_data_t *hd_data)
         s = hd_sysfs_find_driver(hd_data, hd->sysfs_id, 1);
         if(s) add_str_list(&hd->drivers, s);
       }
-      free_str_list(sf_eth_dev);
+      sf_eth_dev = free_str_list(sf_eth_dev);
       free_mem(device_type);
       free_mem(platform_type);
     }
@@ -1128,6 +1128,8 @@ void hd_read_platform(hd_data_t *hd_data)
   free_str_list(net_list);
 
   free_str_list(sf_bus);
+  free_str_list(sf_bus_canonical);
+  free_str_list(sf_eth_dev);
 }
 
 

--- a/src/hd/pppoe.c
+++ b/src/hd/pppoe.c
@@ -641,6 +641,7 @@ void hd_scan_pppoe(hd_data_t *hd_data2)
       );
     }
   }
+  free_mem(conn);
 }
 
 /** @} */


### PR DESCRIPTION
- hd_read_platform: free sf_bus_canonical and sf_eth_dev at function end
- hd_read_platform: use assignment form for sf_eth_dev to avoid dangling pointer
- hd_scan_pppoe: free conn allocation before function exit