### PR TITLE
fix(core): free modinfo_ext instead of modinfo in hd_free_hd_data (bsc#1267348)

### DIFF
--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -1013,7 +1013,7 @@ API_SYM hd_data_t *hd_free_hd_data(hd_data_t *hd_data)
   if((p = hd_data->modinfo_ext)) {
     for(; p->type; p++) free_mem(p->module);
   }
-  hd_data->modinfo = free_mem(hd_data->modinfo_ext);
+  hd_data->modinfo_ext = free_mem(hd_data->modinfo_ext);
 
   if(hd_data->hddb2[0]) {
     free_mem(hd_data->hddb2[0]->list);


### PR DESCRIPTION
In hd_free_hd_data(), the pointer being freed and assigned was hd_data->modinfo instead of hd_data->modinfo_ext, causing the wrong field to be nulled out after free. This could lead to a use-after-free or double-free of modinfo_ext.

Fix the assignment to correctly reference modinfo_ext.