### PR TITLE
serial driver file name changed in /proc in current kernel, adjusting code (bsc#1271724)

### DIFF
--- a/src/hd/hd_int.h
+++ b/src/hd/hd_int.h
@@ -12,7 +12,8 @@
 #define PROC_CDROM_INFO		"/proc/sys/dev/cdrom/info"
 #define PROC_NET_IF_INFO	"/proc/net/dev"
 #define PROC_MODULES		"/proc/modules"
-#define PROC_DRIVER_SERIAL	"/proc/tty/driver/serial"
+#define PROC_DRIVER_SERIAL_OLD	"/proc/tty/driver/serial"
+#define PROC_DRIVER_SERIAL	"/proc/tty/driver/serial_8250"
 #define PROC_DRIVER_MACSERIAL	"/proc/tty/driver/macserial"
 #define PROC_PARPORT_22		"/proc/parport/"			/* Final '/' is essential! */
 #define PROC_PARPORT_24		"/proc/sys/dev/parport/parport"

--- a/src/hd/serial.c
+++ b/src/hd/serial.c
@@ -177,7 +177,15 @@ void get_serial_info(hd_data_t *hd_data)
    * somewhat buggy at the moment (2.2.13), hence the explicit 44 lines
    * limit. That may be dropped later.
    */
-  sl0 = read_file(PROC_DRIVER_SERIAL, 1, 44);
+
+  char *serial_driver_name = PROC_DRIVER_SERIAL;
+
+  sl0 = read_file(serial_driver_name, 1, 44);
+  if(!sl0) {
+    sl0 = read_file(PROC_DRIVER_SERIAL_OLD, 1, 44);
+    if(sl0) serial_driver_name = PROC_DRIVER_SERIAL_OLD;
+  }
+
   sll = &sl0;
   while(*sll) sll = &(*sll)->next;
   // append Agere modem devices
@@ -206,11 +214,11 @@ void get_serial_info(hd_data_t *hd_data)
 
     if((hd_data->debug & HD_DEB_SERIAL)) {
       /* log just the first 16 entries */
-      ADD2LOG("----- "PROC_DRIVER_SERIAL" -----\n");
+      ADD2LOG("----- %s -----\n", serial_driver_name);
       for(sl = sl0, i = 16; sl && i--; sl = sl->next) {
         ADD2LOG("  %s", sl->str);
       }
-      ADD2LOG("----- "PROC_DRIVER_SERIAL" end -----\n");
+      ADD2LOG("----- %s end -----\n", serial_driver_name);
     }
   }
 #endif	/* !defined(__PPC__) */


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1271724

Serial device list is incomplete since `/proc/tty/driver/serial` changed to `/proc/tty/driver/serial_8250`.
