### PR TITLE
add MMC/SD card block device support

### DIFF
--- a/src/hd/block.c
+++ b/src/hd/block.c
@@ -32,6 +32,7 @@ static void add_cdrom_info(hd_data_t *hd_data, hd_t *hd);
 static void add_other_sysfs_info(hd_data_t *hd_data, hd_t *hd);
 static void add_ide_sysfs_info(hd_data_t *hd_data, hd_t *hd);
 static void add_scsi_sysfs_info(hd_data_t *hd_data, hd_t *hd, char *sf_dev);
+static void add_mmc_sysfs_info(hd_data_t *hd_data, hd_t *hd, char *sf_dev);
 static void read_partitions(hd_data_t *hd_data);
 static void read_cdroms(hd_data_t *hd_data);
 static cdrom_info_t *new_cdrom_entry(cdrom_info_t **ci);
@@ -288,6 +289,7 @@ void get_block_devs(hd_data_t *hd_data)
         else if(!strcmp(bus_name, "pci")) hd->bus.id = bus_pci;
         else if(!strcmp(bus_name, "nvme")) hd->bus.id = bus_nvme;
         else if(!strcmp(bus_name, "nvme-subsystem")) hd->bus.id = bus_nvme;
+        else if(!strcmp(bus_name, "mmc")) hd->bus.id = bus_mmc;
       }
       hd->sysfs_bus_id = new_str(bus_id);
 
@@ -392,6 +394,9 @@ void get_block_devs(hd_data_t *hd_data)
         else {
           add_scsi_sysfs_info(hd_data, hd, sf_dev);
         }
+      }
+      else if(hd->bus.id == bus_mmc) {
+        add_mmc_sysfs_info(hd_data, hd, sf_dev);
       }
       else {
         add_other_sysfs_info(hd_data, hd);
@@ -555,6 +560,104 @@ void add_cdrom_info(hd_data_t *hd_data, hd_t *hd)
   ) {
     hd_read_cdrom_info(hd_data, hd);
   }
+}
+
+
+void add_mmc_sysfs_info(hd_data_t *hd_data, hd_t *hd, char *sf_dev)
+{
+  char *s, *cs;
+  uint64_t ul0;
+  mmc_info_t *mmc;
+
+  if(!hd_report_this(hd_data, hd)) return;
+
+  hd->detail = new_mem(sizeof *hd->detail);
+  hd->detail->type = hd_detail_mmc;
+  hd->detail->mmc.data = mmc = new_mem(sizeof *mmc);
+
+  /* hook into the generic "MMC/SD Storage Device" entry (special 0x6016)
+   * so an unrecognized manufacturer still resolves to a device name */
+  hd->compat_vendor.id = MAKE_ID(TAG_SPECIAL, 0x6016);
+  hd->compat_device.id = MAKE_ID(TAG_SPECIAL, 0x0000);
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "manfid"))) {
+    if(hd_attr_uint(s, &ul0, 0)) {
+      ADD2LOG("    manfid = 0x%x\n", (unsigned) ul0);
+      mmc->manfid = ul0 & 0xffff;
+      hd->vendor.id = MAKE_ID(TAG_MMC, mmc->manfid);
+    }
+  }
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "oemid"))) {
+    if(hd_attr_uint(s, &ul0, 0)) {
+      ADD2LOG("    oemid = 0x%x\n", (unsigned) ul0);
+      mmc->oemid = ul0 & 0xffff;
+    }
+  }
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "name"))) {
+    cs = canon_str(s, strlen(s));
+    ADD2LOG("    name = %s\n", cs);
+    if(*cs) {
+      free_mem(hd->device.name);
+      hd->device.name = cs;
+    }
+    else {
+      free_mem(cs);
+    }
+  }
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "serial"))) {
+    cs = canon_str(s, strlen(s));
+    ADD2LOG("    serial = %s\n", cs);
+    if(*cs) {
+      free_mem(hd->serial);
+      hd->serial = cs;
+    }
+    else {
+      free_mem(cs);
+    }
+  }
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "type"))) {
+    cs = canon_str(s, strlen(s));
+    ADD2LOG("    type = %s\n", cs);
+    if(*cs) {
+      mmc->type = cs;
+    }
+    else {
+      free_mem(cs);
+    }
+  }
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "hwrev"))) {
+    if(hd_attr_uint(s, &ul0, 0)) {
+      ADD2LOG("    hwrev = 0x%x\n", (unsigned) ul0);
+      mmc->hwrev = ul0;
+      str_printf(&hd->revision.name, 0, "hw%u", (unsigned) ul0);
+    }
+  }
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "fwrev"))) {
+    if(hd_attr_uint(s, &ul0, 0)) {
+      ADD2LOG("    fwrev = 0x%x\n", (unsigned) ul0);
+      mmc->fwrev = ul0;
+      str_printf(&hd->revision.name, 0, "fw%u", (unsigned) ul0);
+    }
+  }
+
+  if((s = get_sysfs_attr_by_path(sf_dev, "date"))) {
+    cs = canon_str(s, strlen(s));
+    ADD2LOG("    date = %s\n", cs);
+    if(*cs) {
+      mmc->date = cs;
+    }
+    else {
+      free_mem(cs);
+    }
+  }
+
+  add_disk_size(hd_data, hd);
 }
 
 

--- a/src/hd/hd.c
+++ b/src/hd/hd.c
@@ -1393,6 +1393,17 @@ hd_detail_t *free_hd_detail(hd_detail_t *d)
     case hd_detail_joystick:
       free_mem(d->joystick.data);
       break;
+
+    case hd_detail_mmc:
+      {
+        mmc_info_t *m = d->mmc.data;
+        if(m) {
+          free_mem(m->type);
+          free_mem(m->date);
+          free_mem(m);
+        }
+      }
+      break;
   }
 
   free_mem(d);
@@ -4103,6 +4114,7 @@ void hd_scan_xtra(hd_data_t *hd_data)
           case 'u': tag = TAG_USB; s++; break;
           case 'P': tag = TAG_PCMCIA; s++; break;
           case 'S': tag = TAG_SDIO; s++; break;
+          case 'm': tag = TAG_MMC; s++; break;
         }
         u1 = strtoul(s, &s, 16);
         if(*s) err |= 2;
@@ -4513,6 +4525,7 @@ char *vend_id2str(unsigned vend)
     if(ID_TAG(vend) == TAG_USB) *s++ = 'u', *s = 0;
     if(ID_TAG(vend) == TAG_SPECIAL) *s++ = 's', *s = 0;
     if(ID_TAG(vend) == TAG_PCMCIA) *s++ = 'P', *s = 0;
+    if(ID_TAG(vend) == TAG_MMC) *s++ = 'm', *s = 0;
     sprintf(s, "%04x", ID_VALUE(vend));
   }
 

--- a/src/hd/hd.h
+++ b/src/hd/hd.h
@@ -88,6 +88,7 @@ extern "C" {
 #define TAG_SPECIAL	4	/**< Internally used ids. */
 #define TAG_PCMCIA	5	/**< PCMCIA ids. */
 #define TAG_SDIO	6	/**< SDIO ids. */
+#define TAG_MMC		7	/**< MMC/SD card ids. */
 
 /**
  * Get the real id value.
@@ -2107,7 +2108,7 @@ typedef enum hd_detail_type {
   hd_detail_pci, hd_detail_usb, hd_detail_isapnp, hd_detail_cdrom,
   hd_detail_floppy, hd_detail_bios, hd_detail_cpu, hd_detail_prom,
   hd_detail_monitor, hd_detail_sys, hd_detail_scsi, hd_detail_devtree,
-  hd_detail_ccw, hd_detail_joystick
+  hd_detail_ccw, hd_detail_joystick, hd_detail_mmc
 } hd_detail_type_t;
 
 typedef struct {
@@ -2181,6 +2182,25 @@ typedef struct {
   joystick_t *data;
 } hd_detail_joystick_t;
 
+/**
+ * MMC/SD card detail information.
+ * Captures MMC-specific sysfs attributes read from
+ * /sys/class/block/mmcblkX/device/.
+ */
+typedef struct {
+  unsigned manfid;	/**< Manufacturer ID (from sysfs 'manfid'). */
+  unsigned oemid;	/**< OEM ID (from sysfs 'oemid'). */
+  char *type;		/**< Card type: "SD", "MMC", "SDIO" (from sysfs 'type'). */
+  unsigned hwrev;	/**< Hardware revision (from sysfs 'hwrev'). */
+  unsigned fwrev;	/**< Firmware revision (from sysfs 'fwrev'). */
+  char *date;		/**< Manufacturing date, e.g. "01/2021" (from sysfs 'date'). */
+} mmc_info_t;
+
+typedef struct {
+  enum hd_detail_type type;
+  mmc_info_t *data;
+} hd_detail_mmc_t;
+
 typedef union {
   enum hd_detail_type type;
   hd_detail_pci_t pci;
@@ -2197,6 +2217,7 @@ typedef union {
   hd_detail_devtree_t devtree;
   hd_detail_ccw_t ccw;
   hd_detail_joystick_t joystick;
+  hd_detail_mmc_t mmc;
 } hd_detail_t;
 
 /** @} */

--- a/src/hd/hddb.c
+++ b/src/hd/hddb.c
@@ -28,9 +28,9 @@ extern hddb2_data_t hddb_internal;
 // #define HDDB_TEST
 // #define HDDB_EXTERNAL_ONLY
 
-static char *hid_tag_names[] = { "", "pci ", "eisa ", "usb ", "special ", "pcmcia ", "sdio " };
+static char *hid_tag_names[] = { "", "pci ", "eisa ", "usb ", "special ", "pcmcia ", "sdio ", "mmc " };
 // just experimenting...
-static char *hid_tag_names2[] = { "", "pci ", "eisa ", "usb ", "int ", "pcmcia ", "sdio " };
+static char *hid_tag_names2[] = { "", "pci ", "eisa ", "usb ", "int ", "pcmcia ", "sdio ", "mmc " };
 
 typedef enum {
   pref_empty, pref_new, pref_and, pref_or, pref_add
@@ -887,6 +887,7 @@ int parse_id(char *str, unsigned *id, unsigned *range, unsigned *mask)
     else if(!strcmp(s, "isapnp")) tag = TAG_EISA;
     else if(!strcmp(s, "pcmcia")) tag = TAG_PCMCIA;
     else if(!strcmp(s, "sdio")) tag = TAG_SDIO;
+    else if(!strcmp(s, "mmc")) tag = TAG_MMC;
     else {
       str = s;
       if(t) *t = c;	/* restore */

--- a/src/hd/hdp.c
+++ b/src/hd/hdp.c
@@ -839,6 +839,23 @@ void dump_normal(hd_data_t *hd_data, hd_t *h, FILE *f)
     dump_line("Axes: %hhd\n", jt->axes);
   }
 
+  // print mmc/sd card details
+  if(
+    h->detail &&
+    h->detail->type == hd_detail_mmc &&
+    h->detail->mmc.data
+  )
+  {
+    mmc_info_t *mmc = h->detail->mmc.data;
+
+    dump_line("Manufacturer ID: 0x%04x\n", mmc->manfid);
+    dump_line("OEM ID: 0x%04x\n", mmc->oemid);
+    if(mmc->type) dump_line("Card Type: \"%s\"\n", mmc->type);
+    if(mmc->hwrev) dump_line("Hardware Revision: 0x%x\n", mmc->hwrev);
+    if(mmc->fwrev) dump_line("Firmware Revision: 0x%x\n", mmc->fwrev);
+    if(mmc->date) dump_line("Manufacturing Date: \"%s\"\n", mmc->date);
+  }
+
   if(
     h->detail &&
     h->detail->type == hd_detail_monitor &&

--- a/src/ids/Makefile
+++ b/src/ids/Makefile
@@ -15,7 +15,7 @@ include $(TOPDIR)/Makefile.common
 
 IDFILES	+= src/bus src/class src/extra src/special src/scanner src/network \
 	  src/usb src/usb2 src/isapnp src/monitor src/camera src/tv2 src/tv src/dvb2 src/dvb \
-	  src/chipcard src/modem src/pcmcia src/s390 src/sdio
+	  src/chipcard src/modem src/pcmcia src/s390 src/sdio src/sdcard
 
 ifeq "$(ARCH)" "i386"
 IDFILES += src/x11.i386 src/modem.i386

--- a/src/ids/check_hd.c
+++ b/src/ids/check_hd.c
@@ -32,6 +32,7 @@ typedef enum hw_item {
 #define TAG_SPECIAL	4	/* internally used ids */
 #define TAG_PCMCIA	5	/* pcmcia ids */
 #define TAG_SDIO	6	/* sdio ids */
+#define TAG_MMC		7	/* mmc/sd card ids */
 
 #define ID_VALUE(id)		((id) & 0xffff)
 #define ID_TAG(id)		(((id) >> 16) & 0xf)
@@ -801,6 +802,7 @@ int parse_id(char *str, unsigned *id, unsigned *tag, unsigned *range, unsigned *
     else if(!strcmp(s, "isapnp")) *tag = TAG_EISA;
     else if(!strcmp(s, "pcmcia")) *tag = TAG_PCMCIA;
     else if(!strcmp(s, "sdio")) *tag = TAG_SDIO;
+    else if(!strcmp(s, "mmc")) *tag = TAG_MMC;
     else {
       str = s;
       if(t) *t = c;	/* restore */
@@ -1116,7 +1118,7 @@ void write_ent_name(FILE *f, hid_t *hid, char pre, hddb_entry_t ent)
 
 void write_id(FILE *f, hddb_entry_t ent, hid_t *hid)
 {
-  static char *tag_name[7] = { "", "pci ", "eisa ", "usb ", "special ", "pcmcia ", "sdio " };
+  static char *tag_name[8] = { "", "pci ", "eisa ", "usb ", "special ", "pcmcia ", "sdio ", "mmc " };
   int tag;
   unsigned u;
   char c, *s;

--- a/src/ids/src/sdcard
+++ b/src/ids/src/sdcard
@@ -1,0 +1,51 @@
+#
+# SD card manufacturer IDs (from sdcard.ids, upstream bp0/verbose-spork)
+# https://www.cameramemoryspeed.com/sd-memory-card-faq/reading-sd-card-cid-serial-psn-internal-numbers
+# Tag: TAG_MMC (7) — used by hwinfo for MMC/SD block device vendor lookup
+#
+# Format:
+#  vendor.id	mmc 0xXXXX
+# +vendor.name	Manufacturer Name
+#
+# The id value is the lower 16 bits of the 'manfid' sysfs attribute
+# (/sys/class/block/mmcblkX/device/manfid).
+#
+
+ vendor.id		mmc 0x0001
++vendor.name		Panasonic
+
+ vendor.id		mmc 0x0002
++vendor.name		Toshiba
+
+ vendor.id		mmc 0x0003
++vendor.name		SanDisk
+
+ vendor.id		mmc 0x001b
++vendor.name		Samsung
+
+ vendor.id		mmc 0x001d
++vendor.name		ADATA
+
+ vendor.id		mmc 0x0027
++vendor.name		Phison
+
+ vendor.id		mmc 0x0028
++vendor.name		Lexar
+
+ vendor.id		mmc 0x0031
++vendor.name		Silicon Power
+
+ vendor.id		mmc 0x0041
++vendor.name		Kingston
+
+ vendor.id		mmc 0x0074
++vendor.name		Transcend Information
+
+ vendor.id		mmc 0x0076
++vendor.name		Patriot Memory
+
+ vendor.id		mmc 0x0082
++vendor.name		Sony
+
+ vendor.id		mmc 0x009c
++vendor.name		Angelbird / Hoodman

--- a/src/ids/src/special
+++ b/src/ids/src/special
@@ -686,6 +686,11 @@
 &device.id		special 0x0000
 +device.name		MMC Controller
 
+# mmc storage device (SD/MMC card)
+ vendor.id		special 0x6016
+&device.id		special 0x0000
++device.name		MMC/SD Storage Device
+
 # internal: usb scanner driver list
  vendor.id		special 0xf000
 &device.id		special 0x0001


### PR DESCRIPTION
Detect MMC block devices (/dev/mmcblk*) by reading sysfs attributes (manfid, name, serial, type, hwrev, fwrev, date) and map manufacturer IDs to vendor names via new TAG_MMC=7 and sdcard ID database.