### PR TITLE
add bash completion script for hwinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ Changelog
 VERSION
 *.o
 .depend
-hwinfo
+/hwinfo
 hwinfo.pc

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ include Makefile.common
 
 INSTALL_PREFIX = /usr
 
+BASHCOMP_DIR ?= $(DESTDIR)$(INSTALL_PREFIX)/share/bash-completion/completions
+
 ifeq "$(ARCH)" "x86_64"
 LIBDIR		?= $(INSTALL_PREFIX)/lib64
 else ifeq "$(ARCH)" "loongarch64"
@@ -128,6 +130,8 @@ install:
 	install -d -m 755 $(DESTDIR)/var/lib/hardware/udi
 	install -m 644 src/isdn/cdb/ISDN.CDB.txt $(DESTDIR)$(INSTALL_PREFIX)/share/hwinfo
 	install -m 644 src/isdn/cdb/ISDN.CDB.hwdb $(DESTDIR)$(INSTALL_PREFIX)/share/hwinfo
+	install -d -m 755 $(BASHCOMP_DIR)
+	install -m 644 bash-completion/hwinfo $(BASHCOMP_DIR)/hwinfo
 
 archive: changelog
 	@if [ ! -d .git ] ; then echo no git repo ; false ; fi

--- a/bash-completion/hwinfo
+++ b/bash-completion/hwinfo
@@ -1,0 +1,166 @@
+_hwinfo_module()
+{
+	local cur prev OPTS
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	case $prev in
+		'--only')
+			local IFS=$'\n'
+			compopt -o filenames
+			COMPREPLY=( $(compgen -f -- $cur) )
+			return 0
+			;;
+		'--log'|'-l')
+			local IFS=$'\n'
+			compopt -o filenames
+			COMPREPLY=( $(compgen -f -- $cur) )
+			return 0
+			;;
+		'--debug'|'-d')
+			COMPREPLY=( $(compgen -W "1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 2097152 4194304 8388608" -- $cur) )
+			return 0
+			;;
+		'--save-config'|'--show-config'|'--write-udi')
+			return 0
+			;;
+		'--format')
+			COMPREPLY=( $(compgen -W "0 1 2 3" -- $cur) )
+			return 0
+			;;
+		'--dump-db'|'--dump-db-raw')
+			COMPREPLY=( $(compgen -W "0 1" -- $cur) )
+			return 0
+			;;
+		'--root')
+			compopt -o filenames
+			COMPREPLY=( $(compgen -o dirnames -- $cur) )
+			return 0
+			;;
+		'--hddb-dir'|'--hddb-dir-new')
+			compopt -o filenames
+			COMPREPLY=( $(compgen -o dirnames -- $cur) )
+			return 0
+			;;
+		'--db')
+			return 0
+			;;
+		'--kernel-version')
+			return 0
+			;;
+		'-h'|'--help'|'--version'|'-p'|'--packages'|'-v'|'--verbose')
+			return 0
+			;;
+	esac
+	case $cur in
+		-*)
+			OPTS="--all
+				--arch
+				--bios
+				--block
+				--bluetooth
+				--braille
+				--bridge
+				--camera
+				--cdrom
+				--chipcard
+				--cpu
+				--disk
+				--display
+				--dsl
+				--dvb
+				--fingerprint
+				--firewire
+				--firewire-ctrl
+				--firewire_ctrl
+				--floppy
+				--framebuffer
+				--gfxcard
+				--hotplug
+				--hotplug-ctrl
+				--hotplug_ctrl
+				--hub
+				--ide
+				--ieee1394
+				--ieee1394-ctrl
+				--ieee1394_ctrl
+				--isapnp
+				--isdn
+				--joystick
+				--keyboard
+				--listmd
+				--manual
+				--memory
+				--mmc-ctrl
+				--mmc_ctrl
+				--modem
+				--monitor
+				--mouse
+				--netcard
+				--netcards
+				--network
+				--network-ctrl
+				--network_ctrl
+				--nvme
+				--partition
+				--pci
+				--pcmcia
+				--pcmcia-ctrl
+				--pcmcia_ctrl
+				--pppoe
+				--printer
+				--reallyall
+				--redasd
+				--scanner
+				--scsi
+				--smp
+				--sound
+				--special
+				--storage-ctrl
+				--storage_ctrl
+				--sys
+				--tape
+				--tv
+				--uml
+				--usb
+				--usb-ctrl
+				--usb_ctrl
+				--vbe
+				--wlan
+				--xen
+				--zip
+				--db
+				--debug
+				--dump-db
+				--dump-db-raw
+				--fast
+				--format
+				--hddb-dir
+				--hddb-dir-new
+				--help
+				--kernel-version
+				--log
+				--map
+				--map2
+				--nowpa
+				--packages
+				--root
+				--save-config
+				--separate
+				--short
+				--show-config
+				--test
+				--verbose
+				--version
+				--write-udi
+				-h -d -l -p -v"
+			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
+			return 0
+			;;
+	esac
+	local IFS=$'\n'
+	compopt -o filenames
+	COMPREPLY=( $(compgen -f -- $cur) )
+	return 0
+}
+complete -F _hwinfo_module hwinfo


### PR DESCRIPTION
Hi, This PR adds a bash completion script (`bash-completion/hwinfo`) that provides tab completion for the `hwinfo` command. The completion function was verified against the `getopt_long` option definitions in `hwinfo.c` (`struct option options[]`, lines 76–178) and the short option string `"hd:l:pv"`. Please let me know if this feature would be necessory.

Just circling back on this—do you think this feature is worth including, or should I close the PR if it's outside the project's scope? Happy to make changes if needed! :-)

**Features:**

| Category                | Details                                                      |
| ----------------------- | ------------------------------------------------------------ |
| **Option coverage**     | All 82 long options and 5 short options (`-h`, `-d`, `-l`, `-p`, `-v`) |
| **Hardware types**      | All probe options (`--cpu`, `--network`, `--pci`, etc.) including legacy/compatibility aliases (`--netcards`, `--netcard`, `--network-ctrl`, `--network_ctrl`) |
| **Underscore variants** | Both `-` and `_` forms (`--storage-ctrl` / `--storage_ctrl`, `--usb-ctrl` / `--usb_ctrl`, etc.) |
| **Hidden options**      | Includes options not listed in `help()` but present in source: `--display`, `--firewire*`, `--hotplug*`, `--ieee1394*`, `--manual`, `--mmc_ctrl`, `--redasd`, `--special` |

**Value completions:**

| Option                                                       | Values                | Rationale                                                    |
| ------------------------------------------------------------ | --------------------- | ------------------------------------------------------------ |
| `--debug` / `-d`                                             | `1 2 4 8 ... 8388608` | All 24 `HD_DEB_*` bitmask flags (bit 0–23, `hd.h:33-56`)     |
| `--format`                                                   | `0 1 2 3`             | 2-bit `dformat` field parsed via `strtol()` (`hd.h:2687`)    |
| `--dump-db` / `--dump-db-raw`                                | `0 1`                 | 0 = external DB, 1 = internal DB                             |
| `--root`, `--hddb-dir`, `--hddb-dir-new`                     | Directory names       | Path-based options                                           |
| `--log`, `-l`, `--only`                                      | Filenames             | With `IFS=$'\n'` and `compopt -o filenames` for proper space handling |
| `--db`                                                       | No completion         | Accepts free-form query strings (e.g. `"pci vendor=0x8086"`) |
| `--save-config`, `--show-config`, `--write-udi`, `--kernel-version` | No completion         | Free-form string arguments                                   |

**Other:** Falls through to generic filename completion for positional arguments (e.g., old-style hardware type names). 

**Reference:**  [https://github.com/util-linux/util-linux/tree/master/bash-completion](https://github.com/util-linux/util-linux/tree/master/bash-completion
)

https://github.com/user-attachments/assets/cc97d68f-b827-4d71-b57e-38ebb266f1aa

