### PR TITLE
Fix: fix sizeof in joystick allocation to use struct size instead of pointer size (bsc#1267348)

### DIFF
--- a/src/hd/input.c
+++ b/src/hd/input.c
@@ -57,7 +57,7 @@ void add_joystick_details(hd_data_t *hd_data, hd_t *h, const char *key, const ch
   h->detail = new_mem(sizeof *h->detail);
   h->detail->type = hd_detail_joystick;
 
-  joystick_t *jt = new_mem(sizeof jt);
+  joystick_t *jt = new_mem(sizeof *jt);
   unsigned u;
 
   if(key) {


### PR DESCRIPTION
…pointer size

In add_joystick_details(), `sizeof jt` evaluates to the size of a pointer (8 bytes on 64-bit), not the size of the joystick_t struct. This caused heap corruption as subsequent writes to jt->buttons and jt->axes exceeded the allocated memory.

Change to `sizeof *jt` to correctly allocate the full struct.