### PR TITLE
Remove boot_arch enum and improve Linux boot detection

### DIFF
--- a/hwinfo.c
+++ b/hwinfo.c
@@ -504,7 +504,7 @@ void do_hw(hd_data_t *hd_data, FILE *f, int hw_item)
   hd_t *hd, *hd0;
   int smp = -1, uml = 0, xen = 0, i;
   char *s, *t;
-  enum boot_arch b_arch;
+  char *boot_mode;
   enum cpu_arch c_arch;
 
   hd0 = NULL;
@@ -581,7 +581,6 @@ void do_hw(hd_data_t *hd_data, FILE *f, int hw_item)
   }
   else if(hw_item == 2003) {
     c_arch = hd_cpu_arch(hd_data);
-    b_arch = hd_boot_arch(hd_data);
 
     s = t = "Unknown";
     switch(c_arch) {
@@ -637,42 +636,12 @@ void do_hw(hd_data_t *hd_data, FILE *f, int hw_item)
         break;
     }
 
-    switch(b_arch) {
-      case boot_unknown:
-        break;
-      case boot_lilo:
-        t = "lilo";
-        break;
-      case boot_milo:
-        t = "milo";
-        break;
-      case boot_aboot:
-        t = "aboot";
-        break;
-      case boot_silo:
-        t = "silo";
-        break;
-      case boot_ppc:
-        t = "ppc";
-        break;
-      case boot_elilo:
-        t = "elilo";
-        break;
-      case boot_s390:
-        t = "s390";
-        break;
-      case boot_mips:
-        t = "mips";
-        break;
-      case boot_grub:
-        t = "grub";
-        break;
-      case boot_uboot:
-        t = "uboot";
-        break;
-    }
+    t = hd_bootloader(hd_data);
+    if(!t) t = "Unknown";
 
     fprintf(f ? f : stdout, "Arch: %s/%s\n", s, t);
+    boot_mode = hd_boot_mode(hd_data);
+    if(boot_mode) fprintf(f ? f : stdout, "Boot mode: %s\n", boot_mode);
   }
   else if(hw_item == 2004) {
     fprintf(f ? f : stdout, "UML: %s\n", uml ? "yes" : "no");

--- a/src/hd/cpu.c
+++ b/src/hd/cpu.c
@@ -186,9 +186,9 @@ void read_cpuinfo(hd_data_t *hd_data)
     if(*model_id) ct->model_name = new_str(model_id);
     if(*system_id) ct->vend_name = new_str(system_id);
     if(strncmp(serial_number, "MILO", 4) == 0)
-      hd_data->boot = boot_milo;
+      hd_set_bootloader(hd_data, "milo");
     else
-      hd_data->boot = boot_aboot;
+      hd_set_bootloader(hd_data, "aboot");
 
     ct->family = cpu_variation;
     ct->model = cpu_revision;
@@ -229,7 +229,7 @@ void read_cpuinfo(hd_data_t *hd_data)
   cpu_variation = cpu_revision = 0;
   ct = 0; bogo = 0;
 
-  hd_data->boot = boot_uboot;
+  hd_set_bootloader(hd_data, "u-boot");
 
   for(sl = hd_data->cpu; sl; sl = sl->next) {
     if(sscanf(sl->str, "Processor       : %79[^\n]", model_id) == 1) continue;
@@ -295,7 +295,7 @@ void read_cpuinfo(hd_data_t *hd_data)
   ct = 0; bogo = 0;
   vendor_id = 0;
 
-  hd_data->boot = boot_uboot;
+  hd_set_bootloader(hd_data, "u-boot");
 
   for(sl = hd_data->cpu; sl; sl = sl->next) {
     if(sscanf(sl->str, "Processor       : %79[^\n]", model_id) == 1);
@@ -370,7 +370,7 @@ void read_cpuinfo(hd_data_t *hd_data)
         ct->model = cpu_revision;
         ct->bogo = bogo;
         ct->clock = mhz;
-        hd_data->boot = boot_grub;
+        hd_set_bootloader(hd_data, "grub");
 
         if(*model_id) ct->model_name = new_str(model_id);
         hd = add_hd_entry(hd_data, __LINE__, 0);
@@ -422,7 +422,7 @@ void read_cpuinfo(hd_data_t *hd_data)
       ct->model_name = new_str(cpu_id);
       ct->bogo = bogo;
 
-      hd_data->boot = boot_silo;
+      hd_set_bootloader(hd_data, "silo");
 
       hd = add_hd_entry(hd_data, __LINE__, 0);
       hd->base_class.id = bc_internal;
@@ -503,7 +503,7 @@ void read_cpuinfo(hd_data_t *hd_data)
         ct->address_size_physical = address_size_physical;
         ct->address_size_virtual = address_size_virtual;
 
-        hd_data->boot = boot_grub;
+        hd_set_bootloader(hd_data, "grub");
 
         /* round clock to typical values */
         if(mhz >= 38 && mhz <= 42)
@@ -598,7 +598,7 @@ void read_cpuinfo(hd_data_t *hd_data)
         ct->model = model;
         ct->stepping = stepping;
         ct->cache = cache;
-        hd_data->boot = boot_ppc;
+        hd_set_bootloader(hd_data, "ppc");
         ct->clock = mhz;
         ct->bogo = bogo;
 
@@ -648,7 +648,7 @@ void read_cpuinfo(hd_data_t *hd_data)
         ct->family = family;
         ct->model = model;
         ct->stepping = stepping;
-	hd_data->boot = boot_elilo;
+	hd_set_bootloader(hd_data, "elilo");
 
         /* round clock to typical values */
         if(mhz >= 38 && mhz <= 42)
@@ -724,7 +724,7 @@ void read_cpuinfo(hd_data_t *hd_data)
 #endif
       if(*vendor_id) ct->vend_name = new_str(vendor_id);
       ct->stepping = u1;
-      hd_data->boot = boot_s390;
+      hd_set_bootloader(hd_data, "s390");
       ct->bogo = bogo;
 
       hd = add_hd_entry(hd_data, __LINE__, 0);

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -1032,6 +1032,8 @@ API_SYM hd_data_t *hd_free_hd_data(hd_data_t *hd_data)
   hd_data->bios_ram.data = free_mem(hd_data->bios_ram.data);
   hd_data->bios_ebda.data = free_mem(hd_data->bios_ebda.data);
   hd_data->cmd_line = free_mem(hd_data->cmd_line);
+  hd_data->boot = free_mem(hd_data->boot);
+  hd_data->boot_mode = free_mem(hd_data->boot_mode);
   hd_data->xtra_hd = free_str_list(hd_data->xtra_hd);
   hd_data->devtree = free_devtree(hd_data);
 
@@ -3190,9 +3192,135 @@ API_SYM enum cpu_arch hd_cpu_arch(hd_data_t *hd_data)
 }
 
 
-API_SYM enum boot_arch hd_boot_arch(hd_data_t *hd_data)
+void hd_set_bootloader(hd_data_t *hd_data, char *name)
 {
+  if(!name || !*name) return;
+
+  if(hd_data->boot && !strcmp(hd_data->boot, name)) return;
+
+  hd_data->boot = free_mem(hd_data->boot);
+  hd_data->boot = new_str(name);
+}
+
+
+static char *decode_efi_string(unsigned char *buf, ssize_t len)
+{
+  char *s;
+  ssize_t i, j;
+
+  if(len <= 4) return NULL;
+
+  buf += 4;
+  len -= 4;
+
+  s = new_mem(len + 1);
+  for(i = j = 0; i < len; i += 2) {
+    if(i + 1 < len && buf[i + 1]) {
+      s = free_mem(s);
+      return NULL;
+    }
+    if(!buf[i]) break;
+    s[j++] = buf[i];
+  }
+  s[j] = 0;
+
+  return *s ? s : free_mem(s);
+}
+
+
+static char *linux_efi_loader_info(void)
+{
+  unsigned len;
+  char *buf;
+  char *loader_info = NULL;
+  str_list_t *entry, *entries;
+
+  entries = read_dir("/sys/firmware/efi/efivars", 'r');
+  for(entry = entries; entry; entry = entry->next) {
+    if(strncmp(entry->str, "LoaderInfo-", sizeof "LoaderInfo-" - 1)) continue;
+    buf = get_sysfs_attr_by_path2("/sys/firmware/efi/efivars", entry->str, &len);
+    if(!buf) continue;
+    loader_info = decode_efi_string((unsigned char *) buf, len);
+    if(loader_info) break;
+  }
+  free_str_list(entries);
+
+  return loader_info;
+}
+
+
+static char *linux_cmdline_bootloader(hd_data_t *hd_data)
+{
+  str_list_t *boot_image;
+  char *bootloader = NULL;
+  char *cmdline;
+
+  boot_image = get_cmdline(hd_data, "BOOT_IMAGE");
+  cmdline = hd_data->cmd_line;
+  if(cmdline) {
+    if(strcasestr(cmdline, "systemd-boot")) bootloader = new_str("systemd-boot");
+    else if(strcasestr(cmdline, "grub")) bootloader = new_str("grub");
+    else if(strcasestr(cmdline, "lilo")) bootloader = new_str("lilo");
+    else if(strcasestr(cmdline, "elilo")) bootloader = new_str("elilo");
+    else if(strcasestr(cmdline, "uboot") || strcasestr(cmdline, "u-boot")) bootloader = new_str("u-boot");
+  }
+  free_str_list(boot_image);
+
+  return bootloader;
+}
+
+
+static void detect_linux_boot(hd_data_t *hd_data)
+{
+  char *loader_info;
+  struct stat st;
+
+  if(!hd_data->boot_mode) {
+    if(!stat("/sys/firmware/efi", &st)) {
+      hd_data->boot_mode = new_str("UEFI");
+    }
+#if defined(__i386__) || defined(__x86_64__)
+    else {
+      hd_data->boot_mode = new_str("BIOS");
+    }
+#endif
+  }
+
+  loader_info = linux_efi_loader_info();
+  if(loader_info) {
+    if(
+      !hd_data->boot ||
+      !strcmp(hd_data->boot, "grub") ||
+      !strcmp(hd_data->boot, "u-boot") ||
+      !strcmp(hd_data->boot, "elilo")
+    ) {
+      hd_data->boot = free_mem(hd_data->boot);
+      hd_data->boot = loader_info;
+    }
+    else {
+      free_mem(loader_info);
+    }
+  }
+
+  if(!hd_data->boot) {
+    hd_data->boot = linux_cmdline_bootloader(hd_data);
+  }
+}
+
+
+API_SYM char *hd_bootloader(hd_data_t *hd_data)
+{
+  detect_linux_boot(hd_data);
+
   return hd_data->boot;
+}
+
+
+API_SYM char *hd_boot_mode(hd_data_t *hd_data)
+{
+  detect_linux_boot(hd_data);
+
+  return hd_data->boot_mode;
 }
 
 

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -1456,16 +1456,6 @@ typedef enum cpu_arch {
 } hd_cpu_arch_t;
 
 /**
- * @todo drop boot_arch at all? 
- */
-typedef enum boot_arch {
-  boot_unknown = 0,
-  boot_lilo, boot_milo, boot_aboot, boot_silo, boot_ppc, boot_elilo, boot_s390,
-  boot_mips, boot_grub, boot_uboot,
-} hd_boot_arch_t;
-
-
-/**
  * @addtogroup HWDETAILpub
  * @{
  */
@@ -2722,7 +2712,8 @@ typedef struct {
   hal_prop_t *probe_val;	/**< (Internal) probing features with arbitrary values */
   unsigned last_idx;		/**< (Internal) index of the last hd entry generated */
   unsigned module;		/**< (Internal) the current probing module we are in */
-  enum boot_arch boot;		/**< (Internal) boot method */
+  char *boot;			/**< (Internal) bootloader name */
+  char *boot_mode;		/**< (Internal) firmware boot mode */
   hd_t *old_hd;			/**< (Internal) old (outdated) entries (if you scan more than once) */
   pci_t *pci;			/**< (Internal) raw PCI data */
   isapnp_t *isapnp;		/**< (Internal) raw ISA-PnP data */
@@ -2837,7 +2828,8 @@ int hd_is_xen(hd_data_t *hd_data);
 unsigned hd_display_adapter(hd_data_t *hd_data);
 unsigned hd_boot_disk(hd_data_t *hd_data, int *matches);
 enum cpu_arch hd_cpu_arch(hd_data_t *hd_data);
-enum boot_arch hd_boot_arch(hd_data_t *hd_data);
+char *hd_bootloader(hd_data_t *hd_data);
+char *hd_boot_mode(hd_data_t *hd_data);
 
 hd_t *hd_get_device_by_idx(hd_data_t *hd_data, unsigned idx);
 

--- a/src/hd/hd_int.h
+++ b/src/hd/hd_int.h
@@ -170,6 +170,7 @@ int cmp_hd(hd_t *hd1, hd_t *hd2);
 unsigned has_something_attached(hd_data_t *hd_data, hd_t *hd);
 
 str_list_t *get_cmdline(hd_data_t *hd_data, char *key);
+void hd_set_bootloader(hd_data_t *hd_data, char *name);
 
 int detect_smp_bios(hd_data_t *hd_data);
 int detect_smp_prom(hd_data_t *hd_data);


### PR DESCRIPTION
Remove the boot_arch enum and store bootloader information as strings.
Add Linux bootloader detection using EFI LoaderInfo when available, and report UEFI boot mode from sysfs. Only report legacy BIOS mode on x86 platforms to avoid mislabeling non-EFI AArch64 systems as BIOS.